### PR TITLE
feat: 第一人称渲染与弹道手感，扩展枪械表并重做平衡

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -470,13 +470,13 @@
     .player-name {
       overflow: hidden;
       color: #fff;
-      font: 700 10px var(--font-ui);
+      font: 800 12px var(--font-ui);
       line-height: 1;
       text-overflow: ellipsis;
-      text-shadow: 0 1px 2px #000;
+      text-shadow: 0 1px 3px #000, 0 0 8px rgb(0 0 0 / .8);
       white-space: nowrap;
     }
-    .player-health { height: 4px; overflow: hidden; border: 1px solid rgb(240 234 220 / .35); background: rgb(11 13 11 / .88); }
+    .player-health { height: 6px; overflow: hidden; border: 1px solid rgb(240 234 220 / .5); background: rgb(11 13 11 / .88); }
     .player-health i { display: block; width: 100%; height: 100%; transform-origin: left; }
     .player-hp { width: 21px; color: var(--paper); font: 700 9px var(--font-mono); text-align: right; }
 
@@ -491,7 +491,7 @@
       contain: layout style;
       --spread: 0px;
     }
-    .ch-line, .ch-dot { position: absolute; background: #e8e7dd; box-shadow: 0 0 1px #0b0d0b; }
+    .ch-line, .ch-dot { position: absolute; background: #f4f1e4; box-shadow: 0 0 0 1px rgb(11 13 11 / .85); }
     .ch-line { will-change: transform; }
     .ch-top, .ch-bot { width: 2px; height: 6px; left: 11px; }
     .ch-top { top: 0; }
@@ -689,15 +689,91 @@
       height: 40px;
       filter: drop-shadow(2px 2px 0 #000000);
     }
-      border-color: var(--accent-hi);
-      background: rgb(34 197 94 / .14);
-      color: var(--paper);
+    #ammo-wrap {
+      position: absolute;
+      right: 18px;
+      bottom: 18px;
+      min-width: 168px;
+      text-align: right;
+      pointer-events: none;
+      text-shadow: 0 2px 8px #000, 0 0 18px rgb(0 0 0 / .55);
     }
-    .inventory-item.primed { border-color: #f0b429; color: #ffd166; }
-    .item-head { display: flex; justify-content: space-between; gap: 4px; }
-    .item-key { color: var(--accent-hi); }
-    .item-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .item-ammo { display: block; margin-top: 2px; color: var(--muted); font-size: 7px; }
+    #ammo-weapon {
+      color: var(--accent-hi);
+      font: 700 11px var(--font-mono);
+      letter-spacing: .14em;
+      text-transform: uppercase;
+    }
+    .ammo-count {
+      display: flex;
+      align-items: baseline;
+      justify-content: flex-end;
+      gap: 6px;
+      line-height: .85;
+    }
+    #ammo {
+      color: #fff8ea;
+      font: 64px/.8 var(--font-display);
+      letter-spacing: .02em;
+    }
+    #ammo.low { color: #ffb020; }
+    #ammo.empty { color: #ef4444; }
+    #ammo-reserve {
+      color: var(--muted);
+      font: 700 22px var(--font-mono);
+    }
+    #pickup-toast {
+      position: absolute;
+      left: 50%;
+      bottom: 92px;
+      display: none;
+      transform: translateX(-50%);
+      border: 1px solid rgb(240 234 220 / .35);
+      border-left: 4px solid var(--accent-hi);
+      background: rgb(11 13 11 / .92);
+      padding: 8px 14px;
+      color: #fff8ea;
+      font: 700 12px var(--font-mono);
+      letter-spacing: .06em;
+      box-shadow: 0 8px 24px rgb(0 0 0 / .45);
+      pointer-events: none;
+    }
+    #pickup-toast.show { display: block; animation: toast-in .16s ease-out; }
+    #fx-grain {
+      position: fixed;
+      inset: 0;
+      z-index: 12;
+      pointer-events: none;
+      opacity: .055;
+      mix-blend-mode: overlay;
+      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+      background-size: 220px 220px;
+    }
+    #lowhp-vignette {
+      position: absolute;
+      inset: 0;
+      display: none;
+      background: radial-gradient(circle, transparent 40%, rgb(120 18 16 / .58) 100%);
+      pointer-events: none;
+    }
+    #hud.low-hp #lowhp-vignette { display: block; animation: lowhp-pulse 1.05s ease-in-out infinite; }
+    #hud.low-hp #vitals { border-left-color: #ff3b30; box-shadow: 0 0 18px rgb(239 68 68 / .35); }
+    #hurt-arc {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 320px;
+      height: 320px;
+      margin: -160px 0 0 -160px;
+      border-radius: 50%;
+      opacity: 0;
+      background: conic-gradient(from var(--hurt-dir, 0deg), transparent 0 148deg, rgb(189 81 70 / .62) 180deg, transparent 212deg 360deg);
+      -webkit-mask: radial-gradient(circle, transparent 54%, #000 70%, transparent 84%);
+      mask: radial-gradient(circle, transparent 54%, #000 70%, transparent 84%);
+      pointer-events: none;
+      transition: opacity .08s linear;
+    }
+    #hurt-arc.on { opacity: 1; }
     #sniper-scope {
       position: fixed;
       inset: 0;
@@ -799,6 +875,8 @@
     @keyframes streak-in { from { opacity: 0; transform: translate(-50%, -10px) scale(.9); } to { opacity: 1; transform: translateX(-50%) scale(1); } }
     @keyframes dialog-in { from { opacity: 0; transform: translateY(8px); } }
     @keyframes menu-in { from { opacity: 0; transform: translateY(6px); } }
+    @keyframes toast-in { from { opacity: 0; transform: translate(-50%, 8px); } }
+    @keyframes lowhp-pulse { 0%, 100% { opacity: .72; } 50% { opacity: 1; } }
     @media (prefers-reduced-motion: no-preference) {
       .deploy-panel { animation: menu-in .24s ease-out both; }
       .intel-panel { animation: menu-in .24s .04s ease-out both; }
@@ -898,8 +976,13 @@
                   <option value="-1" selected>🎲 随机主武器（每次重生随机）</option>
                   <option value="3">AK-47 经典突击步枪</option>
                   <option value="4">M4A4 特战突击步枪</option>
+                  <option value="9">FAMAS 突击步枪</option>
+                  <option value="10">AUG 光学突击步枪</option>
                   <option value="2">MP5-SD 微声冲锋枪</option>
+                  <option value="8">UMP-45 战术冲锋枪</option>
                   <option value="5">AWP 重型狙击步枪</option>
+                  <option value="11">SSG 08 轻型狙击</option>
+                  <option value="12">XM1014 战术霰弹</option>
                 </select>
               </div>
               <div class="field">
@@ -907,6 +990,7 @@
                 <select class="control" id="secondary-select">
                   <option value="-1" selected>🎲 随机副武器（每次重生随机）</option>
                   <option value="0">GLOCK-18 战术手枪</option>
+                  <option value="7">USP-S 消音手枪</option>
                   <option value="1">DESERT EAGLE 沙漠之鹰</option>
                 </select>
               </div>
@@ -982,7 +1066,7 @@
       <div class="radar-meta"><span>CITADEL 128M</span><span>在线 <strong id="online-count">0</strong></span></div>
     </div>
 
-    <div id="match-strip"><span>FREE FOR ALL</span><span id="shield-badge">出生保护</span></div>
+    <div id="match-strip"><span>FREE FOR ALL</span><span>黄昏要塞</span><span id="shield-badge">出生保护</span></div>
     <div id="net-stats" aria-live="polite">
       <span>延迟 <strong id="latency-value">-- ms</strong></span>
       <span>总带宽 <strong id="bandwidth-value">0.0 Mbps</strong></span>
@@ -1025,7 +1109,10 @@
     </div>
     <div id="grenade-ready" role="status" aria-live="polite">右键拉栓</div>
     <div id="hitmarker" aria-hidden="true"></div>
+    <div id="hurt-arc" aria-hidden="true"></div>
     <div id="damage-flash" aria-hidden="true"></div>
+    <div id="lowhp-vignette" aria-hidden="true"></div>
+    <div id="pickup-toast" role="status" aria-live="polite"></div>
     <div id="death-countdown" role="status" aria-live="polite"></div>
 
     <div id="vitals">
@@ -1060,6 +1147,11 @@
         <div class="slot-icon" id="slot-4-icon"></div>
         <span class="slot-stack" id="slot-4-ammo">1</span>
       </div>
+    </div>
+
+    <div id="ammo-wrap">
+      <div id="ammo-weapon">AK-47</div>
+      <div class="ammo-count"><strong id="ammo">30</strong><span id="ammo-reserve">/ 90</span></div>
     </div>
 
     <div id="reload-bar-wrap">
@@ -1115,6 +1207,14 @@
             <option value="high">超清 / DPR 1.5</option>
           </select>
         </div>
+        <div class="field">
+          <label for="fov-slider">视野 FOV</label>
+          <input id="fov-slider" type="range" min="70" max="100" value="75">
+        </div>
+        <div class="field">
+          <label for="bob-slider">持枪手感</label>
+          <input id="bob-slider" type="range" min="0" max="100" value="55">
+        </div>
       </div>
       <div class="dialog-actions">
         <button class="secondary-button" id="close-settings-btn" type="button">保存并返回</button>
@@ -1131,6 +1231,7 @@
     </div>
   </div>
 
+  <div id="fx-grain" aria-hidden="true"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/client/src/audio.ts
+++ b/client/src/audio.ts
@@ -2,6 +2,7 @@
 
 const SFX_NAMES = [
   'fire_glock', 'fire_deagle', 'fire_mp5', 'fire_ak47', 'fire_m4a4', 'fire_awp',
+  'fire_usp', 'fire_ump', 'fire_famas', 'fire_aug', 'fire_scout', 'fire_xm',
   'headshot_ding', 'hitmarker', 'death', 'hurt', 'grenade_explode',
   'step', 'reload_click', 'bolt_rack',
   'mag_out', 'mag_in', 'bolt_cycle', 'empty_click',
@@ -130,6 +131,32 @@ export class AudioEngine {
         noise(0.65, 1600);
         osc('sine', 75, 25, 0.6);
         osc('sawtooth', 140, 35, 0.35);
+        break;
+      case 'fire_usp':
+        noise(0.16, 3400);
+        osc('sine', 170, 50, 0.1);
+        break;
+      case 'fire_ump':
+        noise(0.2, 2400);
+        osc('triangle', 150, 55, 0.12);
+        break;
+      case 'fire_famas':
+        noise(0.22, 3000);
+        osc('triangle', 240, 50, 0.16);
+        break;
+      case 'fire_aug':
+        noise(0.23, 2800);
+        osc('sine', 200, 48, 0.17);
+        break;
+      case 'fire_scout':
+        noise(0.45, 1800);
+        osc('sine', 90, 28, 0.4);
+        osc('triangle', 160, 40, 0.22);
+        break;
+      case 'fire_xm':
+        noise(0.4, 1400);
+        osc('sine', 70, 22, 0.32);
+        osc('sawtooth', 110, 30, 0.2);
         break;
       case 'headshot_ding':
         // CS:GO iconic metallic DINK (twin crystal sine ringing)

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -75,17 +75,29 @@ export interface WeaponDef {
   automatic: boolean;
   color: number;
   length: number;
+  pellets?: number;
 }
 
 export const WEAPONS: WeaponDef[] = [
-  { id: 0, name: 'Glock-18', dmg: 20, headMult: 3.0, rpm: 400, mag: 20, reserve: 120, reloadMs: 1400, speedMult: 1.0, spread: 0.42, moveSpread: 1.3, bloom: 0.14, adsFov: 68, automatic: false, color: 0x222225, length: 0.35 },
+  { id: 0, name: 'Glock-18', dmg: 24, headMult: 3.0, rpm: 450, mag: 20, reserve: 120, reloadMs: 1400, speedMult: 1.0, spread: 0.36, moveSpread: 1.2, bloom: 0.12, adsFov: 68, automatic: false, color: 0x222225, length: 0.35 },
   { id: 1, name: 'Desert Eagle', dmg: 48, headMult: 2.3, rpm: 267, mag: 7, reserve: 35, reloadMs: 1800, speedMult: 0.98, spread: 0.22, moveSpread: 2.2, bloom: 0.36, adsFov: 64, automatic: false, color: 0x9b9890, length: 0.42 },
-  { id: 2, name: 'MP5-SD', dmg: 25, headMult: 3.0, rpm: 800, mag: 30, reserve: 120, reloadMs: 1800, speedMult: 0.98, spread: 0.72, moveSpread: 1.6, bloom: 0.07, adsFov: 60, automatic: true, color: 0x34485a, length: 0.55 },
+  { id: 2, name: 'MP5-SD', dmg: 26, headMult: 3.0, rpm: 800, mag: 30, reserve: 120, reloadMs: 1800, speedMult: 1.0, spread: 0.50, moveSpread: 1.45, bloom: 0.06, adsFov: 60, automatic: true, color: 0x34485a, length: 0.55 },
   { id: 3, name: 'AK-47', dmg: 33, headMult: 4.0, rpm: 600, mag: 30, reserve: 90, reloadMs: 2200, speedMult: 0.92, spread: 0.38, moveSpread: 2.0, bloom: 0.17, adsFov: 56, automatic: true, color: 0x79502f, length: 0.75 },
-  { id: 4, name: 'M4A4', dmg: 31, headMult: 3.6, rpm: 666, mag: 30, reserve: 90, reloadMs: 2100, speedMult: 0.92, spread: 0.32, moveSpread: 1.75, bloom: 0.12, adsFov: 54, automatic: true, color: 0x3b463b, length: 0.75 },
-  { id: 5, name: 'AWP', dmg: 108, headMult: 2.5, rpm: 32, mag: 5, reserve: 30, reloadMs: 2800, speedMult: 0.75, spread: 0.03, moveSpread: 4.8, bloom: 0, adsFov: 28, automatic: false, color: 0x35463a, length: 1.05 },
+  { id: 4, name: 'M4A4', dmg: 31, headMult: 3.6, rpm: 666, mag: 30, reserve: 90, reloadMs: 2100, speedMult: 0.93, spread: 0.28, moveSpread: 1.65, bloom: 0.11, adsFov: 54, automatic: true, color: 0x3b463b, length: 0.75 },
+  { id: 5, name: 'AWP', dmg: 108, headMult: 2.5, rpm: 32, mag: 5, reserve: 30, reloadMs: 2800, speedMult: 0.76, spread: 0.03, moveSpread: 4.8, bloom: 0, adsFov: 28, automatic: false, color: 0x35463a, length: 1.05 },
   { id: 6, name: 'Knife', dmg: 34, headMult: 1.0, rpm: 150, mag: 0, reserve: 0, reloadMs: 0, speedMult: 1.08, spread: 0, moveSpread: 0, bloom: 0, adsFov: 75, automatic: false, color: 0x777777, length: 0.3 },
+  { id: 7, name: 'USP-S', dmg: 27, headMult: 2.4, rpm: 352, mag: 12, reserve: 24, reloadMs: 1700, speedMult: 1.0, spread: 0.16, moveSpread: 1.4, bloom: 0.22, adsFov: 66, automatic: false, color: 0x2a3340, length: 0.38 },
+  { id: 8, name: 'UMP-45', dmg: 26, headMult: 2.6, rpm: 600, mag: 25, reserve: 100, reloadMs: 2100, speedMult: 0.97, spread: 0.68, moveSpread: 1.55, bloom: 0.10, adsFov: 58, automatic: true, color: 0x4a4036, length: 0.58 },
+  { id: 9, name: 'FAMAS', dmg: 30, headMult: 3.2, rpm: 700, mag: 25, reserve: 90, reloadMs: 2200, speedMult: 0.94, spread: 0.36, moveSpread: 1.75, bloom: 0.14, adsFov: 54, automatic: true, color: 0x5a6848, length: 0.7 },
+  { id: 10, name: 'AUG', dmg: 31, headMult: 3.4, rpm: 600, mag: 30, reserve: 90, reloadMs: 2300, speedMult: 0.88, spread: 0.27, moveSpread: 1.6, bloom: 0.12, adsFov: 44, automatic: true, color: 0x3d4a3a, length: 0.78 },
+  { id: 11, name: 'SSG 08', dmg: 80, headMult: 2.4, rpm: 40, mag: 8, reserve: 80, reloadMs: 2600, speedMult: 0.80, spread: 0.05, moveSpread: 3.8, bloom: 0, adsFov: 32, automatic: false, color: 0x2f3a48, length: 1.0 },
+  { id: 12, name: 'XM1014', dmg: 14, headMult: 1.2, rpm: 150, mag: 5, reserve: 24, reloadMs: 2600, speedMult: 0.93, spread: 3.2, moveSpread: 4.2, bloom: 0.40, adsFov: 68, automatic: false, color: 0x6a5a3a, length: 0.72, pellets: 6 },
 ];
+
+export const isSniper = (id: number) => id === 5 || id === 11;
+export const isPistol = (id: number) => id === 0 || id === 1 || id === 7;
+export const isGun = (id: number) => id !== 6;
+export const scopeSettleMs = (id: number) => id === 5 ? 320 : id === 11 ? 240 : 0;
 
 export const KEY = {
   Forward: 1,

--- a/client/src/hud.ts
+++ b/client/src/hud.ts
@@ -26,7 +26,13 @@ const WEAPON_BADGES: Record<number, string> = {
   4: 'M4A4',
   5: 'AWP',
   6: 'KNIFE',
-  7: 'GRENADE',
+  7: 'USP-S',
+  8: 'UMP-45',
+  9: 'FAMAS',
+  10: 'AUG',
+  11: 'SSG 08',
+  12: 'XM1014',
+  13: 'HE',
 };
 
 const BLOCK_RADAR_COLORS: Record<number, string> = {
@@ -54,17 +60,26 @@ const WEAPON_SVGS: Record<number, string> = {
   4: `<svg viewBox="0 0 32 32"><rect x="3" y="14" width="7" height="6" fill="#22252a"/><rect x="10" y="13" width="10" height="6" fill="#333842"/><rect x="20" y="13" width="7" height="6" fill="#555d68"/><rect x="27" y="14" width="4" height="3" fill="#88929e"/><rect x="14" y="19" width="3" height="8" fill="#22252a" transform="rotate(25 7 19)"/><rect x="7" y="19" width="3" height="6" fill="#22252a" transform="rotate(25 7 19)"/></svg>`,
   5: `<svg viewBox="0 0 32 32"><rect x="2" y="15" width="8" height="6" fill="#344d37"/><rect x="10" y="14" width="12" height="6" fill="#344d37"/><rect x="22" y="15" width="8" height="3" fill="#22252a"/><rect x="29" y="14" width="2" height="5" fill="#555d68"/><rect x="11" y="9" width="11" height="4" rx="1" fill="#1b1b1e"/><rect x="13" y="13" width="2" height="2" fill="#555d68"/><rect x="19" y="13" width="2" height="2" fill="#555d68"/><rect x="14" y="20" width="4" height="5" fill="#22252a"/></svg>`,
   6: `<svg viewBox="0 0 32 32"><path d="M6 26 L12 20 L15 21 L9 27 Z" fill="#22252a"/><path d="M11 19 L14 17 L16 19 L13 21 Z" fill="#555d68"/><path d="M14 17 L25 5 L27 7 L16 19 Z" fill="#d2d6dc"/><path d="M23 7 L25 5 L27 7 L25 9 Z" fill="#ffffff"/></svg>`,
-  7: `<svg viewBox="0 0 32 32"><ellipse cx="16" cy="18" rx="7" ry="9" fill="#475e38"/><rect x="11" y="17" width="10" height="2" fill="#2e3f24"/><rect x="15" y="11" width="2" height="14" fill="#2e3f24"/><rect x="14" y="7" width="4" height="4" fill="#9fa3ab"/><circle cx="11" cy="8" r="2.5" fill="none" stroke="#d2d6dc" stroke-width="1.5"/></svg>`,
+  7: `<svg viewBox="0 0 32 32"><rect x="7" y="12" width="15" height="5" fill="#2a3340"/><rect x="20" y="13" width="6" height="3" fill="#223547"/><rect x="9" y="17" width="5" height="7" fill="#1b1b1e" transform="rotate(18 9 17)"/></svg>`,
+  8: `<svg viewBox="0 0 32 32"><rect x="4" y="13" width="18" height="7" fill="#4a4036"/><rect x="20" y="14" width="8" height="5" fill="#22252a"/><rect x="10" y="20" width="4" height="7" fill="#22252a" transform="rotate(20 10 20)"/><rect x="12" y="18" width="5" height="8" fill="#1b1b1e"/></svg>`,
+  9: `<svg viewBox="0 0 32 32"><rect x="3" y="12" width="20" height="8" fill="#5a6848"/><rect x="22" y="14" width="7" height="4" fill="#555d68"/><rect x="8" y="20" width="3" height="7" fill="#22252a" transform="rotate(18 8 20)"/></svg>`,
+  10: `<svg viewBox="0 0 32 32"><rect x="4" y="13" width="22" height="7" fill="#3d4a3a"/><rect x="14" y="8" width="8" height="5" rx="1" fill="#1b1b1e"/><rect x="24" y="14" width="5" height="4" fill="#555d68"/></svg>`,
+  11: `<svg viewBox="0 0 32 32"><rect x="2" y="15" width="24" height="4" fill="#2f3a48"/><rect x="12" y="9" width="10" height="4" rx="1" fill="#1b1b1e"/><rect x="26" y="14" width="4" height="3" fill="#555d68"/></svg>`,
+  12: `<svg viewBox="0 0 32 32"><rect x="3" y="13" width="20" height="7" fill="#6a5a3a"/><rect x="22" y="14" width="7" height="5" fill="#22252a"/><rect x="9" y="20" width="4" height="7" fill="#22252a" transform="rotate(18 9 20)"/></svg>`,
+  13: `<svg viewBox="0 0 32 32"><ellipse cx="16" cy="18" rx="7" ry="9" fill="#475e38"/><rect x="11" y="17" width="10" height="2" fill="#2e3f24"/><rect x="15" y="11" width="2" height="14" fill="#2e3f24"/><rect x="14" y="7" width="4" height="4" fill="#9fa3ab"/><circle cx="11" cy="8" r="2.5" fill="none" stroke="#d2d6dc" stroke-width="1.5"/></svg>`,
 };
 export class Hud {
   root = el('hud');
   sensitivity = 0.00216;
   volume = 0.8;
+  hipFov = 75;
+  bobScale = 0.55;
   quality: 'low' | 'medium' | 'high' = 'medium';
   private loadoutPrimary = -1;
   private loadoutSecondary = -1;
   onJoin: ((name: string, primary: number, secondary: number) => void) | null = null;
   onVolumeChange: ((v: number) => void) | null = null;
+  onFovChange: ((fov: number) => void) | null = null;
   onQualityChange: ((q: 'low' | 'medium' | 'high') => void) | null = null;
   onLoadoutChange: ((primary: number, secondary: number) => void) | null = null;
   onExit: (() => void) | null = null;
@@ -101,6 +116,9 @@ export class Hud {
   private lastDeathCountdown = -2;
   private lastReloading: boolean | null = null;
   private lastReloadPct = -1;
+  private lastAmmo = '';
+  private hurtTimer = 0;
+  private toastTimer = 0;
 
   constructor() {
     const name = el('name-input') as HTMLInputElement;
@@ -148,7 +166,8 @@ export class Hud {
       }
       const weapon = WEAPONS[id];
       if (!weapon) return;
-      tag.textContent = `${weapon.name.toUpperCase()} / ${id === 5 ? '重型狙击' : id === 2 ? '微声冲锋' : '突击步枪'}`;
+      const kind = id === 5 || id === 11 ? '狙击步枪' : id === 2 || id === 8 ? '冲锋枪' : id === 12 ? '霰弹枪' : id === 10 ? '光学步枪' : '突击步枪';
+      tag.textContent = `${weapon.name.toUpperCase()} / ${kind}`;
       dmgVal.textContent = String(weapon.dmg);
       rpmVal.textContent = `${weapon.rpm} RPM`;
       headVal.textContent = `${weapon.headMult.toFixed(1)} ×`;
@@ -201,18 +220,26 @@ export class Hud {
     const sens = el('sens-slider') as HTMLInputElement;
     const vol = el('vol-slider') as HTMLInputElement;
     const quality = el('quality-select') as HTMLSelectElement;
+    const fov = el('fov-slider') as HTMLInputElement;
+    const bob = el('bob-slider') as HTMLInputElement;
 
     const savedSens = localStorage.getItem('ps_sens');
     const savedVol = localStorage.getItem('ps_vol');
     const savedQ = localStorage.getItem('ps_quality') as typeof this.quality | null;
+    const savedFov = localStorage.getItem('ps_hip_fov');
+    const savedBob = localStorage.getItem('ps_gun_bob');
 
     if (savedSens && sens) sens.value = savedSens;
     if (savedVol && vol) vol.value = savedVol;
     if (savedQ && quality) quality.value = savedQ;
+    if (savedFov && fov) fov.value = savedFov;
+    if (savedBob && bob) bob.value = savedBob;
 
     this.sensitivity = sens ? (+sens.value / 50) * 0.0024 : 0.00216;
     this.volume = vol ? +vol.value / 100 : 0.8;
     this.quality = quality ? (quality.value as typeof this.quality) : 'medium';
+    this.hipFov = fov ? +fov.value : 75;
+    this.bobScale = bob ? +bob.value / 100 : 0.55;
 
     sens?.addEventListener('input', () => {
       this.sensitivity = (+sens.value / 50) * 0.0024;
@@ -229,6 +256,17 @@ export class Hud {
       this.quality = quality.value as typeof this.quality;
       localStorage.setItem('ps_quality', this.quality);
       this.onQualityChange?.(this.quality);
+    });
+
+    fov?.addEventListener('input', () => {
+      this.hipFov = +fov.value;
+      localStorage.setItem('ps_hip_fov', fov.value);
+      this.onFovChange?.(this.hipFov);
+    });
+
+    bob?.addEventListener('input', () => {
+      this.bobScale = +bob.value / 100;
+      localStorage.setItem('ps_gun_bob', bob.value);
     });
 
     el('open-settings-btn')?.addEventListener('click', () => this.toggleSettings(true));
@@ -330,6 +368,34 @@ export class Hud {
     if (hpEl) hpEl.textContent = String(v);
     const fillEl = el('hp-bar-fill');
     if (fillEl) fillEl.style.width = `${Math.max(0, Math.min(100, v))}%`;
+    this.root.classList.toggle('low-hp', v > 0 && v <= 30);
+  }
+
+  setAmmoDisplay(weapon: string, mag: string, reserve: string) {
+    const state = `${weapon}:${mag}:${reserve}`;
+    if (state === this.lastAmmo) return;
+    this.lastAmmo = state;
+    const nameEl = el('ammo-weapon');
+    if (nameEl) nameEl.textContent = weapon;
+    const magEl = el('ammo');
+    if (magEl) {
+      magEl.textContent = mag;
+      const n = Number(mag);
+      magEl.classList.toggle('empty', Number.isFinite(n) && n <= 0);
+      magEl.classList.toggle('low', Number.isFinite(n) && n > 0 && n <= 5);
+    }
+    const reserveEl = el('ammo-reserve');
+    if (reserveEl) reserveEl.textContent = reserve ? `/ ${reserve}` : '';
+  }
+
+  showHurtDir(radians: number) {
+    const arc = el('hurt-arc');
+    if (!arc) return;
+    const deg = ((radians * 180 / Math.PI) + 360) % 360;
+    arc.style.setProperty('--hurt-dir', `${deg}deg`);
+    arc.classList.add('on');
+    clearTimeout(this.hurtTimer);
+    this.hurtTimer = window.setTimeout(() => arc.classList.remove('on'), 280);
   }
 
   setArmor(v: number) {
@@ -358,7 +424,7 @@ export class Hud {
     const slot3Icon = el('slot-3-icon');
     if (slot3Icon && slot3Icon.innerHTML === '') slot3Icon.innerHTML = WEAPON_SVGS[6];
     const slot4Icon = el('slot-4-icon');
-    if (slot4Icon && slot4Icon.innerHTML === '') slot4Icon.innerHTML = WEAPON_SVGS[7];
+    if (slot4Icon && slot4Icon.innerHTML === '') slot4Icon.innerHTML = WEAPON_SVGS[13];
 
     const slot1Ammo = el('slot-1-ammo');
     if (slot1Ammo) slot1Ammo.textContent = String(mags[1] ?? 30);
@@ -488,12 +554,12 @@ export class Hud {
   }
 
   showPickupNotice(message: string) {
-    const row = document.createElement('div');
-    row.className = 'kill-row mine';
-    row.textContent = message;
-    this.killfeed.prepend(row);
-    while (this.killfeed.children.length > 6) this.killfeed.lastElementChild?.remove();
-    setTimeout(() => row.remove(), 2400);
+    const toast = el('pickup-toast');
+    if (!toast) return;
+    toast.textContent = message;
+    toast.classList.add('show');
+    clearTimeout(this.toastTimer);
+    this.toastTimer = window.setTimeout(() => toast.classList.remove('show'), 2200);
   }
 
 
@@ -565,6 +631,7 @@ export class Hud {
     document.exitPointerLock?.();
     void document.exitFullscreen?.();
     this.root.style.display = 'none';
+    this.root.classList.remove('low-hp');
     this.menu.style.display = 'block';
     if (this.pause) this.pause.style.display = 'none';
     if (this.settings) this.settings.style.display = 'none';

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -6,28 +6,37 @@ import { Weapons } from './weapons.js';
 import { Hud } from './hud.js';
 import { AudioEngine, type SfxName } from './audio.js';
 import { ParticleSystem } from './particles.js';
-import { KEY, PHYS, WEAPONS, type MapData, type PlayerSnap, type RosterEntry, type WeaponDef } from './constants.js';
+import { KEY, PHYS, WEAPONS, isSniper, scopeSettleMs, type MapData, type PlayerSnap, type RosterEntry, type WeaponDef } from './constants.js';
 import bundledMap from '../../map.json';
 
 const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
 const wsUrl = import.meta.env.VITE_WS_URL || `${proto}//${location.host}/ws`;
 
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x8bc4f5);
-scene.fog = new THREE.Fog(0xa2d2f8, 50, 260);
+scene.background = new THREE.Color(0xc48a5a);
+scene.fog = new THREE.Fog(0xc48a5a, 36, 210);
 
 const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.05, 400);
 camera.rotation.order = 'YXZ';
+camera.layers.enable(0);
+camera.layers.disable(1);
 const renderer = new THREE.WebGLRenderer({ antialias: false, powerPreference: 'high-performance' });
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.08;
+renderer.outputColorSpace = THREE.SRGBColorSpace;
 document.body.appendChild(renderer.domElement);
 
-const hemiLight = new THREE.HemisphereLight(0xb4dcff, 0x5a7840, 0.75);
+const hemiLight = new THREE.HemisphereLight(0xffc8a0, 0x3a2a1c, 0.62);
 scene.add(hemiLight);
 
-const sun = new THREE.DirectionalLight(0xfffae8, 1.25);
-sun.position.set(110, 160, -150);
+const sun = new THREE.DirectionalLight(0xffd4a0, 1.42);
+sun.position.set(90, 48, -120);
 scene.add(sun);
 scene.add(camera);
+
+const fillLight = new THREE.DirectionalLight(0x6a8cb0, 0.22);
+fillLight.position.set(-70, 28, 90);
+scene.add(fillLight);
 
 const hud = new Hud();
 const audio = new AudioEngine();
@@ -51,7 +60,6 @@ let inputSeq = 0;
 let shotSeq = 0;
 let lastInput = 0;
 const INPUT_INTERVAL = 1000 / 60;
-const AWP_SCOPE_MS = 450;
 const SPEED_BOOST_MULTIPLIER = 1.35;
 let fireHeld = false;
 let firePressed = false;
@@ -80,8 +88,8 @@ let lastWeaponSlot = 1;
 let grenadePrimed = false;
 let userPrimaryChoice = -1;
 let userSecondaryChoice = -1;
-const PRIMARY_IDS = [3, 4, 2, 5];
-const SECONDARY_IDS = [0, 1];
+const PRIMARY_IDS = [3, 4, 2, 5, 8, 9, 10, 11, 12];
+const SECONDARY_IDS = [0, 1, 7];
 
 function resolveLoadout(p: number, s: number): { primary: number; secondary: number } {
   const actualPrimary = p === -1 ? PRIMARY_IDS[Math.floor(Math.random() * PRIMARY_IDS.length)] : p;
@@ -120,6 +128,7 @@ function resize() {
   renderer.setSize(window.innerWidth, window.innerHeight);
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
+  weapons.setAspect(camera.aspect);
   crosshairScale = window.innerHeight * 0.5 / Math.tan(camera.fov * Math.PI / 360);
 }
 resize();
@@ -130,6 +139,15 @@ hud.onQualityChange = (q) => {
   resize();
 };
 hud.onVolumeChange = (v) => audio.setVolume(v);
+hud.onFovChange = () => {
+  if (!aiming) {
+    camera.fov = hud.hipFov;
+    camera.updateProjectionMatrix();
+    crosshairScale = window.innerHeight * 0.5 / Math.tan(camera.fov * Math.PI / 360);
+  }
+};
+camera.fov = hud.hipFov;
+camera.updateProjectionMatrix();
 audio.setVolume(hud.volume);
 
 const keys = new Set<string>();
@@ -155,6 +173,9 @@ function resetInventory(primary: number, secondary: number) {
 
 function refreshWeaponHud() {
   hud.setInventory(primaryWeapon, secondaryWeapon, activeSlot, slotMags, nades, grenadePrimed);
+  if (activeSlot === 3) hud.setAmmoDisplay('KNIFE', '—', '');
+  else if (activeSlot === 4) hud.setAmmoDisplay('HE', String(nades), grenadePrimed ? 'PIN' : '');
+  else hud.setAmmoDisplay(WEAPONS[weapons.weaponId]?.name ?? '', String(mag), String(reserve));
 }
 
 function grenadeVelocity(out: THREE.Vector3) {
@@ -367,7 +388,7 @@ window.addEventListener('mousemove', (e) => {
 
   const mx = Math.max(-80, Math.min(80, e.movementX));
   const my = Math.max(-80, Math.min(80, e.movementY));
-  const sens = aiming && weapons.weaponId === 5 ? hud.sensitivity * camera.fov / 75 : hud.sensitivity;
+  const sens = aiming && isSniper(weapons.weaponId) ? hud.sensitivity * camera.fov / hud.hipFov : hud.sensitivity;
   local.yaw -= mx * sens;
   local.pitch = Math.max(-1.45, Math.min(1.45, local.pitch - my * sens));
   mouseX = Math.max(-160, Math.min(160, mouseX + mx));
@@ -393,8 +414,8 @@ window.addEventListener('mousedown', (e) => {
   if (e.button === 0) {
     fireHeld = true;
     firePressed = true;
-  } else if (e.button === 2 && weapons.weaponId < 6) {
-    if (weapons.weaponId === 5 && awpRescopeAt) return;
+  } else if (e.button === 2 && weapons.weaponId !== 6) {
+    if (isSniper(weapons.weaponId) && awpRescopeAt) return;
     if (aiming) stopAiming();
     else {
       aimStartedAt = performance.now();
@@ -680,6 +701,18 @@ function handleEvent(e: GameEvent) {
       hud.damageFlash();
       audio.play('hurt', 0.7);
       screenShake = Math.max(screenShake, 0.05);
+      const attacker = states.get(e.player ?? -1);
+      if (attacker) {
+        const dx = attacker.x - local.pos.x;
+        const dz = attacker.z - local.pos.z;
+        const fx = -Math.sin(local.yaw);
+        const fz = -Math.cos(local.yaw);
+        const rx = Math.cos(local.yaw);
+        const rz = -Math.sin(local.yaw);
+        hud.showHurtDir(Math.atan2(dx * rx + dz * rz, dx * fx + dz * fz));
+      } else {
+        hud.showHurtDir(Math.PI);
+      }
     }
     if (e.player === net.yourId) {
       const headshot = e.headshot === 1;
@@ -791,7 +824,7 @@ function refreshScoreboard() {
 }
 
 remotes.onShot = (s, position) => {
-  if (s.weapon >= 6) {
+  if (s.weapon === 6) {
     playSpatial('knife_slash', position.x, position.z, 0.55, 22);
     return;
   }
@@ -854,7 +887,7 @@ function frame(t: number) {
       audio.play('step', 0.18, 0.92 + Math.random() * 0.16);
     }
 
-    if (awpRescopeAt && t >= awpRescopeAt && weapons.weaponId === 5 && reloadPendingSlot !== activeSlot && !weapons.isReloading(t)) {
+    if (awpRescopeAt && t >= awpRescopeAt && isSniper(weapons.weaponId) && reloadPendingSlot !== activeSlot && !weapons.isReloading(t)) {
       awpRescopeAt = 0;
       aiming = true;
       aimStartedAt = t;
@@ -868,7 +901,7 @@ function frame(t: number) {
     if (shouldFire && document.pointerLockElement === renderer.domElement) {
       if (reloadPendingSlot !== activeSlot && weapons.canFire(t)) {
         fire(0, t);
-      } else if (firePressed && reloadPendingSlot !== activeSlot && weapons.ammoLocal === 0 && !weapons.isReloading(t) && t >= weapons.nextFireAt && weapons.weaponId < 6) {
+      } else if (firePressed && reloadPendingSlot !== activeSlot && weapons.ammoLocal === 0 && !weapons.isReloading(t) && t >= weapons.nextFireAt && weapons.weaponId !== 6) {
         if (reserve > 0) {
           startReload(t, true);
         } else {
@@ -896,9 +929,10 @@ function frame(t: number) {
     }
     camera.rotation.y = local.yaw;
     camera.rotation.x = local.pitch;
+    camera.rotation.z = 0;
 
-    const targetFov = aiming ? WEAPONS[weapons.weaponId].adsFov : 75;
-    const aimRate = weapons.weaponId === 5 ? 4.5 : 14;
+    const targetFov = aiming ? WEAPONS[weapons.weaponId].adsFov : hud.hipFov;
+    const aimRate = isSniper(weapons.weaponId) ? 5.5 : weapons.weaponId === 10 ? 8 : 14;
     const nextFov = camera.fov + (targetFov - camera.fov) * Math.min(1, dt * aimRate);
     if (Math.abs(nextFov - camera.fov) > 0.01) {
       camera.fov = nextFov;
@@ -906,7 +940,7 @@ function frame(t: number) {
       crosshairScale = window.innerHeight * 0.5 / Math.tan(camera.fov * Math.PI / 360);
     }
 
-    weapons.animate(t, dt, moving && local.onGround, aiming, mouseX, mouseY, activeSlot !== 4);
+    weapons.animate(t, dt, moving && local.onGround, aiming, mouseX, mouseY, activeSlot !== 4, hud.bobScale);
     mouseX = 0;
     mouseY = 0;
 
@@ -915,12 +949,13 @@ function frame(t: number) {
     const reloadPending = reloadPendingSlot === activeSlot;
     hud.setReloading(activeSlot <= 2 && (localReloading || reloadPending), localReloading ? weapons.getReloadProgress(t) : 1);
   } else if (joined && !alive) {
+    camera.rotation.z = 0;
     deathCam();
   }
-  hud.setScope(joined && alive && activeSlot !== 4 && weapons.weaponId === 5 && weapons.adsProgress > (aiming ? 0.86 : 0.14));
+  hud.setScope(joined && alive && activeSlot !== 4 && isSniper(weapons.weaponId) && weapons.adsProgress > (aiming ? 0.86 : 0.14));
 
   hud.setDeathCountdown(joined && !alive && respawnAt ? Math.max(0, Math.ceil((respawnAt - t) / 1000)) : -1);
-  const spread = joined && alive && activeSlot !== 4 && weapons.weaponId < 6 ? localSpread(t) : 0;
+  const spread = joined && alive && activeSlot !== 4 && weapons.weaponId !== 6 ? localSpread(t) : 0;
   const targetCrosshair = Math.tan(spread * Math.PI / 180) * crosshairScale;
   const crosshairResponse = targetCrosshair > displayedCrosshair ? 18 : 10;
   displayedCrosshair += (targetCrosshair - displayedCrosshair) * (1 - Math.exp(-dt * crosshairResponse));
@@ -930,7 +965,9 @@ function frame(t: number) {
     remotes.update(t);
     particles.update(dt, t, world);
     world?.animate(t);
+    weapons.syncFrom(camera);
     renderer.render(scene, camera);
+    if (alive) weapons.renderOverlay(renderer, scene);
     if (t - lastLabels >= 1000 / 30) {
       lastLabels = t;
       remotes.updateLabels(camera, world);
@@ -941,30 +978,33 @@ requestAnimationFrame(frame);
 
 function fire(mode: number, t: number) {
   const origin = localShotOrigin.set(local.pos.x, local.eyeY(), local.pos.z);
-  const autoRescope = weapons.weaponId === 5 && aiming && weapons.ammoLocal > 1;
+  const autoRescope = isSniper(weapons.weaponId) && aiming && weapons.ammoLocal > 1;
   if (t - lastPatternShot > 420) patternShots = 0;
-  const spread = weapons.weaponId < 6 ? localSpread(t) : 0;
+  const spread = weapons.weaponId === 6 ? 0 : localSpread(t);
   lastPatternShot = t;
   patternShots++;
+  const pellets = Math.max(1, WEAPONS[weapons.weaponId]?.pellets ?? 1);
   const dir = shotDirection(localShotDir, local.yaw, local.pitch, spread, patternShots, weapons.weaponId);
   weapons.onFired(t, origin);
   net.sendFire(++shotSeq, net.lastServerTick, mode | (aiming ? 0x80 : 0), local.yaw, local.pitch);
   mag = weapons.ammoLocal;
-  if (weapons.weaponId === 5) {
+  if (isSniper(weapons.weaponId)) {
     stopAiming();
-    if (autoRescope) awpRescopeAt = weapons.nextFireAt - AWP_SCOPE_MS;
+    if (autoRescope) awpRescopeAt = weapons.nextFireAt - scopeSettleMs(weapons.weaponId);
   }
   if (activeSlot === 1 || activeSlot === 2) slotMags[activeSlot] = mag;
   refreshWeaponHud();
-  if (weapons.weaponId < 6) {
+  if (weapons.weaponId !== 6) {
     audio.play(fireSound(weapons.weaponId), 1, 0.985 + Math.random() * 0.03, 0, true);
-    const dist = world?.raycastDistance(origin, dir, 180) ?? 180;
-    weapons.spawnTracer(origin, dir, dist);
-    if (dist < 180) {
-      particles.spawnImpact(impactPoint.copy(origin).addScaledVector(dir, dist), impactNormal, 0xd6b36e, 4);
+    for (let i = 0; i < pellets; i++) {
+      const pelletDir = pellets === 1 ? dir : shotDirection(localShotDir.clone(), local.yaw, local.pitch, spread, patternShots * 17 + i, weapons.weaponId);
+      const dist = world?.raycastDistance(origin, pelletDir, 180) ?? 180;
+      weapons.spawnTracer(origin, pelletDir, dist);
+      if (dist < 180) {
+        particles.spawnImpact(impactPoint.copy(origin).addScaledVector(pelletDir, dist), impactNormal, 0xd6b36e, pellets > 1 ? 3 : 5);
+      }
     }
-    const climb = weapons.weaponId === 3 ? 0.028 : weapons.weaponId === 4 ? 0.022 : weapons.weaponId === 5 ? 0.045 : 0.012;
-    local.pitch = Math.min(1.5, local.pitch + climb * (aiming ? 0.45 : 1.0));
+    applyRecoil(weapons.weaponId, patternShots, aiming);
   } else {
     weapons.onKnifeSlash();
     audio.play('knife_slash', 0.85);
@@ -973,7 +1013,7 @@ function fire(mode: number, t: number) {
       particles.spawnImpact(impactPoint.copy(origin).addScaledVector(dir, dist), impactNormal, 0xd6b36e, 3);
     }
   }
-  if (mag === 0 && reserve > 0 && weapons.weaponId < 6) startReload(t);
+  if (mag === 0 && reserve > 0 && weapons.weaponId !== 6) startReload(t);
 }
 
 function deathCam() {
@@ -992,29 +1032,89 @@ function deathCam() {
   camera.rotation.x = Math.atan2(dy, Math.hypot(dx, dz));
 }
 
-function weaponSpread(def: WeaponDef, vx: number, vz: number, onGround: boolean, crouching: boolean, landing: boolean, burstShots: number): number {
+function weaponSpread(def: WeaponDef, vx: number, vz: number, onGround: boolean, crouching: boolean, landing: boolean, ads: boolean, burstShots: number): number {
   const moveFactor = Math.min(1, Math.hypot(vx, vz) / 3);
   let spread = def.spread + (def.moveSpread - def.spread) * moveFactor;
-  spread += Math.min(def.moveSpread - def.spread, burstShots * def.bloom);
-  if (!onGround) spread = Math.max(spread, def.moveSpread * 2.2 + 1);
-  if (crouching) spread *= 0.6;
-  if (landing) spread = Math.max(spread, def.moveSpread * 1.35);
+  spread += Math.min(0.22, burstShots * def.bloom * 0.12);
+  if (!onGround) spread = Math.max(spread, def.moveSpread * 1.55 + 0.45);
+  if (crouching) spread *= 0.55;
+  if (ads && !isSniper(def.id)) spread *= 0.48;
+  if (landing) spread = Math.max(spread, def.moveSpread * 1.12);
   return spread;
 }
 
 function localSpread(t: number): number {
   const def = WEAPONS[weapons.weaponId];
   const burstShots = t - lastPatternShot <= 420 ? patternShots : 0;
-  let spread = weaponSpread(def, local.vel.x, local.vel.z, local.onGround, local.crouch, t < landingPenaltyUntil, burstShots);
-  if (weapons.weaponId === 5 && (!aiming || t - aimStartedAt < AWP_SCOPE_MS)) spread = Math.max(spread, def.moveSpread);
+  let spread = weaponSpread(def, local.vel.x, local.vel.z, local.onGround, local.crouch, t < landingPenaltyUntil, aiming, burstShots);
+  if (isSniper(weapons.weaponId) && (!aiming || t - aimStartedAt < scopeSettleMs(weapons.weaponId))) spread = Math.max(spread, def.moveSpread);
   return spread;
 }
 
 function remoteSpread(s: PlayerSnap): number {
   const def = WEAPONS[s.weapon];
-  let spread = weaponSpread(def, s.vx, s.vz, !!(s.state & 8), !!(s.state & 4), false, Math.max(0, s.shot - 1));
-  if (s.weapon === 5 && !(s.state & 16)) spread = Math.max(spread, def.moveSpread);
+  let spread = weaponSpread(def, s.vx, s.vz, !!(s.state & 8), !!(s.state & 4), false, !!(s.state & 16), Math.max(0, s.shot - 1));
+  if (isSniper(s.weapon) && !(s.state & 16)) spread = Math.max(spread, def.moveSpread);
   return spread;
+}
+
+function applyRecoil(weapon: number, shot: number, ads: boolean) {
+  const i = Math.max(0, shot - 1);
+  const scale = ads ? 0.45 : 1;
+  let pitch = 0;
+  let yaw = 0;
+  switch (weapon) {
+    case 0:
+      pitch = 0.009 + Math.min(i, 5) * 0.0010;
+      yaw = (i % 2 ? 1 : -1) * 0.0015;
+      break;
+    case 1:
+      pitch = 0.026;
+      yaw = i % 2 ? 0.005 : -0.004;
+      break;
+    case 2:
+      pitch = 0.007 + Math.min(i, 8) * 0.0008;
+      yaw = Math.sin(i * 1.7) * 0.0020;
+      break;
+    case 3:
+      pitch = 0.020 + Math.min(i, 7) * 0.0028;
+      yaw = i < 8 ? (i % 2 ? 0.0036 : -0.0028) : -0.006;
+      break;
+    case 4:
+      pitch = 0.016 + Math.min(i, 7) * 0.0022;
+      yaw = i < 8 ? (i % 2 ? 0.0028 : -0.0028) : 0.0045;
+      break;
+    case 5:
+      pitch = 0.038;
+      break;
+    case 7:
+      pitch = 0.014;
+      yaw = (i % 2 ? 1 : -1) * 0.0015;
+      break;
+    case 8:
+      pitch = 0.013 + Math.min(i, 7) * 0.0016;
+      yaw = Math.sin(i * 1.4) * 0.0032;
+      break;
+    case 9:
+      pitch = 0.018 + Math.min(i, 6) * 0.0022;
+      yaw = i < 7 ? (i % 2 ? 0.0032 : -0.0028) : 0.005;
+      break;
+    case 10:
+      pitch = 0.018 + Math.min(i, 6) * 0.0024;
+      yaw = (i % 2 ? 0.003 : -0.0026);
+      break;
+    case 11:
+      pitch = 0.036;
+      break;
+    case 12:
+      pitch = 0.038;
+      yaw = i % 2 ? 0.006 : -0.006;
+      break;
+    default:
+      return;
+  }
+  local.pitch = Math.min(1.45, local.pitch + pitch * scale);
+  local.yaw -= yaw * scale;
 }
 
 function shotDirection(out: THREE.Vector3, yaw: number, pitch: number, spread: number, shot: number, weapon: number): THREE.Vector3 {
@@ -1048,6 +1148,12 @@ const sounds: Record<number, SfxName> = {
   3: 'fire_ak47',
   4: 'fire_m4a4',
   5: 'fire_awp',
+  7: 'fire_usp',
+  8: 'fire_ump',
+  9: 'fire_famas',
+  10: 'fire_aug',
+  11: 'fire_scout',
+  12: 'fire_xm',
 };
 
 function fireSound(id: number): SfxName {

--- a/client/src/particles.ts
+++ b/client/src/particles.ts
@@ -96,6 +96,23 @@ export class ParticleSystem {
         gravity: 18,
       });
     }
+    const sparks = Math.min(5, Math.max(0, MAX_PARTICLES - this.particles.length));
+    for (let i = 0; i < sparks; i++) {
+      const speed = 5 + Math.random() * 6;
+      this.particles.push({
+        x: pos.x,
+        y: pos.y,
+        z: pos.z,
+        vx: (normal.x + (Math.random() - 0.5)) * speed,
+        vy: Math.abs(normal.y) * speed + 2,
+        vz: (normal.z + (Math.random() - 0.5)) * speed,
+        color: FIRE_COLORS[i % FIRE_COLORS.length],
+        born: now,
+        life: 180 + Math.random() * 140,
+        size: 0.45 + Math.random() * 0.35,
+        gravity: 12,
+      });
+    }
   }
   spawnDeath(pos: THREE.Vector3, headshot = false) {
     const count = Math.min(headshot ? 42 : 30, MAX_PARTICLES - this.particles.length);

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -521,14 +521,14 @@ export class RemotePlayers {
       this.place(this.head, model.index, model, sin, cos, 0, headY, 0, model.pitch);
       // Two-handed forward triangular V-shape weapon grip (尖尖双手持枪)
       const isKnife = state.weapon === 6;
-      const isPistol = state.weapon === 0 || state.weapon === 1;
+      const pistolHold = state.weapon === 0 || state.weapon === 1 || state.weapon === 7;
 
       if (isKnife) {
         // Knife stance: Right hand holds blade forward-down, left arm swings with walking
         this.place(this.armR, model.index, model, sin, cos, 0.22, shoulderY, -0.04, Math.PI / 2.6 + model.pitch * 0.8, -0.15, -0.25);
         this.place(this.armL, model.index, model, sin, cos, -0.24, shoulderY, 0, -swing * 0.75, 0, 0);
         this.place(this.gun, model.index, model, sin, cos, 0.14, bodyY + 0.08, -0.28, model.pitch, 0, 0);
-      } else if (isPistol) {
+      } else if (pistolHold) {
         // Two-handed pistol grip: Both arms angle forward-inward meeting at pistol grip
         this.place(this.armR, model.index, model, sin, cos, 0.24, shoulderY, 0, Math.PI / 2.15 + model.pitch, 0.42, 0);
         this.place(this.armL, model.index, model, sin, cos, -0.24, shoulderY, 0, Math.PI / 2.15 + model.pitch, -0.42, 0);

--- a/client/src/viewmodels.ts
+++ b/client/src/viewmodels.ts
@@ -1,0 +1,360 @@
+import * as THREE from 'three';
+
+const VIEW_LAYER = 1;
+
+export interface AssembledWeapon {
+  root: THREE.Group;
+  magazine: THREE.Group | null;
+  bolt: THREE.Group | null;
+  muzzle: THREE.Vector3;
+}
+
+interface Mats {
+  dark: THREE.MeshLambertMaterial;
+  gun: THREE.MeshLambertMaterial;
+  silver: THREE.MeshLambertMaterial;
+  chrome: THREE.MeshLambertMaterial;
+  wood: THREE.MeshLambertMaterial;
+  camo: THREE.MeshLambertMaterial;
+  grip: THREE.MeshLambertMaterial;
+  blue: THREE.MeshLambertMaterial;
+  brass: THREE.MeshLambertMaterial;
+  tritium: THREE.MeshBasicMaterial;
+  red: THREE.MeshLambertMaterial;
+  white: THREE.MeshBasicMaterial;
+  glass: THREE.MeshLambertMaterial;
+  skin: THREE.MeshLambertMaterial;
+  sleeve: THREE.MeshLambertMaterial;
+  tan: THREE.MeshLambertMaterial;
+}
+
+function mats(): Mats {
+  return {
+    dark: new THREE.MeshLambertMaterial({ color: 0x1a1b1e }),
+    gun: new THREE.MeshLambertMaterial({ color: 0x3a3e46 }),
+    silver: new THREE.MeshLambertMaterial({ color: 0x9aa1ab }),
+    chrome: new THREE.MeshLambertMaterial({ color: 0xd5dae0 }),
+    wood: new THREE.MeshLambertMaterial({ color: 0x7a3c18 }),
+    camo: new THREE.MeshLambertMaterial({ color: 0x3a4d38 }),
+    grip: new THREE.MeshLambertMaterial({ color: 0x121314 }),
+    blue: new THREE.MeshLambertMaterial({ color: 0x243546 }),
+    brass: new THREE.MeshLambertMaterial({ color: 0xd4af37 }),
+    tritium: new THREE.MeshBasicMaterial({ color: 0x39ff14 }),
+    red: new THREE.MeshLambertMaterial({ color: 0xb42318 }),
+    white: new THREE.MeshBasicMaterial({ color: 0xf4f1e8 }),
+    glass: new THREE.MeshLambertMaterial({ color: 0x1a3344, transparent: true, opacity: 0.72 }),
+    skin: new THREE.MeshLambertMaterial({ color: 0xd9a177 }),
+    sleeve: new THREE.MeshLambertMaterial({ color: 0x1c8f92 }),
+    tan: new THREE.MeshLambertMaterial({ color: 0x8a7a5c }),
+  };
+}
+
+function box(mat: THREE.Material, w: number, h: number, d: number, x = 0, y = 0, z = 0, rx = 0, ry = 0, rz = 0) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), mat);
+  mesh.position.set(x, y, z);
+  mesh.rotation.set(rx, ry, rz);
+  return mesh;
+}
+
+function cylZ(mat: THREE.Material, r: number, len: number, x = 0, y = 0, z = 0, segs = 12, r2 = r) {
+  const mesh = new THREE.Mesh(new THREE.CylinderGeometry(r, r2, len, segs), mat);
+  mesh.rotation.x = Math.PI / 2;
+  mesh.position.set(x, y, z);
+  return mesh;
+}
+
+function addHands(handL: THREE.Group, handR: THREE.Group, m: Mats, style: 'pistol' | 'rifle' | 'knife') {
+  const palmR = box(m.skin, 0.09, 0.075, 0.11);
+  const fingersR = box(m.skin, 0.078, 0.032, 0.07, 0, -0.012, -0.075);
+  const thumbR = box(m.skin, 0.028, 0.028, 0.055, 0.05, 0.01, -0.02, 0, 0, 0.4);
+  const armR = box(m.sleeve, 0.12, 0.12, 0.4, 0.16, -0.22, 0.2, 0.55, -0.22, 0.12);
+  if (style === 'pistol') {
+    palmR.position.set(0.02, -0.13, 0.05);
+    fingersR.position.set(0.02, -0.142, -0.025);
+    thumbR.position.set(0.06, -0.11, 0.02);
+    armR.position.set(0.18, -0.34, 0.22);
+  } else if (style === 'knife') {
+    palmR.position.set(0.02, -0.02, 0.08);
+    fingersR.position.set(0.02, -0.03, 0.01);
+    thumbR.position.set(0.06, 0.0, 0.06);
+    armR.position.set(0.18, -0.3, 0.24);
+  } else {
+    palmR.position.set(0.02, -0.1, 0.05);
+    fingersR.position.set(0.02, -0.112, -0.025);
+    thumbR.position.set(0.06, -0.08, 0.02);
+    armR.position.set(0.22, -0.3, 0.22);
+  }
+  handR.add(palmR, fingersR, thumbR, armR);
+
+  if (style === 'knife') return;
+  const palmL = box(m.skin, 0.085, 0.07, 0.1);
+  const fingersL = box(m.skin, 0.074, 0.03, 0.065, 0, -0.01, -0.07);
+  const thumbL = box(m.skin, 0.026, 0.026, 0.05, -0.048, 0.008, -0.018, 0, 0, -0.4);
+  const armL = box(m.sleeve, 0.12, 0.12, 0.4, -0.18, -0.22, 0.16, 0.52, 0.28, -0.12);
+  if (style === 'pistol') {
+    palmL.position.set(-0.04, -0.14, 0.02);
+    fingersL.position.set(-0.04, -0.15, -0.05);
+    thumbL.position.set(-0.08, -0.12, 0.0);
+    armL.position.set(-0.2, -0.34, 0.18);
+  } else {
+    palmL.position.set(-0.03, -0.02, -0.22);
+    fingersL.position.set(-0.03, -0.03, -0.29);
+    thumbL.position.set(-0.07, 0.0, -0.2);
+    armL.position.set(-0.22, -0.26, -0.04);
+  }
+  handL.add(palmL, fingersL, thumbL, armL);
+}
+
+function pistolFrame(root: THREE.Group, m: Mats, opts: { chrome?: boolean; long?: boolean; suppressor?: boolean }) {
+  const bodyMat = opts.chrome ? m.chrome : m.dark;
+  const slide = new THREE.Group();
+  slide.add(
+    box(bodyMat, opts.long ? 0.082 : 0.074, 0.062, opts.long ? 0.4 : 0.34, 0, 0.04, opts.long ? -0.08 : -0.05),
+    box(m.gun, opts.long ? 0.084 : 0.076, 0.04, 0.055, 0, 0.04, opts.long ? 0.1 : 0.08),
+    box(m.dark, 0.012, 0.02, 0.02, 0, 0.08, opts.long ? -0.26 : -0.2),
+    box(m.dark, 0.04, 0.02, 0.018, 0, 0.08, opts.long ? 0.11 : 0.1),
+    box(m.tritium, 0.006, 0.008, 0.004, 0, 0.082, opts.long ? -0.25 : -0.19),
+  );
+  root.add(
+    box(m.grip, 0.07, 0.05, opts.long ? 0.36 : 0.3, 0, -0.016, -0.04),
+    box(m.grip, 0.066, 0.185, 0.09, 0, -0.13, 0.05, 0.3),
+    box(m.grip, 0.028, 0.065, 0.1, 0, -0.07, -0.06),
+    box(m.red, 0.016, 0.034, 0.022, 0, -0.06, -0.035),
+    cylZ(m.silver, 0.016, opts.long ? 0.14 : 0.1, 0, 0.032, opts.long ? -0.32 : -0.26, 10),
+  );
+  if (opts.suppressor) {
+    root.add(cylZ(m.blue, 0.02, 0.16, 0, 0.032, -0.38, 12));
+  }
+  const mag = new THREE.Group();
+  mag.add(
+    box(m.dark, 0.055, 0.21, 0.075, 0, -0.14, 0.05, 0.3),
+    box(m.grip, 0.062, 0.025, 0.085, 0, -0.24, 0.08, 0.3),
+  );
+  root.add(slide, mag);
+  return { slide, mag, muzzle: new THREE.Vector3(0, 0.035, opts.suppressor ? -0.46 : opts.long ? -0.42 : -0.34) };
+}
+
+export function assembleViewWeapon(id: number, handL: THREE.Group, handR: THREE.Group): AssembledWeapon {
+  const m = mats();
+  const root = new THREE.Group();
+  let magazine: THREE.Group | null = null;
+  let bolt: THREE.Group | null = null;
+  let muzzle = new THREE.Vector3(0, 0.04, -0.5);
+
+  const style: 'pistol' | 'rifle' | 'knife' = id === 6 ? 'knife' : isPistolId(id) ? 'pistol' : 'rifle';
+
+  switch (id) {
+    case 0: {
+      const built = pistolFrame(root, m, {});
+      bolt = built.slide; magazine = built.mag; muzzle.copy(built.muzzle);
+      break;
+    }
+    case 1: {
+      const built = pistolFrame(root, m, { chrome: true, long: true });
+      built.slide.add(box(m.brass, 0.08, 0.04, 0.04, 0, -0.14, 0.06, 0.3));
+      bolt = built.slide; magazine = built.mag; muzzle.copy(built.muzzle);
+      break;
+    }
+    case 7: {
+      const built = pistolFrame(root, m, { suppressor: true });
+      bolt = built.slide; magazine = built.mag; muzzle.copy(built.muzzle);
+      break;
+    }
+    case 2: {
+      root.add(
+        box(m.dark, 0.09, 0.1, 0.42, 0, 0.04, -0.02),
+        cylZ(m.blue, 0.046, 0.4, 0, 0.03, -0.42, 14),
+        cylZ(m.grip, 0.05, 0.22, 0, 0.03, -0.38, 12),
+        cylZ(m.silver, 0.044, 0.03, 0, 0.03, -0.62, 12),
+        cylZ(m.gun, 0.02, 0.32, 0, 0.085, -0.22, 10),
+        box(m.grip, 0.066, 0.18, 0.08, 0, -0.12, 0.06, 0.32),
+        box(m.dark, 0.055, 0.12, 0.04, 0, 0.02, 0.36),
+      );
+      const mag = new THREE.Group();
+      mag.add(box(m.dark, 0.05, 0.2, 0.09, 0, -0.12, 0.02, 0.15));
+      const slide = new THREE.Group();
+      slide.add(box(m.gun, 0.04, 0.04, 0.08, 0, 0.09, 0.12));
+      root.add(mag, slide);
+      magazine = mag; bolt = slide; muzzle.set(0, 0.03, -0.64);
+      break;
+    }
+    case 3: {
+      root.add(
+        box(m.dark, 0.086, 0.1, 0.46, 0, 0.04, -0.04),
+        box(m.wood, 0.09, 0.085, 0.18, 0, 0.03, 0.28),
+        box(m.wood, 0.07, 0.16, 0.1, 0, -0.1, 0.08, 0.35),
+        cylZ(m.gun, 0.018, 0.46, 0, 0.055, -0.42, 10),
+        cylZ(m.dark, 0.028, 0.12, 0, 0.055, -0.68, 10),
+        box(m.wood, 0.078, 0.07, 0.22, 0, -0.02, -0.22),
+        box(m.dark, 0.05, 0.08, 0.08, 0, 0.1, 0.05),
+        box(m.dark, 0.02, 0.06, 0.02, 0, 0.14, -0.55),
+      );
+      const mag = new THREE.Group();
+      mag.add(box(m.dark, 0.05, 0.22, 0.1, 0, -0.12, -0.02, 0.18));
+      const boltG = new THREE.Group();
+      boltG.add(box(m.gun, 0.03, 0.03, 0.16, 0.04, 0.08, 0.02));
+      root.add(mag, boltG);
+      magazine = mag; bolt = boltG; muzzle.set(0, 0.055, -0.76);
+      break;
+    }
+    case 4: {
+      root.add(
+        box(m.dark, 0.084, 0.095, 0.44, 0, 0.04, -0.02),
+        box(m.camo, 0.078, 0.07, 0.26, 0, -0.015, -0.24),
+        box(m.grip, 0.064, 0.17, 0.09, 0, -0.12, 0.08, 0.28),
+        cylZ(m.gun, 0.016, 0.42, 0, 0.05, -0.46, 10),
+        box(m.gun, 0.07, 0.04, 0.08, 0, 0.05, -0.7),
+        box(m.dark, 0.05, 0.1, 0.16, 0, 0.02, 0.32),
+        box(m.dark, 0.04, 0.05, 0.12, 0, 0.1, -0.08),
+        box(m.dark, 0.018, 0.05, 0.018, 0, 0.14, -0.48),
+      );
+      const mag = new THREE.Group();
+      mag.add(box(m.dark, 0.048, 0.2, 0.09, 0, -0.12, 0.0));
+      const boltG = new THREE.Group();
+      boltG.add(box(m.gun, 0.03, 0.028, 0.14, 0.038, 0.075, 0.04));
+      root.add(mag, boltG);
+      magazine = mag; bolt = boltG; muzzle.set(0, 0.05, -0.74);
+      break;
+    }
+    case 5: {
+      root.add(
+        box(m.camo, 0.09, 0.1, 0.52, 0, 0.03, 0.02),
+        box(m.grip, 0.06, 0.16, 0.12, 0, -0.1, 0.14, 0.2),
+        cylZ(m.dark, 0.016, 0.62, 0, 0.04, -0.52, 10),
+        box(m.gun, 0.07, 0.06, 0.12, 0, 0.04, -1.0),
+        cylZ(m.dark, 0.028, 0.28, 0, 0.12, -0.12, 12),
+        cylZ(m.glass, 0.022, 0.2, 0, 0.12, -0.12, 12),
+        box(m.dark, 0.05, 0.05, 0.05, 0, 0.16, -0.12),
+        box(m.dark, 0.04, 0.09, 0.18, 0, 0.0, 0.38),
+      );
+      const mag = new THREE.Group();
+      mag.add(box(m.dark, 0.06, 0.2, 0.12, 0, -0.08, -0.04));
+      const boltG = new THREE.Group();
+      boltG.add(box(m.gun, 0.035, 0.035, 0.18, 0.05, 0.08, 0.08));
+      root.add(mag, boltG);
+      magazine = mag; bolt = boltG; muzzle.set(0, 0.04, -1.08);
+      break;
+    }
+    case 8: {
+      root.add(
+        box(m.tan, 0.1, 0.11, 0.4, 0, 0.04, 0.0),
+        box(m.grip, 0.07, 0.18, 0.1, 0, -0.12, 0.1, 0.25),
+        cylZ(m.dark, 0.02, 0.32, 0, 0.04, -0.36, 10),
+        box(m.gun, 0.08, 0.05, 0.08, 0, 0.04, -0.54),
+        box(m.dark, 0.06, 0.12, 0.14, 0, 0.02, 0.3),
+        box(m.dark, 0.045, 0.06, 0.1, 0, 0.12, -0.04),
+      );
+      const mag = new THREE.Group();
+      mag.add(box(m.dark, 0.07, 0.24, 0.12, 0, -0.14, 0.02, 0.12));
+      const boltG = new THREE.Group();
+      boltG.add(box(m.gun, 0.03, 0.03, 0.1, 0.04, 0.09, 0.08));
+      root.add(mag, boltG);
+      magazine = mag; bolt = boltG; muzzle.set(0, 0.04, -0.58);
+      break;
+    }
+    case 9: {
+      root.add(
+        box(m.camo, 0.088, 0.12, 0.5, 0, 0.02, -0.04),
+        box(m.grip, 0.062, 0.16, 0.09, 0, -0.12, 0.16, 0.2),
+        cylZ(m.gun, 0.016, 0.28, 0, 0.04, -0.42, 10),
+        box(m.dark, 0.07, 0.045, 0.1, 0, 0.03, -0.6),
+        box(m.dark, 0.04, 0.08, 0.2, 0, 0.1, -0.06),
+        box(m.dark, 0.05, 0.09, 0.16, 0, 0.0, 0.32),
+        box(m.gun, 0.03, 0.06, 0.08, 0.0, -0.06, -0.28),
+      );
+      const mag = new THREE.Group();
+      mag.add(box(m.dark, 0.05, 0.18, 0.09, 0, -0.1, 0.08));
+      const boltG = new THREE.Group();
+      boltG.add(box(m.gun, 0.028, 0.03, 0.12, 0.04, 0.08, 0.02));
+      root.add(mag, boltG);
+      magazine = mag; bolt = boltG; muzzle.set(0, 0.04, -0.66);
+      break;
+    }
+    case 10: {
+      root.add(
+        box(m.camo, 0.09, 0.11, 0.58, 0, 0.03, -0.08),
+        box(m.grip, 0.06, 0.15, 0.1, 0, -0.1, -0.02, 0.15),
+        cylZ(m.dark, 0.018, 0.36, 0, 0.05, -0.52, 10),
+        cylZ(m.dark, 0.026, 0.18, 0, 0.12, -0.16, 12),
+        cylZ(m.glass, 0.02, 0.12, 0, 0.12, -0.16, 12),
+        box(m.dark, 0.055, 0.1, 0.2, 0, 0.02, 0.32),
+        box(m.gun, 0.07, 0.05, 0.1, 0, 0.04, -0.72),
+      );
+      const mag = new THREE.Group();
+      mag.add(box(m.dark, 0.05, 0.2, 0.1, 0, -0.12, -0.08));
+      const boltG = new THREE.Group();
+      boltG.add(box(m.gun, 0.03, 0.03, 0.14, 0.04, 0.08, 0.04));
+      root.add(mag, boltG);
+      magazine = mag; bolt = boltG; muzzle.set(0, 0.05, -0.78);
+      break;
+    }
+    case 11: {
+      root.add(
+        box(m.blue, 0.08, 0.09, 0.48, 0, 0.03, 0.04),
+        box(m.grip, 0.055, 0.15, 0.1, 0, -0.1, 0.16, 0.22),
+        cylZ(m.dark, 0.014, 0.7, 0, 0.04, -0.48, 10),
+        cylZ(m.dark, 0.024, 0.22, 0, 0.11, -0.08, 12),
+        cylZ(m.glass, 0.018, 0.16, 0, 0.11, -0.08, 12),
+        box(m.dark, 0.04, 0.08, 0.16, 0, 0.0, 0.36),
+        box(m.gun, 0.05, 0.04, 0.08, 0, 0.04, -0.9),
+      );
+      const mag = new THREE.Group();
+      mag.add(box(m.dark, 0.045, 0.16, 0.08, 0, -0.08, 0.02));
+      const boltG = new THREE.Group();
+      boltG.add(box(m.gun, 0.03, 0.03, 0.16, 0.045, 0.07, 0.1));
+      root.add(mag, boltG);
+      magazine = mag; bolt = boltG; muzzle.set(0, 0.04, -0.96);
+      break;
+    }
+    case 12: {
+      root.add(
+        box(m.tan, 0.092, 0.1, 0.46, 0, 0.03, -0.02),
+        box(m.grip, 0.064, 0.16, 0.1, 0, -0.11, 0.12, 0.28),
+        cylZ(m.dark, 0.028, 0.36, 0, 0.03, -0.4, 12),
+        box(m.gun, 0.08, 0.06, 0.1, 0, 0.03, -0.62),
+        box(m.dark, 0.05, 0.08, 0.18, 0, 0.02, 0.32),
+        box(m.dark, 0.04, 0.05, 0.2, 0, 0.1, -0.08),
+      );
+      const mag = new THREE.Group();
+      mag.add(box(m.dark, 0.055, 0.08, 0.22, 0, -0.06, -0.08));
+      const boltG = new THREE.Group();
+      boltG.add(box(m.gun, 0.04, 0.04, 0.1, 0.0, 0.09, 0.06));
+      root.add(mag, boltG);
+      magazine = mag; bolt = boltG; muzzle.set(0, 0.03, -0.68);
+      break;
+    }
+    default: {
+      root.add(
+        box(m.chrome, 0.02, 0.07, 0.32, 0, 0.02, -0.16),
+        box(m.silver, 0.014, 0.028, 0.3, 0, -0.016, -0.16),
+        box(m.gun, 0.06, 0.028, 0.024, 0, 0.01, 0.01),
+        box(m.grip, 0.05, 0.062, 0.17, 0, 0.01, 0.1),
+        box(m.silver, 0.052, 0.066, 0.028, 0, 0.01, 0.2),
+      );
+      muzzle.set(0, 0.02, -0.34);
+      break;
+    }
+  }
+
+  addHands(handL, handR, m, style);
+  return { root, magazine, bolt, muzzle };
+}
+
+function isPistolId(id: number) {
+  return id === 0 || id === 1 || id === 7;
+}
+
+export function markViewLayer(root: THREE.Object3D) {
+  root.traverse((obj) => {
+    obj.layers.set(VIEW_LAYER);
+    if (!(obj instanceof THREE.Mesh)) return;
+    const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
+    for (const material of materials) {
+      if (material instanceof THREE.MeshBasicMaterial && material.blending === THREE.AdditiveBlending) continue;
+      material.depthTest = true;
+      material.depthWrite = !material.transparent;
+    }
+  });
+}
+
+export const VIEWMODEL_LAYER = VIEW_LAYER;

--- a/client/src/weapons.ts
+++ b/client/src/weapons.ts
@@ -1,7 +1,8 @@
 import * as THREE from 'three';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-import { WEAPONS } from './constants.js';
+import { WEAPONS, isPistol, isSniper } from './constants.js';
 import type { SfxName } from './audio.js';
+import { assembleViewWeapon, markViewLayer, VIEWMODEL_LAYER } from './viewmodels.js';
 
 interface Shell {
   mesh: THREE.Mesh;
@@ -25,7 +26,7 @@ interface SoundCue {
   pitch?: number;
 }
 
-const RELOAD_PITCH = [1.12, 0.82, 1.18, 0.92, 1, 0.72];
+const RELOAD_PITCH: Record<number, number> = { 0: 1.12, 1: 0.82, 2: 1.18, 3: 0.92, 4: 1, 5: 0.72, 7: 1.08, 8: 1.05, 9: 0.95, 10: 0.9, 11: 0.7, 12: 0.85 };
 
 export type SoundCallback = (name: SfxName, volume?: number, pitch?: number) => void;
 
@@ -33,11 +34,12 @@ export class Weapons {
   group = new THREE.Group();
   tracers = new THREE.Group();
   shellsGroup = new THREE.Group();
+  vmCamera = new THREE.PerspectiveCamera(54, 1, 0.02, 3);
 
   private gunMeshes: THREE.Object3D[] = [];
   private handsGroup = new THREE.Group();
-  private muzzleFlashMesh: THREE.Mesh;
-  private muzzleLight = new THREE.PointLight(0xffdf88, 0, 6);
+  private muzzleFlash = new THREE.Group();
+  private muzzleLight = new THREE.PointLight(0xffdf88, 0, 8);
   private muzzleUntil = 0;
 
   // Animated sub-components for dynamic viewmodel reload
@@ -67,8 +69,8 @@ export class Weapons {
   private shellSide = new THREE.Vector3();
   private activeTracers: Tracer[] = [];
   private tracerPool: THREE.Mesh[] = [];
-  private tracerGeo = new THREE.BoxGeometry(0.025, 0.025, 1);
-  private tracerMat = new THREE.MeshBasicMaterial({ color: 0xffea78 });
+  private tracerGeo = new THREE.BoxGeometry(0.035, 0.035, 1);
+  private tracerMat = new THREE.MeshBasicMaterial({ color: 0xffc14a, transparent: true, opacity: 0.92, depthWrite: false, blending: THREE.AdditiveBlending });
   private tracerTarget = new THREE.Vector3();
 
   // Aim Down Sights (ADS)
@@ -85,19 +87,38 @@ export class Weapons {
   swayX = 0;
   swayY = 0;
 
-  constructor(camera: THREE.Camera, scene: THREE.Scene) {
-    camera.add(this.group);
-    this.group.scale.setScalar(0.86);
+  constructor(_camera: THREE.Camera, scene: THREE.Scene) {
+    this.vmCamera.rotation.order = 'YXZ';
+    this.vmCamera.layers.set(VIEWMODEL_LAYER);
+    const fill = new THREE.DirectionalLight(0xfff2dd, 1.35);
+    fill.position.set(0.35, 0.8, 0.55);
+    fill.layers.set(VIEWMODEL_LAYER);
+    const hemi = new THREE.HemisphereLight(0xffd8b0, 0x1c1410, 0.6);
+    hemi.layers.set(VIEWMODEL_LAYER);
+    this.vmCamera.add(fill, hemi, this.group);
+    scene.add(this.vmCamera);
+    this.group.scale.setScalar(0.78);
     scene.add(this.tracers);
     scene.add(this.shellsGroup);
 
-    const flashGeo = new THREE.BoxGeometry(0.18, 0.18, 0.18);
-    this.muzzleFlashMesh = new THREE.Mesh(
-      flashGeo,
-      new THREE.MeshBasicMaterial({ color: 0xffea78, transparent: true, opacity: 0.95 })
+    const flashMat = new THREE.MeshBasicMaterial({
+      color: 0xffea78,
+      transparent: true,
+      opacity: 0.95,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+    });
+    const flashA = new THREE.Mesh(new THREE.PlaneGeometry(0.28, 0.28), flashMat);
+    const flashB = new THREE.Mesh(new THREE.PlaneGeometry(0.28, 0.28), flashMat.clone());
+    flashB.rotation.y = Math.PI / 2;
+    const flashCore = new THREE.Mesh(
+      new THREE.PlaneGeometry(0.12, 0.12),
+      new THREE.MeshBasicMaterial({ color: 0xfff6c8, transparent: true, opacity: 1, depthWrite: false, blending: THREE.AdditiveBlending, side: THREE.DoubleSide }),
     );
-    this.muzzleFlashMesh.visible = false;
-    this.group.add(this.muzzleFlashMesh);
+    this.muzzleFlash.add(flashA, flashB, flashCore);
+    this.muzzleFlash.visible = false;
+    this.group.add(this.muzzleFlash);
     this.group.add(this.muzzleLight);
 
     this.handsGroup.add(this.handLGroup);
@@ -140,619 +161,21 @@ export class Weapons {
     this.handRGroup.position.set(0, 0, 0);
     this.handRGroup.rotation.set(0, 0, 0);
 
-    const root = new THREE.Group();
-
-    // High-definition tactical material palette
-    const darkMetal = new THREE.MeshLambertMaterial({ color: 0x1b1b1e });
-    const gunmetal = new THREE.MeshLambertMaterial({ color: 0x33363d });
-    const silverSteel = new THREE.MeshLambertMaterial({ color: 0x9fa3ab });
-    const chromeSteel = new THREE.MeshLambertMaterial({ color: 0xd2d6dc });
-    const cherryWood = new THREE.MeshLambertMaterial({ color: 0x7a3a1a });
-    const greenCamo = new THREE.MeshLambertMaterial({ color: 0x344d37 });
-    const darkGrip = new THREE.MeshLambertMaterial({ color: 0x121316 });
-    const tacticalBlue = new THREE.MeshLambertMaterial({ color: 0x223547 });
-    const goldBrass = new THREE.MeshLambertMaterial({ color: 0xd4af37 });
-    const tritiumGreen = new THREE.MeshBasicMaterial({ color: 0x39ff14 });
-    const redAccent = new THREE.MeshLambertMaterial({ color: 0xc92a2a });
-    const whiteDot = new THREE.MeshBasicMaterial({ color: 0xffffff });
-    const glassMat = new THREE.MeshLambertMaterial({ color: 0x182e3d, transparent: true, opacity: 0.85 });
-    const skinMat = new THREE.MeshLambertMaterial({ color: 0xd9a177 });
-    const sleeveMat = new THREE.MeshLambertMaterial({ color: 0x009ea2 });
-
-    switch (id) {
-      case 0: { // Glock-18 (Tactical Semi/Burst Pistol)
-        const frame = new THREE.Mesh(new THREE.BoxGeometry(0.074, 0.055, 0.34), darkGrip);
-        frame.position.set(0, -0.018, -0.05);
-
-        const rail = new THREE.Mesh(new THREE.BoxGeometry(0.065, 0.018, 0.11), darkGrip);
-        rail.position.set(0, -0.052, -0.16);
-
-        const barrel = new THREE.Mesh(new THREE.BoxGeometry(0.036, 0.036, 0.12), silverSteel);
-        barrel.position.set(0, 0.035, -0.26);
-
-        const guideRod = new THREE.Mesh(new THREE.BoxGeometry(0.018, 0.018, 0.08), silverSteel);
-        guideRod.position.set(0, 0.01, -0.24);
-
-        const guard = new THREE.Mesh(new THREE.BoxGeometry(0.028, 0.068, 0.11), darkGrip);
-        guard.position.set(0, -0.07, -0.07);
-
-        const trigger = new THREE.Mesh(new THREE.BoxGeometry(0.016, 0.038, 0.025), redAccent);
-        trigger.position.set(0, -0.062, -0.04);
-
-        const grip = new THREE.Mesh(new THREE.BoxGeometry(0.068, 0.19, 0.095), darkGrip);
-        grip.position.set(0, -0.13, 0.05);
-        grip.rotation.x = 0.28;
-
-        const gripStipple = new THREE.Mesh(new THREE.BoxGeometry(0.07, 0.14, 0.075), darkMetal);
-        gripStipple.position.set(0, -0.14, 0.055);
-        gripStipple.rotation.x = 0.28;
-
-        root.add(frame, rail, barrel, guideRod, guard, trigger, grip, gripStipple);
-
-        // Slide group (moves during fire and reload)
-        const slideGroup = new THREE.Group();
-        const slide = new THREE.Mesh(new THREE.BoxGeometry(0.076, 0.065, 0.36), darkMetal);
-        slide.position.set(0, 0.04, -0.05);
-
-        const frontSerr = new THREE.Mesh(new THREE.BoxGeometry(0.078, 0.038, 0.06), gunmetal);
-        frontSerr.position.set(0, 0.04, -0.18);
-
-        const rearSerr = new THREE.Mesh(new THREE.BoxGeometry(0.078, 0.042, 0.06), gunmetal);
-        rearSerr.position.set(0, 0.04, 0.08);
-
-        const frontSight = new THREE.Mesh(new THREE.BoxGeometry(0.012, 0.02, 0.02), darkMetal);
-        frontSight.position.set(0, 0.08, -0.21);
-        const frontDot = new THREE.Mesh(new THREE.BoxGeometry(0.006, 0.008, 0.004), tritiumGreen);
-        frontDot.position.set(0, 0.082, -0.20);
-
-        const rearSight = new THREE.Mesh(new THREE.BoxGeometry(0.042, 0.022, 0.02), darkMetal);
-        rearSight.position.set(0, 0.08, 0.11);
-        const dotL = new THREE.Mesh(new THREE.BoxGeometry(0.005, 0.008, 0.004), whiteDot);
-        dotL.position.set(-0.014, 0.082, 0.10);
-        const dotR = new THREE.Mesh(new THREE.BoxGeometry(0.005, 0.008, 0.004), whiteDot);
-        dotR.position.set(0.014, 0.082, 0.10);
-
-        const ejectPort = new THREE.Mesh(new THREE.BoxGeometry(0.038, 0.028, 0.08), gunmetal);
-        ejectPort.position.set(0.022, 0.055, -0.04);
-
-        slideGroup.add(slide, frontSerr, rearSerr, frontSight, frontDot, rearSight, dotL, dotR, ejectPort);
-        root.add(slideGroup);
-        this.boltMesh = slideGroup;
-
-        // Magazine group (moves during reload)
-        const magGroup = new THREE.Group();
-        const magBody = new THREE.Mesh(new THREE.BoxGeometry(0.056, 0.22, 0.076), darkMetal);
-        magBody.position.set(0, -0.14, 0.05);
-        magBody.rotation.x = 0.28;
-        const magPad = new THREE.Mesh(new THREE.BoxGeometry(0.066, 0.028, 0.09), darkGrip);
-        magPad.position.set(0, -0.24, 0.08);
-        magPad.rotation.x = 0.28;
-        magGroup.add(magBody, magPad);
-        root.add(magGroup);
-        this.magazineMesh = magGroup;
-
-        this.muzzleLight.position.set(0, 0.04, -0.36);
-        this.muzzleFlashMesh.position.set(0, 0.04, -0.36);
-
-        // Hands (Right grip & Left support)
-        const handR = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.14, 0.14), skinMat);
-        handR.position.set(0.01, -0.13, 0.04);
-        const armR = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armR.position.set(0.18, -0.35, 0.22);
-        armR.rotation.set(0.7, -0.3, 0.2);
-        this.handRGroup.add(handR, armR);
-
-        const handL = new THREE.Mesh(new THREE.BoxGeometry(0.11, 0.13, 0.13), skinMat);
-        handL.position.set(-0.04, -0.14, 0.02);
-        const armL = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armL.position.set(-0.20, -0.34, 0.18);
-        armL.rotation.set(0.68, 0.35, -0.2);
-        this.handLGroup.add(handL, armL);
-        break;
-      }
-
-      case 1: { // Desert Eagle .50 AE (Heavy Hand Cannon)
-        const frame = new THREE.Mesh(new THREE.BoxGeometry(0.088, 0.075, 0.40), silverSteel);
-        frame.position.set(0, -0.02, -0.06);
-
-        const frontBarrel = new THREE.Mesh(new THREE.BoxGeometry(0.092, 0.086, 0.16), chromeSteel);
-        frontBarrel.position.set(0, 0.05, -0.35);
-
-        const compPorts = new THREE.Mesh(new THREE.BoxGeometry(0.096, 0.022, 0.045), darkMetal);
-        compPorts.position.set(0, 0.065, -0.37);
-
-        const hammer = new THREE.Mesh(new THREE.BoxGeometry(0.025, 0.045, 0.035), darkMetal);
-        hammer.position.set(0, 0.035, 0.14);
-
-        const guard = new THREE.Mesh(new THREE.BoxGeometry(0.03, 0.075, 0.13), silverSteel);
-        guard.position.set(0, -0.075, -0.09);
-
-        const trigger = new THREE.Mesh(new THREE.BoxGeometry(0.02, 0.045, 0.035), darkMetal);
-        trigger.position.set(0, -0.065, -0.06);
-
-        const grip = new THREE.Mesh(new THREE.BoxGeometry(0.082, 0.23, 0.115), darkGrip);
-        grip.position.set(0, -0.16, 0.06);
-        grip.rotation.x = 0.32;
-
-        const medallion = new THREE.Mesh(new THREE.BoxGeometry(0.086, 0.045, 0.045), goldBrass);
-        medallion.position.set(0, -0.15, 0.065);
-        medallion.rotation.x = 0.32;
-
-        root.add(frame, frontBarrel, compPorts, hammer, guard, trigger, grip, medallion);
-
-        // Slide group (Chrome slide)
-        const slideGroup = new THREE.Group();
-        const slide = new THREE.Mesh(new THREE.BoxGeometry(0.096, 0.092, 0.44), chromeSteel);
-        slide.position.set(0, 0.05, -0.08);
-
-        const topRail = new THREE.Mesh(new THREE.BoxGeometry(0.052, 0.018, 0.32), chromeSteel);
-        topRail.position.set(0, 0.102, -0.08);
-
-        const serr = new THREE.Mesh(new THREE.BoxGeometry(0.098, 0.065, 0.08), silverSteel);
-        serr.position.set(0, 0.05, 0.10);
-
-        const frontSight = new THREE.Mesh(new THREE.BoxGeometry(0.014, 0.024, 0.025), darkMetal);
-        frontSight.position.set(0, 0.105, -0.28);
-
-        const rearSight = new THREE.Mesh(new THREE.BoxGeometry(0.052, 0.028, 0.025), darkMetal);
-        rearSight.position.set(0, 0.105, 0.12);
-
-        const safety = new THREE.Mesh(new THREE.BoxGeometry(0.104, 0.02, 0.04), darkMetal);
-        safety.position.set(0, 0.07, 0.08);
-
-        slideGroup.add(slide, topRail, serr, frontSight, rearSight, safety);
-        root.add(slideGroup);
-        this.boltMesh = slideGroup;
-
-        // Magazine group
-        const magGroup = new THREE.Group();
-        const magBody = new THREE.Mesh(new THREE.BoxGeometry(0.07, 0.24, 0.095), darkMetal);
-        magBody.position.set(0, -0.16, 0.06);
-        magBody.rotation.x = 0.32;
-        const magPad = new THREE.Mesh(new THREE.BoxGeometry(0.08, 0.028, 0.105), darkGrip);
-        magPad.position.set(0, -0.28, 0.10);
-        magPad.rotation.x = 0.32;
-        magGroup.add(magBody, magPad);
-        root.add(magGroup);
-        this.magazineMesh = magGroup;
-
-        this.muzzleLight.position.set(0, 0.05, -0.45);
-        this.muzzleFlashMesh.position.set(0, 0.05, -0.45);
-
-        const handR = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.14, 0.14), skinMat);
-        handR.position.set(0.01, -0.15, 0.05);
-        const armR = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armR.position.set(0.2, -0.36, 0.24);
-        armR.rotation.set(0.7, -0.3, 0.2);
-        this.handRGroup.add(handR, armR);
-
-        const handL = new THREE.Mesh(new THREE.BoxGeometry(0.11, 0.13, 0.13), skinMat);
-        handL.position.set(-0.04, -0.16, 0.03);
-        const armL = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armL.position.set(-0.21, -0.35, 0.20);
-        armL.rotation.set(0.68, 0.35, -0.2);
-        this.handLGroup.add(handL, armL);
-        break;
-      }
-
-      case 2: { // MP5-SD (Submachine Gun with Integral Suppressor)
-        const receiver = new THREE.Mesh(new THREE.BoxGeometry(0.088, 0.105, 0.44), darkMetal);
-        receiver.position.set(0, 0.04, -0.02);
-
-        // Suppressor barrel with knurled rubber sleeve
-        const suppressor = new THREE.Mesh(new THREE.CylinderGeometry(0.048, 0.048, 0.38, 16), tacticalBlue);
-        suppressor.rotation.x = Math.PI / 2;
-        suppressor.position.set(0, 0.03, -0.42);
-
-        const sleeve = new THREE.Mesh(new THREE.CylinderGeometry(0.052, 0.052, 0.25, 16), darkGrip);
-        sleeve.rotation.x = Math.PI / 2;
-        sleeve.position.set(0, 0.03, -0.40);
-
-        const muzzleRing = new THREE.Mesh(new THREE.CylinderGeometry(0.046, 0.046, 0.03, 16), silverSteel);
-        muzzleRing.rotation.x = Math.PI / 2;
-        muzzleRing.position.set(0, 0.03, -0.61);
-
-        const cockingTube = new THREE.Mesh(new THREE.CylinderGeometry(0.022, 0.022, 0.34, 12), gunmetal);
-        cockingTube.rotation.x = Math.PI / 2;
-        cockingTube.position.set(0, 0.085, -0.25);
-
-        const diopterSight = new THREE.Mesh(new THREE.CylinderGeometry(0.022, 0.022, 0.025, 12), darkMetal);
-        diopterSight.position.set(0, 0.105, 0.14);
-
-        const hoodedFront = new THREE.Mesh(new THREE.CylinderGeometry(0.024, 0.024, 0.02, 12), darkMetal);
-        hoodedFront.position.set(0, 0.085, -0.48);
-
-        const lowerGrip = new THREE.Mesh(new THREE.BoxGeometry(0.068, 0.19, 0.085), darkGrip);
-        lowerGrip.position.set(0, -0.13, 0.06);
-        lowerGrip.rotation.x = 0.35;
-
-        const selector = new THREE.Mesh(new THREE.BoxGeometry(0.084, 0.015, 0.03), redAccent);
-        selector.position.set(0, -0.03, 0.03);
-
-        const railL = new THREE.Mesh(new THREE.BoxGeometry(0.012, 0.012, 0.28), silverSteel);
-        railL.position.set(-0.042, 0.03, 0.26);
-        const railR = new THREE.Mesh(new THREE.BoxGeometry(0.012, 0.012, 0.28), silverSteel);
-        railR.position.set(0.042, 0.03, 0.26);
-        const buttpad = new THREE.Mesh(new THREE.BoxGeometry(0.06, 0.13, 0.035), darkGrip);
-        buttpad.position.set(0, 0.02, 0.38);
-
-        root.add(receiver, suppressor, sleeve, muzzleRing, cockingTube, diopterSight, hoodedFront, lowerGrip, selector, railL, railR, buttpad);
-
-        // Charging handle (boltMesh)
-        const boltGroup = new THREE.Group();
-        const handle = new THREE.Mesh(new THREE.BoxGeometry(0.045, 0.03, 0.035), silverSteel);
-        handle.position.set(-0.035, 0.09, -0.38);
-        boltGroup.add(handle);
-        root.add(boltGroup);
-        this.boltMesh = boltGroup;
-
-        // Curved 30-round 9mm Banana Magazine
-        const magGroup = new THREE.Group();
-        const magUpper = new THREE.Mesh(new THREE.BoxGeometry(0.052, 0.15, 0.075), darkMetal);
-        magUpper.position.set(0, -0.10, -0.08);
-        magUpper.rotation.x = 0.35;
-        const magLower = new THREE.Mesh(new THREE.BoxGeometry(0.052, 0.14, 0.075), darkMetal);
-        magLower.position.set(0, -0.22, -0.03);
-        magLower.rotation.x = 0.52;
-        const paddle = new THREE.Mesh(new THREE.BoxGeometry(0.018, 0.032, 0.02), silverSteel);
-        paddle.position.set(0, -0.07, -0.04);
-        magGroup.add(magUpper, magLower, paddle);
-        root.add(magGroup);
-        this.magazineMesh = magGroup;
-
-        this.muzzleLight.position.set(0, 0.03, -0.62);
-        this.muzzleFlashMesh.position.set(0, 0.03, -0.62);
-
-        const handR = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.14, 0.14), skinMat);
-        handR.position.set(0.01, -0.13, 0.05);
-        const armR = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armR.position.set(0.22, -0.32, 0.2);
-        armR.rotation.set(0.65, -0.3, 0.2);
-        this.handRGroup.add(handR, armR);
-
-        const handL = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.13, 0.13), skinMat);
-        handL.position.set(-0.01, 0.03, -0.38);
-        const armL = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armL.position.set(-0.24, -0.28, 0.05);
-        armL.rotation.set(0.6, 0.45, -0.3);
-        this.handLGroup.add(handL, armL);
-        break;
-      }
-
-      case 3: { // AK-47 (Classic Tactical Assault Rifle)
-        const receiver = new THREE.Mesh(new THREE.BoxGeometry(0.088, 0.115, 0.46), darkMetal);
-        receiver.position.set(0, 0.04, -0.02);
-
-        const dustCover = new THREE.Mesh(new THREE.BoxGeometry(0.084, 0.05, 0.36), gunmetal);
-        dustCover.position.set(0, 0.095, 0.02);
-
-        const selectorPlate = new THREE.Mesh(new THREE.BoxGeometry(0.008, 0.035, 0.14), gunmetal);
-        selectorPlate.position.set(0.048, 0.03, 0.02);
-
-        const barrel = new THREE.Mesh(new THREE.BoxGeometry(0.032, 0.032, 0.45), gunmetal);
-        barrel.position.set(0, 0.05, -0.48);
-
-        const cleanRod = new THREE.Mesh(new THREE.BoxGeometry(0.01, 0.01, 0.38), silverSteel);
-        cleanRod.position.set(0, 0.025, -0.44);
-
-        const gasTube = new THREE.Mesh(new THREE.BoxGeometry(0.038, 0.038, 0.30), darkMetal);
-        gasTube.position.set(0, 0.09, -0.36);
-
-        const gasBlock = new THREE.Mesh(new THREE.BoxGeometry(0.045, 0.07, 0.05), gunmetal);
-        gasBlock.position.set(0, 0.075, -0.52);
-
-        const woodUpper = new THREE.Mesh(new THREE.BoxGeometry(0.078, 0.055, 0.24), cherryWood);
-        woodUpper.position.set(0, 0.092, -0.35);
-
-        const woodLower = new THREE.Mesh(new THREE.BoxGeometry(0.086, 0.075, 0.26), cherryWood);
-        woodLower.position.set(0, 0.045, -0.36);
-
-        const woodGrip = new THREE.Mesh(new THREE.BoxGeometry(0.068, 0.19, 0.085), cherryWood);
-        woodGrip.position.set(0, -0.13, 0.06);
-        woodGrip.rotation.x = 0.38;
-
-        const woodStock = new THREE.Mesh(new THREE.BoxGeometry(0.072, 0.145, 0.35), cherryWood);
-        woodStock.position.set(0, 0.01, 0.38);
-        woodStock.rotation.x = -0.04;
-
-        const buttplate = new THREE.Mesh(new THREE.BoxGeometry(0.074, 0.15, 0.02), darkMetal);
-        buttplate.position.set(0, 0.01, 0.55);
-
-        const frontSight = new THREE.Mesh(new THREE.BoxGeometry(0.048, 0.085, 0.04), gunmetal);
-        frontSight.position.set(0, 0.085, -0.66);
-
-        const slantComp = new THREE.Mesh(new THREE.BoxGeometry(0.038, 0.04, 0.06), gunmetal);
-        slantComp.position.set(0, 0.05, -0.72);
-
-        const rearSight = new THREE.Mesh(new THREE.BoxGeometry(0.035, 0.025, 0.11), gunmetal);
-        rearSight.position.set(0, 0.11, -0.21);
-
-        root.add(receiver, dustCover, selectorPlate, barrel, cleanRod, gasTube, gasBlock, woodUpper, woodLower, woodGrip, woodStock, buttplate, frontSight, slantComp, rearSight);
-
-        // Bolt carrier group with charging handle (moves during fire and reload)
-        const boltGroup = new THREE.Group();
-        const boltCarrier = new THREE.Mesh(new THREE.BoxGeometry(0.07, 0.045, 0.16), silverSteel);
-        boltCarrier.position.set(0, 0.075, -0.04);
-        const boltHandle = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.02, 0.025), silverSteel);
-        boltHandle.position.set(0.065, 0.075, -0.04);
-        boltGroup.add(boltCarrier, boltHandle);
-        root.add(boltGroup);
-        this.boltMesh = boltGroup;
-
-        // Curved 30-round 7.62mm Steel Waffle Magazine
-        const magGroup = new THREE.Group();
-        const magUpper = new THREE.Mesh(new THREE.BoxGeometry(0.058, 0.18, 0.11), darkMetal);
-        magUpper.position.set(0, -0.12, -0.11);
-        magUpper.rotation.x = 0.38;
-        const magLower = new THREE.Mesh(new THREE.BoxGeometry(0.058, 0.16, 0.11), darkMetal);
-        magLower.position.set(0, -0.25, -0.04);
-        magLower.rotation.x = 0.58;
-        const magLatch = new THREE.Mesh(new THREE.BoxGeometry(0.018, 0.035, 0.025), gunmetal);
-        magLatch.position.set(0, -0.06, -0.04);
-        magGroup.add(magUpper, magLower, magLatch);
-        root.add(magGroup);
-        this.magazineMesh = magGroup;
-
-        this.muzzleLight.position.set(0, 0.05, -0.72);
-        this.muzzleFlashMesh.position.set(0, 0.05, -0.72);
-
-        const handR = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.14, 0.14), skinMat);
-        handR.position.set(0.01, -0.13, 0.05);
-        const armR = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armR.position.set(0.24, -0.32, 0.2);
-        armR.rotation.set(0.65, -0.3, 0.2);
-        this.handRGroup.add(handR, armR);
-
-        const handL = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.13, 0.13), skinMat);
-        handL.position.set(-0.01, 0.02, -0.34);
-        const armL = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armL.position.set(-0.25, -0.28, 0.0);
-        armL.rotation.set(0.6, 0.45, -0.3);
-        this.handLGroup.add(handL, armL);
-        break;
-      }
-
-      case 4: { // M4A4 (Special Operations Carbine)
-        const upper = new THREE.Mesh(new THREE.BoxGeometry(0.086, 0.095, 0.38), darkMetal);
-        upper.position.set(0, 0.04, -0.02);
-
-        const lower = new THREE.Mesh(new THREE.BoxGeometry(0.082, 0.08, 0.34), darkMetal);
-        lower.position.set(0, -0.04, -0.03);
-
-        const deflector = new THREE.Mesh(new THREE.BoxGeometry(0.025, 0.035, 0.05), gunmetal);
-        deflector.position.set(0.05, 0.05, 0.04);
-
-        const assist = new THREE.Mesh(new THREE.BoxGeometry(0.025, 0.025, 0.06), gunmetal);
-        assist.position.set(0.05, 0.02, 0.08);
-
-        const deltaRing = new THREE.Mesh(new THREE.CylinderGeometry(0.048, 0.048, 0.035, 16), gunmetal);
-        deltaRing.rotation.x = Math.PI / 2;
-        deltaRing.position.set(0, 0.04, -0.20);
-
-        const quadRail = new THREE.Mesh(new THREE.BoxGeometry(0.088, 0.092, 0.34), gunmetal);
-        quadRail.position.set(0, 0.04, -0.38);
-
-        const railCovers = new THREE.Mesh(new THREE.BoxGeometry(0.092, 0.075, 0.26), darkGrip);
-        railCovers.position.set(0, 0.04, -0.38);
-
-        const barrel = new THREE.Mesh(new THREE.BoxGeometry(0.032, 0.032, 0.36), silverSteel);
-        barrel.position.set(0, 0.04, -0.58);
-
-        const a2Front = new THREE.Mesh(new THREE.BoxGeometry(0.045, 0.11, 0.055), gunmetal);
-        a2Front.position.set(0, 0.09, -0.66);
-
-        const rearAperture = new THREE.Mesh(new THREE.BoxGeometry(0.055, 0.055, 0.10), gunmetal);
-        rearAperture.position.set(0, 0.105, 0.10);
-
-        const birdcage = new THREE.Mesh(new THREE.BoxGeometry(0.042, 0.042, 0.075), gunmetal);
-        birdcage.position.set(0, 0.04, -0.76);
-
-        const bufferTube = new THREE.Mesh(new THREE.CylinderGeometry(0.024, 0.024, 0.26, 12), silverSteel);
-        bufferTube.rotation.x = Math.PI / 2;
-        bufferTube.position.set(0, 0.03, 0.26);
-
-        const craneStock = new THREE.Mesh(new THREE.BoxGeometry(0.072, 0.14, 0.26), darkGrip);
-        craneStock.position.set(0, 0.02, 0.34);
-
-        const a2Grip = new THREE.Mesh(new THREE.BoxGeometry(0.068, 0.20, 0.09), darkGrip);
-        a2Grip.position.set(0, -0.13, 0.06);
-        a2Grip.rotation.x = 0.32;
-
-        root.add(upper, lower, deflector, assist, deltaRing, quadRail, railCovers, barrel, a2Front, rearAperture, birdcage, bufferTube, craneStock, a2Grip);
-
-        // Rear charging handle (boltMesh)
-        const boltGroup = new THREE.Group();
-        const chargingHandle = new THREE.Mesh(new THREE.BoxGeometry(0.07, 0.02, 0.08), gunmetal);
-        chargingHandle.position.set(0, 0.088, 0.17);
-        boltGroup.add(chargingHandle);
-        root.add(boltGroup);
-        this.boltMesh = boltGroup;
-
-        // Straight STANAG 30-round Magazine
-        const magGroup = new THREE.Group();
-        const stanagMag = new THREE.Mesh(new THREE.BoxGeometry(0.056, 0.28, 0.095), darkGrip);
-        stanagMag.position.set(0, -0.13, -0.10);
-        stanagMag.rotation.x = 0.25;
-        magGroup.add(stanagMag);
-        root.add(magGroup);
-        this.magazineMesh = magGroup;
-
-        this.muzzleLight.position.set(0, 0.04, -0.76);
-        this.muzzleFlashMesh.position.set(0, 0.04, -0.76);
-
-        const handR = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.14, 0.14), skinMat);
-        handR.position.set(0.01, -0.13, 0.05);
-        const armR = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armR.position.set(0.24, -0.32, 0.2);
-        armR.rotation.set(0.65, -0.3, 0.2);
-        this.handRGroup.add(handR, armR);
-
-        const handL = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.13, 0.13), skinMat);
-        handL.position.set(-0.01, 0.03, -0.36);
-        const armL = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armL.position.set(-0.25, -0.28, 0.0);
-        armL.rotation.set(0.6, 0.45, -0.3);
-        this.handLGroup.add(handL, armL);
-        break;
-      }
-
-      case 5: { // AWP (Heavy Precision Sniper Rifle)
-        const chassis = new THREE.Mesh(new THREE.BoxGeometry(0.095, 0.125, 0.68), greenCamo);
-        chassis.position.set(0, 0.03, 0.0);
-
-        const thumbhole = new THREE.Mesh(new THREE.BoxGeometry(0.075, 0.15, 0.38), greenCamo);
-        thumbhole.position.set(0, 0.01, 0.38);
-
-        const cheekRiser = new THREE.Mesh(new THREE.BoxGeometry(0.065, 0.055, 0.18), darkGrip);
-        cheekRiser.position.set(0, 0.10, 0.32);
-
-        const buttpad = new THREE.Mesh(new THREE.BoxGeometry(0.075, 0.16, 0.045), darkGrip);
-        buttpad.position.set(0, 0.01, 0.58);
-
-        const flutedBarrel = new THREE.Mesh(new THREE.BoxGeometry(0.044, 0.044, 0.78), darkMetal);
-        flutedBarrel.position.set(0, 0.04, -0.65);
-
-        const muzzleBrake = new THREE.Mesh(new THREE.BoxGeometry(0.078, 0.068, 0.14), gunmetal);
-        muzzleBrake.position.set(0, 0.04, -1.05);
-
-        // High-Magnification Sniper Optic Scope
-        const scopeMount = new THREE.Mesh(new THREE.BoxGeometry(0.045, 0.035, 0.26), darkMetal);
-        scopeMount.position.set(0, 0.10, -0.05);
-
-        const ringF = new THREE.Mesh(new THREE.CylinderGeometry(0.042, 0.042, 0.03, 16), gunmetal);
-        ringF.rotation.x = Math.PI / 2;
-        ringF.position.set(0, 0.14, -0.14);
-
-        const ringR = new THREE.Mesh(new THREE.CylinderGeometry(0.042, 0.042, 0.03, 16), gunmetal);
-        ringR.rotation.x = Math.PI / 2;
-        ringR.position.set(0, 0.14, 0.04);
-
-        const scopeTube = new THREE.Mesh(new THREE.CylinderGeometry(0.036, 0.036, 0.44, 16), darkMetal);
-        scopeTube.rotation.x = Math.PI / 2;
-        scopeTube.position.set(0, 0.14, -0.05);
-
-        const objBell = new THREE.Mesh(new THREE.CylinderGeometry(0.052, 0.038, 0.10, 16), darkMetal);
-        objBell.rotation.x = Math.PI / 2;
-        objBell.position.set(0, 0.14, -0.28);
-
-        const objGlass = new THREE.Mesh(new THREE.BoxGeometry(0.042, 0.042, 0.005), glassMat);
-        objGlass.position.set(0, 0.14, -0.32);
-
-        const ocularBell = new THREE.Mesh(new THREE.CylinderGeometry(0.044, 0.038, 0.08, 16), darkMetal);
-        ocularBell.rotation.x = Math.PI / 2;
-        ocularBell.position.set(0, 0.14, 0.18);
-
-        const turretTop = new THREE.Mesh(new THREE.CylinderGeometry(0.016, 0.016, 0.025, 12), gunmetal);
-        turretTop.position.set(0, 0.18, -0.05);
-
-        const turretSide = new THREE.Mesh(new THREE.CylinderGeometry(0.016, 0.016, 0.025, 12), gunmetal);
-        turretSide.rotation.z = Math.PI / 2;
-        turretSide.position.set(0.04, 0.14, -0.05);
-
-        // Folded Bipod
-        const bipodL = new THREE.Mesh(new THREE.BoxGeometry(0.016, 0.016, 0.26), silverSteel);
-        bipodL.position.set(-0.045, -0.03, -0.35);
-        const bipodR = new THREE.Mesh(new THREE.BoxGeometry(0.016, 0.016, 0.26), silverSteel);
-        bipodR.position.set(0.045, -0.03, -0.35);
-
-        root.add(chassis, thumbhole, cheekRiser, buttpad, flutedBarrel, muzzleBrake, scopeMount, ringF, ringR, scopeTube, objBell, objGlass, ocularBell, turretTop, turretSide, bipodL, bipodR);
-
-        // Heavy Bolt Assembly
-        const boltGroup = new THREE.Group();
-        const boltBody = new THREE.Mesh(new THREE.BoxGeometry(0.045, 0.045, 0.28), silverSteel);
-        boltBody.position.set(0, 0.05, 0.02);
-        const handleArm = new THREE.Mesh(new THREE.BoxGeometry(0.055, 0.02, 0.02), silverSteel);
-        handleArm.position.set(0.065, 0.065, 0.06);
-        const handleKnob = new THREE.Mesh(new THREE.BoxGeometry(0.032, 0.032, 0.032), silverSteel);
-        handleKnob.position.set(0.09, 0.055, 0.06);
-        boltGroup.add(boltBody, handleArm, handleKnob);
-        root.add(boltGroup);
-        this.boltMesh = boltGroup;
-
-        // Heavy Box Magazine
-        const magGroup = new THREE.Group();
-        const boxMag = new THREE.Mesh(new THREE.BoxGeometry(0.065, 0.22, 0.125), darkMetal);
-        boxMag.position.set(0, -0.09, -0.06);
-        magGroup.add(boxMag);
-        root.add(magGroup);
-        this.magazineMesh = magGroup;
-
-        this.muzzleLight.position.set(0, 0.04, -1.12);
-        this.muzzleFlashMesh.position.set(0, 0.04, -1.12);
-
-        const handR = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.14, 0.14), skinMat);
-        handR.position.set(0.01, -0.11, 0.06);
-        const armR = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armR.position.set(0.25, -0.32, 0.22);
-        armR.rotation.set(0.65, -0.3, 0.2);
-        this.handRGroup.add(handR, armR);
-
-        const handL = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.13, 0.13), skinMat);
-        handL.position.set(-0.01, -0.02, -0.28);
-        const armL = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armL.position.set(-0.25, -0.28, -0.05);
-        armL.rotation.set(0.6, 0.45, -0.3);
-        this.handLGroup.add(handL, armL);
-        break;
-      }
-
-      default: { // Knife (Tactical Combat Bayonet)
-        const blade = new THREE.Mesh(new THREE.BoxGeometry(0.024, 0.085, 0.34), silverSteel);
-        blade.position.set(0, 0.02, -0.16);
-
-        const edge = new THREE.Mesh(new THREE.BoxGeometry(0.016, 0.03, 0.32), chromeSteel);
-        edge.position.set(0, -0.02, -0.16);
-
-        const sawSpine = new THREE.Mesh(new THREE.BoxGeometry(0.026, 0.02, 0.14), gunmetal);
-        sawSpine.position.set(0, 0.06, -0.10);
-
-        const fuller = new THREE.Mesh(new THREE.BoxGeometry(0.026, 0.015, 0.20), darkMetal);
-        fuller.position.set(0, 0.02, -0.15);
-
-        const guard = new THREE.Mesh(new THREE.BoxGeometry(0.065, 0.03, 0.025), gunmetal);
-        guard.position.set(0, 0.01, 0.01);
-
-        const handle = new THREE.Mesh(new THREE.BoxGeometry(0.052, 0.068, 0.18), darkGrip);
-        handle.position.set(0, 0.01, 0.10);
-
-        const rivet1 = new THREE.Mesh(new THREE.BoxGeometry(0.055, 0.015, 0.015), silverSteel);
-        rivet1.position.set(0, 0.01, 0.06);
-        const rivet2 = new THREE.Mesh(new THREE.BoxGeometry(0.055, 0.015, 0.015), silverSteel);
-        rivet2.position.set(0, 0.01, 0.13);
-
-        const pommel = new THREE.Mesh(new THREE.BoxGeometry(0.055, 0.072, 0.03), silverSteel);
-        pommel.position.set(0, 0.01, 0.20);
-
-        root.add(blade, edge, sawSpine, fuller, guard, handle, rivet1, rivet2, pommel);
-
-        const handR = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.14, 0.14), skinMat);
-        handR.position.set(0.01, -0.02, 0.08);
-        const armR = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.45, 0.14), sleeveMat);
-        armR.position.set(0.20, -0.32, 0.24);
-        armR.rotation.set(0.7, -0.25, 0.2);
-        this.handRGroup.add(handR, armR);
-        break;
-      }
-    }
+    const assembled = assembleViewWeapon(id, this.handLGroup, this.handRGroup);
+    this.magazineMesh = assembled.magazine;
+    this.boltMesh = assembled.bolt;
+    this.muzzleLight.position.copy(assembled.muzzle);
+    this.muzzleFlash.position.copy(assembled.muzzle);
     if (this.magazineMesh) mergeMeshesByMaterial(this.magazineMesh);
     if (this.boltMesh) mergeMeshesByMaterial(this.boltMesh);
-    mergeMeshesByMaterial(root, [this.magazineMesh, this.boltMesh]);
-
-    for (const part of [root, this.handLGroup, this.handRGroup]) {
-      part.traverse((obj) => {
-        if (!(obj instanceof THREE.Mesh)) return;
-        const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
-        for (const material of materials) {
-          material.transparent = true;
-          material.depthTest = false;
-          material.depthWrite = false;
-        }
-        obj.renderOrder = 1000;
-      });
-    }
-
-    this.gunMeshes.push(root);
-    this.group.add(root);
+    mergeMeshesByMaterial(assembled.root, [this.magazineMesh, this.boltMesh]);
+    markViewLayer(assembled.root);
+    markViewLayer(this.handLGroup);
+    markViewLayer(this.handRGroup);
+    markViewLayer(this.muzzleFlash);
+    this.muzzleLight.layers.set(VIEWMODEL_LAYER);
+    this.gunMeshes.push(assembled.root);
+    this.group.add(assembled.root);
   }
   canFire(t: number): boolean {
     if (this.weaponId === 6) {
@@ -763,19 +186,19 @@ export class Weapons {
 
   startReload(t: number, reserve = 999): boolean {
     const def = WEAPONS[this.weaponId] ?? WEAPONS[0];
-    if (this.weaponId >= 6 || reserve <= 0 || this.ammoLocal >= def.mag || this.isReloading(t)) return false;
+    if (this.weaponId === 6 || reserve <= 0 || this.ammoLocal >= def.mag || this.isReloading(t)) return false;
 
     this.reloadStartedAt = t;
     this.reloadingUntil = t + def.reloadMs;
     this.nextFireAt = Math.max(this.nextFireAt, this.reloadingUntil);
 
     // Schedule high-definition synchronized reload sound cues
-    const isPistol = this.weaponId === 0 || this.weaponId === 1;
+    const pistolReload = isPistol(this.weaponId);
     const pitch = RELOAD_PITCH[this.weaponId] ?? 1;
     this.scheduledSounds = [
       { time: t + def.reloadMs * 0.18, name: 'mag_out', vol: 0.75, pitch: pitch * 1.04 },
       { time: t + def.reloadMs * 0.54, name: 'mag_in', vol: 0.85, pitch },
-      { time: t + def.reloadMs * 0.78, name: isPistol ? 'reload_click' : 'bolt_cycle', vol: 0.82, pitch: pitch * 0.96 },
+      { time: t + def.reloadMs * 0.78, name: pistolReload ? 'reload_click' : 'bolt_cycle', vol: 0.82, pitch: pitch * 0.96 },
     ];
 
     return true;
@@ -825,17 +248,20 @@ export class Weapons {
     const def = WEAPONS[this.weaponId] ?? WEAPONS[0];
     const interval = 60000 / def.rpm;
     this.nextFireAt = this.nextFireAt > 0 && t - this.nextFireAt < interval ? this.nextFireAt + interval : t + interval;
-    if (this.weaponId === 5) {
+    if (isSniper(this.weaponId)) {
       this.boltCycleStartedAt = t;
       this.boltCycleUntil = this.nextFireAt;
-      this.scheduledSounds.push({ time: t + interval * 0.28, name: 'bolt_cycle', vol: 0.9, pitch: RELOAD_PITCH[5] });
+      this.scheduledSounds.push({ time: t + interval * 0.28, name: 'bolt_cycle', vol: 0.9, pitch: RELOAD_PITCH[this.weaponId] ?? 0.72 });
     }
     if (this.weaponId === 6) return;
     this.ammoLocal = Math.max(0, this.ammoLocal - 1);
-    this.recoil = Math.min(1.2, this.recoil + 0.45);
-    this.muzzleFlashMesh.visible = true;
-    this.muzzleLight.intensity = 2.5;
-    this.muzzleUntil = t + 50;
+    const kick = isSniper(this.weaponId) ? 0.55 : this.weaponId === 1 || this.weaponId === 12 ? 0.5 : 0.38;
+    this.recoil = Math.min(1.05, this.recoil + kick);
+    this.muzzleFlash.visible = true;
+    this.muzzleFlash.rotation.z = Math.random() * Math.PI;
+    this.muzzleFlash.scale.setScalar(0.9 + Math.random() * 0.35);
+    this.muzzleLight.intensity = isSniper(this.weaponId) || this.weaponId === 12 ? 4.2 : 2.8;
+    this.muzzleUntil = t + 48;
     this.ejectShell(origin);
   }
 
@@ -861,10 +287,10 @@ export class Weapons {
     });
   }
 
-  animate(t: number, dt: number, moving: boolean, isAiming: boolean, mouseDeltaX: number, mouseDeltaY: number, equipped = true) {
+  animate(t: number, dt: number, moving: boolean, isAiming: boolean, mouseDeltaX: number, mouseDeltaY: number, equipped = true, bobScale = 1) {
     const reloading = this.isReloading(t);
     const rlProgress = reloading ? this.getReloadProgress(t) : 0;
-    const boltProgress = this.weaponId === 5 && !reloading && t < this.boltCycleUntil
+    const boltProgress = isSniper(this.weaponId) && !reloading && t < this.boltCycleUntil
       ? Math.max(0, Math.min(1, (t - this.boltCycleStartedAt) / (this.boltCycleUntil - this.boltCycleStartedAt)))
       : 1;
     const awpBoltArc = boltProgress < 0.78 ? Math.sin(boltProgress / 0.78 * Math.PI) : 0;
@@ -882,13 +308,13 @@ export class Weapons {
       this.scheduledSounds.length = pending;
     }
 
-    this.group.visible = equipped && !(this.weaponId === 5 && isAiming && !reloading);
+    this.group.visible = equipped && !(isSniper(this.weaponId) && isAiming && !reloading);
     const targetAds = isAiming && !reloading ? 1 : 0;
-    const adsRate = this.weaponId === 5 ? 4.5 : 14;
+    const adsRate = isSniper(this.weaponId) ? 5.5 : this.weaponId === 10 ? 8 : 14;
     this.adsProgress += (targetAds - this.adsProgress) * Math.min(1, dt * adsRate);
 
-    this.swayX += (-mouseDeltaX * 0.00045 - this.swayX) * Math.min(1, dt * 16);
-    this.swayY += (-mouseDeltaY * 0.00045 - this.swayY) * Math.min(1, dt * 16);
+    this.swayX += (-mouseDeltaX * 0.00028 - this.swayX) * Math.min(1, dt * 18);
+    this.swayY += (-mouseDeltaY * 0.00028 - this.swayY) * Math.min(1, dt * 18);
     const motionFactor = 1 - this.adsProgress;
 
     // Smooth weapon draw / deploy transition
@@ -902,12 +328,13 @@ export class Weapons {
     const slashPhase = this.slashProgress > 0 ? Math.sin((1 - this.slashProgress) * Math.PI) : 0;
     // Continuous, jitter-free viewmodel bobbing with target lerp
     if (moving && !isAiming && !reloading) this.bobT += dt * 6.2;
-    const targetBobY = (moving && !isAiming && !reloading ? Math.sin(this.bobT) * 0.006 : Math.sin(t * 0.0018) * 0.0015) * (1 - this.adsProgress);
-    const targetBobX = (moving && !isAiming && !reloading ? Math.cos(this.bobT * 0.5) * 0.0035 : 0) * (1 - this.adsProgress);
-    this.curBobX += (targetBobX - this.curBobX) * Math.min(1, dt * 14);
-    this.curBobY += (targetBobY - this.curBobY) * Math.min(1, dt * 14);
+    const bob = Math.max(0, Math.min(1, bobScale));
+    const targetBobY = (moving && !isAiming && !reloading ? Math.sin(this.bobT) * 0.0055 : Math.sin(t * 0.0018) * 0.0012) * (1 - this.adsProgress) * bob;
+    const targetBobX = (moving && !isAiming && !reloading ? Math.cos(this.bobT * 0.5) * 0.003 : 0) * (1 - this.adsProgress) * bob;
+    this.curBobX += (targetBobX - this.curBobX) * Math.min(1, dt * 16);
+    this.curBobY += (targetBobY - this.curBobY) * Math.min(1, dt * 16);
 
-    this.recoil = Math.max(0, this.recoil - dt * 10);
+    this.recoil = Math.max(0, this.recoil - dt * 11);
 
     // Keep reload motion inside the viewmodel-safe area; animate parts, not the whole gun across the camera.
     const rlTilt = reloading ? Math.sin(Math.PI * rlProgress) : 0;
@@ -917,32 +344,56 @@ export class Weapons {
     // Precision ADS alignment: sights sit precisely at center reticle without receiver body blocking view
     // Natural ADS position: Gun stays visible in lower third of screen, never blocking central reticle/sightline
     let hipX = 0.28, hipY = -0.26, hipZ = -0.72;
-    let adsX = 0.08, adsY = -0.24, adsZ = -0.66;
+    let adsX = 0.08, adsY = -0.22, adsZ = -0.66;
 
     switch (this.weaponId) {
       case 0: // Glock-18
         hipX = 0.22; hipY = -0.20; hipZ = -0.58;
-        adsX = 0.06; adsY = -0.20; adsZ = -0.54;
+        adsX = 0.055; adsY = -0.18; adsZ = -0.52;
         break;
       case 1: // Desert Eagle
         hipX = 0.24; hipY = -0.22; hipZ = -0.60;
-        adsX = 0.06; adsY = -0.22; adsZ = -0.56;
+        adsX = 0.055; adsY = -0.19; adsZ = -0.54;
         break;
       case 2: // MP5-SD
         hipX = 0.26; hipY = -0.24; hipZ = -0.68;
-        adsX = 0.07; adsY = -0.23; adsZ = -0.62;
+        adsX = 0.07; adsY = -0.21; adsZ = -0.62;
         break;
       case 3: // AK-47
         hipX = 0.28; hipY = -0.26; hipZ = -0.72;
-        adsX = 0.08; adsY = -0.24; adsZ = -0.66;
+        adsX = 0.08; adsY = -0.22; adsZ = -0.66;
         break;
       case 4: // M4A4
         hipX = 0.28; hipY = -0.26; hipZ = -0.72;
-        adsX = 0.08; adsY = -0.24; adsZ = -0.66;
+        adsX = 0.08; adsY = -0.22; adsZ = -0.66;
         break;
       case 5: // AWP
         hipX = 0.30; hipY = -0.28; hipZ = -0.78;
-        adsX = 0.08; adsY = -0.26; adsZ = -0.70;
+        adsX = 0.08; adsY = -0.24; adsZ = -0.70;
+        break;
+      case 7: // USP-S
+        hipX = 0.22; hipY = -0.20; hipZ = -0.60;
+        adsX = 0.055; adsY = -0.18; adsZ = -0.54;
+        break;
+      case 8: // UMP-45
+        hipX = 0.26; hipY = -0.24; hipZ = -0.66;
+        adsX = 0.07; adsY = -0.21; adsZ = -0.60;
+        break;
+      case 9: // FAMAS
+        hipX = 0.28; hipY = -0.25; hipZ = -0.70;
+        adsX = 0.08; adsY = -0.21; adsZ = -0.64;
+        break;
+      case 10: // AUG
+        hipX = 0.28; hipY = -0.25; hipZ = -0.72;
+        adsX = 0.06; adsY = -0.2; adsZ = -0.62;
+        break;
+      case 11: // SSG 08
+        hipX = 0.30; hipY = -0.27; hipZ = -0.76;
+        adsX = 0.08; adsY = -0.23; adsZ = -0.68;
+        break;
+      case 12: // XM1014
+        hipX = 0.27; hipY = -0.24; hipZ = -0.68;
+        adsX = 0.075; adsY = -0.21; adsZ = -0.62;
         break;
       default: // Knife
         hipX = adsX = 0.26; hipY = adsY = -0.22; hipZ = adsZ = -0.58;
@@ -951,11 +402,11 @@ export class Weapons {
 
     const posX = hipX + (adsX - hipX) * this.adsProgress + this.curBobX + this.swayX * motionFactor - rlTilt * 0.06 + slashPhase * 0.11;
     const posY = hipY + (adsY - hipY) * this.adsProgress + this.curBobY + this.swayY * motionFactor - rlTilt * 0.05 - rlSeatImpulse - drawDip * 0.12 + Math.sin(slashPhase * Math.PI) * 0.045;
-    const posZ = hipZ + (adsZ - hipZ) * this.adsProgress + this.recoil * 0.06 + rlSeatImpulse * 0.3 - drawDip * 0.06 - slashPhase * 0.07;
+    const posZ = hipZ + (adsZ - hipZ) * this.adsProgress + this.recoil * 0.045 + rlSeatImpulse * 0.3 - drawDip * 0.06 - slashPhase * 0.07;
     this.group.position.set(posX, posY, posZ);
 
-    this.group.rotation.x = this.recoil * 0.12 + rlTilt * 0.16 - this.swayY * motionFactor + drawDip * 0.22 - slashPhase * 0.32 + rlBoltCycle * 0.10 - this.adsProgress * 0.04;
-    this.group.rotation.y = -this.recoil * 0.02 + this.swayX * motionFactor + rlTilt * 0.10 + slashPhase * 0.48 - this.adsProgress * 0.02;
+    this.group.rotation.x = this.recoil * 0.08 + rlTilt * 0.16 - this.swayY * motionFactor + drawDip * 0.22 - slashPhase * 0.32 + rlBoltCycle * 0.10;
+    this.group.rotation.y = -this.recoil * 0.015 + this.swayX * motionFactor + rlTilt * 0.10 + slashPhase * 0.48;
     this.group.rotation.z = -rlTilt * 0.30 - slashPhase * 0.20;
     if (this.magazineMesh) {
       if (reloading && rlProgress < 0.32) {
@@ -972,7 +423,7 @@ export class Weapons {
     if (this.boltMesh) {
       const fireBlowback = Math.max(0, this.recoil) * 0.04;
       this.boltMesh.position.set(0, 0, fireBlowback + rlBoltCycle * 0.065 + awpBoltArc * 0.22);
-      this.boltMesh.rotation.z = this.weaponId === 5 ? -awpBoltArc * 0.65 : 0;
+      this.boltMesh.rotation.z = isSniper(this.weaponId) ? -awpBoltArc * 0.65 : 0;
     }
     if (reloading) {
       if (rlProgress < 0.32) {
@@ -990,7 +441,7 @@ export class Weapons {
     } else {
       this.handLGroup.position.set(0, 0, 0);
     }
-    if (this.weaponId === 5 && awpBoltArc > 0) {
+    if (isSniper(this.weaponId) && awpBoltArc > 0) {
       this.handRGroup.position.set(awpBoltArc * 0.07, awpBoltArc * 0.08, awpBoltArc * 0.16);
       this.handRGroup.rotation.z = -awpBoltArc * 0.35;
     } else {
@@ -998,7 +449,7 @@ export class Weapons {
       this.handRGroup.rotation.set(0, 0, 0);
     }
     if (t > this.muzzleUntil) {
-      this.muzzleFlashMesh.visible = false;
+      this.muzzleFlash.visible = false;
       this.muzzleLight.intensity = 0;
     }
 
@@ -1023,7 +474,7 @@ export class Weapons {
 
     let aliveTracers = 0;
     for (const tracer of this.activeTracers) {
-      if (now - tracer.born > 90) {
+      if (now - tracer.born > 130) {
         this.tracers.remove(tracer.mesh);
         this.tracerPool.push(tracer.mesh);
         continue;
@@ -1041,6 +492,32 @@ export class Weapons {
     mesh.lookAt(this.tracerTarget.copy(origin).addScaledVector(dir, dist));
     this.tracers.add(mesh);
     this.activeTracers.push({ mesh, born: performance.now() });
+  }
+
+  setAspect(aspect: number) {
+    this.vmCamera.aspect = aspect;
+    this.vmCamera.updateProjectionMatrix();
+  }
+
+  syncFrom(camera: THREE.PerspectiveCamera) {
+    this.vmCamera.position.copy(camera.position);
+    this.vmCamera.quaternion.copy(camera.quaternion);
+    if (this.vmCamera.aspect !== camera.aspect) this.setAspect(camera.aspect);
+  }
+
+  renderOverlay(renderer: THREE.WebGLRenderer, scene: THREE.Scene) {
+    if (!this.group.visible) return;
+    const background = scene.background;
+    const fog = scene.fog;
+    scene.background = null;
+    scene.fog = null;
+    const prevAutoClear = renderer.autoClear;
+    renderer.autoClear = false;
+    renderer.clear(false, true, false);
+    renderer.render(scene, this.vmCamera);
+    renderer.autoClear = prevAutoClear;
+    scene.background = background;
+    scene.fog = fog;
   }
 }
 

--- a/client/src/world.ts
+++ b/client/src/world.ts
@@ -456,18 +456,22 @@ export class WorldView {
   }
 
   private setupSky() {
-    // Luminous Voxel Sun
     const sunBox = new THREE.Mesh(
-      new THREE.BoxGeometry(22, 22, 6),
-      new THREE.MeshBasicMaterial({ color: 0xfffae0 })
+      new THREE.BoxGeometry(28, 28, 6),
+      new THREE.MeshBasicMaterial({ color: 0xffb060 })
     );
-    sunBox.position.set(110, 160, -150);
+    sunBox.position.set(90, 42, -130);
     sunBox.lookAt(0, 0, 0);
-    this.sun.add(sunBox);
+    const halo = new THREE.Mesh(
+      new THREE.BoxGeometry(48, 48, 4),
+      new THREE.MeshBasicMaterial({ color: 0xff7a3a, transparent: true, opacity: 0.28, depthWrite: false })
+    );
+    halo.position.copy(sunBox.position);
+    halo.lookAt(0, 0, 0);
+    this.sun.add(halo, sunBox);
     this.scene.add(this.sun);
 
-    // High Stratified Volumetric Clouds across 512x512 arena
-    const cloudMat = new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.88 });
+    const cloudMat = new THREE.MeshBasicMaterial({ color: 0xffd2a8, transparent: true, opacity: 0.62 });
     const cloudGeos: THREE.BufferGeometry[] = [];
     let cSeed = 42;
     const cRnd = () => (cSeed = (cSeed * 16807) % 2147483647) / 2147483647;

--- a/server/proto_test.go
+++ b/server/proto_test.go
@@ -224,6 +224,58 @@ func TestKnifeAttackDoesNotRequireAmmo(t *testing.T) {
 	}
 }
 
+func TestArsenalRolesStaySeparated(t *testing.T) {
+	ak, m4, aug := Weapons[3], Weapons[4], Weapons[10]
+	if aug.Dmg*aug.ArmorPen >= ak.Dmg*ak.ArmorPen {
+		t.Fatalf("AUG body (%.1f) should not match AK (%.1f)", aug.Dmg*aug.ArmorPen, ak.Dmg*ak.ArmorPen)
+	}
+	if m4.SpreadDeg >= ak.SpreadDeg {
+		t.Fatal("M4 should stay more accurate than AK")
+	}
+	if Weapons[7].Dmg >= 30 {
+		t.Fatalf("USP damage too rifle-like: %v", Weapons[7].Dmg)
+	}
+	ssg := Weapons[11]
+	if ssg.Dmg*ssg.ArmorPen >= MaxHP {
+		t.Fatalf("SSG should not body one-shot: %.1f", ssg.Dmg*ssg.ArmorPen)
+	}
+	xm := Weapons[12]
+	if float64(xm.Pellets)*xm.Dmg*xm.ArmorPen >= MaxHP {
+		t.Fatalf("XM should not armor-dump with all pellets: %.1f", float64(xm.Pellets)*xm.Dmg*xm.ArmorPen)
+	}
+	if Weapons[2].SpreadDeg >= .7 {
+		t.Fatal("MP5 spread still unusable")
+	}
+	if Weapons[8].Rpm >= Weapons[2].Rpm {
+		t.Fatal("UMP should not out-cycle MP5")
+	}
+}
+
+func TestLoadoutAcceptsExpandedArsenal(t *testing.T) {
+	if !validLoadout(12, 7) || !validLoadout(11, 1) || !validLoadout(8, 0) {
+		t.Fatal("new primary/secondary pairs rejected")
+	}
+	if validLoadout(7, 3) || validLoadout(6, 0) || validLoadout(3, 8) {
+		t.Fatal("invalid loadout accepted")
+	}
+}
+
+func TestWeaponSpreadStaysControllable(t *testing.T) {
+	ak := Weapons[3]
+	first := weaponSpread(ak, 0, 0, true, false, false, false, 0)
+	hipSpray := weaponSpread(ak, 0, 0, true, false, false, false, 20)
+	ads := weaponSpread(ak, 0, 0, true, false, false, true, 20)
+	if first > ak.SpreadDeg+0.05 {
+		t.Fatalf("first shot inaccuracy too high: %.3f", first)
+	}
+	if hipSpray > first+0.3 {
+		t.Fatalf("spray bloom still dominates recoil: first=%.3f spray=%.3f", first, hipSpray)
+	}
+	if ads >= hipSpray {
+		t.Fatalf("ADS did not tighten inaccuracy: ads=%.3f hip=%.3f", ads, hipSpray)
+	}
+}
+
 func TestPatternDirStaysInsideSpread(t *testing.T) {
 	aim := AimDir(.3, -.2)
 	limit := math.Cos(2 * math.Pi / 180)

--- a/server/sim.go
+++ b/server/sim.go
@@ -23,17 +23,37 @@ type WeaponDef struct {
 	Dmg, HeadMult, Rpm, SpreadDeg, MoveSpreadDeg, BloomDeg, SpeedMult, ArmorPen float64
 	Mag, Reserve, ReloadMs                                                      int
 	Automatic                                                                   bool
+	Pellets                                                                     int
 }
 
-var Weapons = [7]WeaponDef{
-	{0, "Glock-18", 20, 3.0, 400, .42, 1.3, .14, 1.0, .58, 20, 120, 1400, false},
-	{1, "Desert Eagle", 48, 2.3, 267, .22, 2.2, .36, .98, .93, 7, 35, 1800, false},
-	{2, "MP5-SD", 25, 3.0, 800, .72, 1.6, .07, .98, .63, 30, 120, 1800, true},
-	{3, "AK-47", 33, 4.0, 600, .38, 2.0, .17, .92, .78, 30, 90, 2200, true},
-	{4, "M4A4", 31, 3.6, 666, .32, 1.75, .12, .92, .70, 30, 90, 2100, true},
-	{5, "AWP", 108, 2.5, 32, .03, 4.8, 0, .75, .98, 5, 30, 2800, false},
-	{6, "Knife", 34, 1, 150, 0, 0, 0, 1.08, 1, 0, 0, 0, false},
+var Weapons = []WeaponDef{
+	{0, "Glock-18", 24, 3.0, 450, .36, 1.2, .12, 1.0, .58, 20, 120, 1400, false, 1},
+	{1, "Desert Eagle", 48, 2.3, 267, .22, 2.2, .36, .98, .93, 7, 35, 1800, false, 1},
+	{2, "MP5-SD", 26, 3.0, 800, .50, 1.45, .06, 1.0, .65, 30, 120, 1800, true, 1},
+	{3, "AK-47", 33, 4.0, 600, .38, 2.0, .17, .92, .78, 30, 90, 2200, true, 1},
+	{4, "M4A4", 31, 3.6, 666, .28, 1.65, .11, .93, .70, 30, 90, 2100, true, 1},
+	{5, "AWP", 108, 2.5, 32, .03, 4.8, 0, .76, .98, 5, 30, 2800, false, 1},
+	{6, "Knife", 34, 1, 150, 0, 0, 0, 1.08, 1, 0, 0, 0, false, 1},
+	{7, "USP-S", 27, 2.4, 352, .16, 1.4, .22, 1.0, .50, 12, 24, 1700, false, 1},
+	{8, "UMP-45", 26, 2.6, 600, .68, 1.55, .10, .97, .63, 25, 100, 2100, true, 1},
+	{9, "FAMAS", 30, 3.2, 700, .36, 1.75, .14, .94, .67, 25, 90, 2200, true, 1},
+	{10, "AUG", 31, 3.4, 600, .27, 1.6, .12, .88, .70, 30, 90, 2300, true, 1},
+	{11, "SSG 08", 80, 2.4, 40, .05, 3.8, 0, .80, .82, 8, 80, 2600, false, 1},
+	{12, "XM1014", 14, 1.2, 150, 3.2, 4.2, .40, .93, .62, 5, 24, 2600, false, 6},
 }
+
+func isGun(id uint8) bool { return int(id) < len(Weapons) && id != 6 }
+func isSniper(id uint8) bool { return id == 5 || id == 11 }
+func isPrimary(id uint8) bool {
+	switch id {
+	case 2, 3, 4, 5, 8, 9, 10, 11, 12:
+		return true
+	}
+	return false
+}
+func isSecondary(id uint8) bool { return id == 0 || id == 1 || id == 7 }
+
+const WeaponHE uint8 = 13
 
 const (
 	TickRate        = 60
@@ -48,7 +68,7 @@ const (
 	MaxRewindTicks  = 8
 	MaxHP           = 100
 	SpawnProtectS   = 2 * time.Second
-	AWPScopeTime    = 450 * time.Millisecond
+	AWPScopeTime    = 320 * time.Millisecond
 	RespawnDelayS   = 3 * time.Second
 	EyeHeight       = 1.6
 	CrouchEyeH      = 1.12
@@ -106,7 +126,7 @@ func (p *PlayerState) setActiveAmmo(mag, reserve int) {
 	}
 }
 func validLoadout(primary, secondary uint8) bool {
-	return primary >= 2 && primary <= 5 && secondary <= 1
+	return isPrimary(primary) && isSecondary(secondary)
 }
 func (p *PlayerState) ApplyLoadout(primary, secondary uint8) {
 	if !validLoadout(primary, secondary) {
@@ -263,10 +283,10 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 	weapon := min(int(p.Weapon), len(Weapons)-1)
 	def := Weapons[weapon]
 	mag, reserve := p.ActiveAmmo()
-	if weapon < 6 && mag <= 0 {
+	if isGun(uint8(weapon)) && mag <= 0 {
 		return false
 	}
-	if weapon < 6 {
+	if isGun(uint8(weapon)) {
 		p.setActiveAmmo(mag-1, reserve)
 	}
 	gap := time.Duration(60 / def.Rpm * float64(time.Second))
@@ -278,7 +298,7 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 	} else {
 		p.NextFire = p.NextFire.Add(gap)
 	}
-	if weapon < 6 && mag == 1 && reserve > 0 {
+	if isGun(uint8(weapon)) && mag == 1 && reserve > 0 {
 		r.StartReload(p, now)
 	}
 	if now.Sub(p.LastShotAt) > 420*time.Millisecond {
@@ -299,56 +319,74 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 	if weapon == 6 {
 		maxDist = 1.65
 	}
-	if weapon < 6 {
-		spread := weaponSpread(def, p.Vel.X, p.Vel.Z, p.OnGround, p.Crouch, now.Before(p.LandingUntil), max(0, int(p.ShotCounter)-1))
-		if weapon == 5 && (mode&0x80 == 0 || p.AimStarted.IsZero() || now.Sub(p.AimStarted) < AWPScopeTime) {
+	ads := mode&0x80 != 0
+	spread := 0.0
+	if isGun(uint8(weapon)) {
+		spread = weaponSpread(def, p.Vel.X, p.Vel.Z, p.OnGround, p.Crouch, now.Before(p.LandingUntil), ads, max(0, int(p.ShotCounter)-1))
+		settle := AWPScopeTime
+		if weapon == 11 {
+			settle = 240 * time.Millisecond
+		}
+		if isSniper(uint8(weapon)) && (!ads || p.AimStarted.IsZero() || now.Sub(p.AimStarted) < settle) {
 			spread = math.Max(spread, def.MoveSpreadDeg)
 		}
-		dir = patternDir(dir, spread, int(p.ShotCounter), weapon)
 	}
-	_, worldDist := r.World.Raycast(origin, dir, maxDist)
 	if seenTick > r.tick {
 		seenTick = r.tick
 	}
 	if r.tick-seenTick > MaxRewindTicks {
 		seenTick = r.tick - MaxRewindTicks
 	}
-	var target *PlayerState
-	targetDist, hitY, hitHeight := maxDist, 0.0, StandingHeight
-	for _, other := range r.Players {
-		o := &other.PlayerState
-		if o == p || !o.Alive || o.ProtectedAt(now) {
+	pellets := 1
+	if isGun(uint8(weapon)) && def.Pellets > 1 {
+		pellets = def.Pellets
+	}
+	for n := 0; n < pellets; n++ {
+		shotDir := dir
+		if isGun(uint8(weapon)) {
+			shotDir = patternDir(dir, spread, int(p.ShotCounter)*17+n, weapon)
+		}
+		_, worldDist := r.World.Raycast(origin, shotDir, maxDist)
+		var target *PlayerState
+		targetDist, hitY, hitHeight := maxDist, 0.0, StandingHeight
+		for _, other := range r.Players {
+			o := &other.PlayerState
+			if o == p || !o.Alive || o.ProtectedAt(now) {
+				continue
+			}
+			pose := r.poseAt(o.Id, seenTick, o.Pos, o.Crouch)
+			height := StandingHeight
+			if pose.Crouch {
+				height = CrouchingHeight
+			}
+			if d, ok := RayPlayerAABBHeight(origin, shotDir, pose.Pos, height, math.Min(worldDist, maxDist)); ok && d < targetDist {
+				target, targetDist, hitY, hitHeight = o, d, origin.Y+shotDir.Y*d-pose.Pos.Y, height
+			}
+		}
+		if target == nil {
 			continue
 		}
-		pose := r.poseAt(o.Id, seenTick, o.Pos, o.Crouch)
-		height := StandingHeight
-		if pose.Crouch {
-			height = CrouchingHeight
+		headshot := isGun(uint8(weapon)) && hitY >= hitHeight-.4
+		dmg := def.Dmg
+		if weapon == 6 {
+			if mode&1 != 0 {
+				dmg = 55
+			}
+			toAttacker := norm(Vec3{p.Pos.X - target.Pos.X, 0, p.Pos.Z - target.Pos.Z})
+			forward := Vec3{-math.Sin(target.Yaw), 0, -math.Cos(target.Yaw)}
+			if toAttacker.X*forward.X+toAttacker.Z*forward.Z < -.5 {
+				dmg *= 2
+			}
+		} else if headshot {
+			dmg *= def.HeadMult
+		} else if hitY <= .65 {
+			dmg *= .75
 		}
-		if d, ok := RayPlayerAABBHeight(origin, dir, pose.Pos, height, math.Min(worldDist, maxDist)); ok && d < targetDist {
-			target, targetDist, hitY, hitHeight = o, d, origin.Y+dir.Y*d-pose.Pos.Y, height
+		r.Damage(p, target, dmg, headshot, uint8(weapon), now)
+		if !target.Alive && pellets == 1 {
+			break
 		}
 	}
-	if target == nil {
-		return true
-	}
-	headshot := weapon < 6 && hitY >= hitHeight-.4
-	dmg := def.Dmg
-	if weapon == 6 {
-		if mode&1 != 0 {
-			dmg = 55
-		}
-		toAttacker := norm(Vec3{p.Pos.X - target.Pos.X, 0, p.Pos.Z - target.Pos.Z})
-		forward := Vec3{-math.Sin(target.Yaw), 0, -math.Cos(target.Yaw)}
-		if toAttacker.X*forward.X+toAttacker.Z*forward.Z < -.5 {
-			dmg *= 2
-		}
-	} else if headshot {
-		dmg *= def.HeadMult
-	} else if hitY <= .65 {
-		dmg *= .75
-	}
-	r.Damage(p, target, dmg, headshot, uint8(weapon), now)
 	return true
 }
 
@@ -357,7 +395,7 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 		return
 	}
 	actual := dmg
-	if victim.Armor > 0 && weapon < 6 {
+	if victim.Armor > 0 && isGun(weapon) {
 		actual = dmg * Weapons[weapon].ArmorPen
 		lost := uint8(math.Min(float64(victim.Armor), math.Ceil((dmg-actual)*.5)))
 		victim.Armor -= lost
@@ -640,7 +678,7 @@ func (r *Room) StepGrenades(now time.Time) {
 					if hit, hd := r.World.Raycast(g.Pos, dir, d); hit && hd < d-.5 {
 						continue
 					}
-					r.Damage(thrower, v, 85*(1-d/7.5), false, 6, now)
+					r.Damage(thrower, v, 85*(1-d/7.5), false, WeaponHE, now)
 				}
 			}
 			continue
@@ -718,18 +756,23 @@ func AimDir(yaw, pitch float64) Vec3 {
 	cp := math.Cos(pitch)
 	return Vec3{-math.Sin(yaw) * cp, math.Sin(pitch), -math.Cos(yaw) * cp}
 }
-func weaponSpread(def WeaponDef, vx, vz float64, onGround, crouching, landing bool, burstShots int) float64 {
+func weaponSpread(def WeaponDef, vx, vz float64, onGround, crouching, landing, aiming bool, burstShots int) float64 {
 	moveFactor := math.Min(1, math.Hypot(vx, vz)/3)
 	spread := def.SpreadDeg + (def.MoveSpreadDeg-def.SpreadDeg)*moveFactor
-	spread += math.Min(def.MoveSpreadDeg-def.SpreadDeg, float64(burstShots)*def.BloomDeg)
+	// Bloom used to dump the whole spray into a random cone, which made
+	// recoil unreadable. Keep a tiny residual so long sprays aren't lasers.
+	spread += math.Min(.22, float64(burstShots)*def.BloomDeg*.12)
 	if !onGround {
-		spread = math.Max(spread, def.MoveSpreadDeg*2.2+1)
+		spread = math.Max(spread, def.MoveSpreadDeg*1.55+.45)
 	}
 	if crouching {
-		spread *= .6
+		spread *= .55
+	}
+	if aiming && !isSniper(def.Id) {
+		spread *= .48
 	}
 	if landing {
-		spread = math.Max(spread, def.MoveSpreadDeg*1.35)
+		spread = math.Max(spread, def.MoveSpreadDeg*1.12)
 	}
 	return spread
 }


### PR DESCRIPTION
## 摘要

针对第一人称“乱飘 / 弹道不可控”、持枪第二遍渲染清空世界画面、以及新枪过强、老枪过弱的问题，调整了权威开火与客户端预测表现。协议仍为 v4；枪械 ID 向后扩展到 7–12，手雷击杀展示从误用的刀 ID `6` 改为 `13`。

12 个文件，`+1059 / -793`。

## 行为变化

1. **弹道**：子弹沿当前准星方向；后坐只改下一发瞄准角。随机圆锥不再吃满 bloom，开镜会收散布。
2. **镜头**：去掉额外踢枪、随机侧倾、FOV 冲击，准星和弹着对齐。
3. **持枪绘制**：独立 54° viewmodel 相机叠在世界之上；叠层时去掉 `scene.background` / `fog`，只清深度，避免 Three.js 把天空再清一遍。
4. **枪械**：新增 USP-S / UMP-45 / FAMAS / AUG / SSG 08 / XM1014（XM 为多弹丸）。
5. **平衡**：补 Glock / MP5 / M4 / AWP 开镜时间；压 USP 伤害、UMP 射速、AUG 破甲、SSG 不能打身体秒杀、XM 打满甲无法一枪清。

## 文件与影响

### 服务端（权威）

| 文件 | 作用 |
|---|---|
| `server/sim.go` | 武器表扩到 13 项（含刀）；`validLoadout` 改为 `isPrimary` + `isSecondary`。开火路径用 `isGun`（不再 `weapon < 6`，否则 USP/XM 会不扣弹、不散布）。狙
| `server/proto_test.go` | 补充散布可控、配装合法性、枪种职责分离（AUG 破甲不超过 AK、USP 伤害上限、SSG/XM 不能打满甲秒杀、MP5 散布、UMP 射速低于 MP5）。|

### 客户端（表现 / 输入）

| 文件 | 作用 |
|---|---|
| `client/src/constants.ts` | 与服务端对齐的 `WEAPONS`（伤害、RPM、散布、破甲、弹匣、`pellets`）。导出 `isSniper` / `isPistol` / `isGun` / `scopeSettleMs`。|
| `client/src/main.ts` | 主循环：`applyRecoil` 确定性后坐；`weaponSpread` 开镜与 bloom 规则与服务端一致；步枪/狙击/霰弹开火与换弹判断改为 `!== 6`。世界相机 `layers` 不含
| `client/src/weapons.ts` | 持枪从世界相机拆出，挂到 `vmCamera`（layer 1）。`build()` 改为调用 `assembleViewWeapon`。换弹限制改为仅刀。狙击拉栓、开镜隐藏持枪。叠层渲染保
| `client/src/viewmodels.ts` | **新增**。13 把视角枪零件组装（枪管/握把/弹匣/瞄具/手），以及 `markViewLayer`。|
| `client/src/hud.ts` | 弹药大字、受击方向、低血暗角、拾取提示、FOV/持枪手感滑条。武器短名与 SVG 扩到 7–13（13=HE）。快捷栏手雷图标改用 `WEAPON_SVGS[13]`。|
| `client/index.html` | 大厅主/副武器选项、弹药 HUD、设置项、颗粒叠层等样式。修复原 `.slot-icon` 后无选择器的 CSS 碎片。|
| `client/src/audio.ts` | 新枪声合成回退：`fire_usp/ump/famas/aug/scout/xm`。无对应 wav 时走 WebAudio。|
| `client/src/player.ts` | 第三人称持枪：USP（id 7）用手枪姿势。|
| `client/src/particles.ts` | 弹着额外火花；去掉会糊在镜头前的 muzzle puff。|
| `client/src/world.ts` | 黄昏太阳/云层色，与主场景雾和平行光一致。|

## 协议与兼容

- 协议版本仍为 **4**，帧格式未改。
- 枪械 id：`0–6` 原样；`7–12` 为新枪；击杀/战绩里手雷为 **13**（旧客户端会把 7–13 显示成未知/HE 回退，新客户端有短名）。
- 旧客户端若只发 `primary∈[2,5] && secondary∈[0,1]`，新服务端仍接受。
- 新枪必须两边同时更新