### PR TITLE
feat: 增加基于 IP 的武器皮肤进度系统

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ pixel-strike/
 - 无限 FFA，无回合、经济和购买阶段；3 秒自动复活，2 秒出生保护（开火即解除）。
 - 自由选择一把主武器和一把副武器；1/2/3 切换主武器、副武器、刀。
 - Glock、Deagle、MP5-SD、AK-47、M4A4、AWP、刀和一枚 HE。
+- 真人玩家按服务端解析出的客户端 IP 绑定进度账号；每把枪分别累计击杀，100 杀解锁黄金皮肤、500 杀解锁钻石皮肤。
+- 进入游戏时可为主、副武器选择默认、黄金、钻石或随机已解锁皮肤；随机武器会先抽枪，再抽取该枪已解锁的皮肤。
 - 弹匣、备弹、换弹、护甲穿透、动态准星、同步弹道、移动/落地散布、蹲伏精度、后坐力、跳跃、爆头与刀背刺。
 - AK-47 与 Deagle 奖励精准爆头；AWP 开镜需 180 ms 稳定，远近枪声、爆炸和脚步按距离与方向播放。
 - 服务端 60 Hz 权威模拟，最多 200 ms 延迟补偿。
@@ -158,12 +160,12 @@ Compose 默认强制后台 Cookie 使用 HTTPS，并将 `TRUSTED_PROXY_CIDRS` �
 
 Compose 已限制服务端 512 MB、静态前端 128 MB，总上限 640 MB。
 
-## 协议 v4 摘要
+## 协议 v6 摘要
 
 所有多字节字段均为 Little-Endian。
 
-- 客户端：Join `01`、Input `02`、Fire `03`、Reload `04`、Grenade `06`、SetBots `07`、Switch `08`、Loadout `09`、RosterRequest `0A`、Ping `F0`。
+- 客户端：Join `01`、Input `02`、Fire `03`、Reload `04`、Grenade `06`、SetBots `07`、Switch `08`、Loadout `09`、RosterRequest `0A`、Ping `F0`。Join 与 Loadout 均携带主、副武器皮肤选择，服务端按解锁进度校验。
 - 服务端：Welcome `81`、Snapshot `82`、Events `83`、Pong `84`、Self `86`、Roster `87`、Reject `88`。
-- Snapshot：`tick(u32) + inputAck(u16) + count(u8)`，玩家记录由 `id(u16) + fieldMask(u16)` 开始；`0x8000` 表示完整关键帧。
+- Snapshot：`tick(u32) + inputAck(u16) + count(u8)`，玩家记录由 `id(u16) + fieldMask(u16)` 开始；`0x8000` 表示完整关键帧，状态包含角色皮肤和当前枪械皮肤。
 
 主要实现位置：`server/netstate.go`（带宽）、`server/sim.go`（权威玩法）、`server/room.go`（60 Hz 房间）、`client/src/net.ts`（协议）、`client/src/player.ts`（预测与实例化角色）、`tools/bots.mjs`（压测）。

--- a/client/index.html
+++ b/client/index.html
@@ -1177,6 +1177,21 @@
                     <option value="1">DESERT EAGLE 沙漠之鹰</option>
                   </select>
                 </div>
+				<div class="field">
+				  <label for="primary-weapon-skin">主武器皮肤 / FINISH</label>
+				  <select class="control" id="primary-weapon-skin">
+					<option value="3">随机已解锁皮肤</option><option value="0">默认</option>
+					<option value="1">黄金（100 杀敌）</option><option value="2">钻石（500 杀敌）</option>
+				  </select>
+				</div>
+				<div class="field">
+				  <label for="secondary-weapon-skin">副武器皮肤 / FINISH</label>
+				  <select class="control" id="secondary-weapon-skin">
+					<option value="3">随机已解锁皮肤</option><option value="0">默认</option>
+					<option value="1">黄金（100 杀敌）</option><option value="2">钻石（500 杀敌）</option>
+				  </select>
+				</div>
+				<div class="field full"><small id="weapon-skin-progress">正在读取当前 IP 的武器击杀进度…</small></div>
               </div>
 
               <div class="loadout-brief" id="weapon-spec-box">

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 5;
+export const PROTOCOL_VERSION = 6;
 
 export const OP = {
   Join: 0x01,
@@ -51,6 +51,7 @@ export interface PlayerSnap {
   weapon: number;
   shot: number;
   skin: number;
+  weaponSkin: number;
 }
 
 export interface RosterEntry {

--- a/client/src/hud.ts
+++ b/client/src/hud.ts
@@ -79,7 +79,7 @@ export class Hud {
   private loadoutPrimary = -1;
   private loadoutSecondary = -1;
   characterPreview: CharacterPreview | null = null;
-  onJoin: ((name: string, primary: number, secondary: number, skin: number) => void) | null = null;
+  onJoin: ((name: string, primary: number, secondary: number, skin: number, primaryWeaponSkin: number, secondaryWeaponSkin: number) => void) | null = null;
   onVolumeChange: ((v: number) => void) | null = null;
   onFovChange: ((fov: number) => void) | null = null;
   onQualityChange: ((q: 'low' | 'medium' | 'high') => void) | null = null;
@@ -127,6 +127,26 @@ export class Hud {
     const name = el('name-input') as HTMLInputElement;
     const primary = el('primary-select') as HTMLSelectElement;
     const secondary = el('secondary-select') as HTMLSelectElement;
+	const primaryWeaponSkin = el('primary-weapon-skin') as HTMLSelectElement;
+	const secondaryWeaponSkin = el('secondary-weapon-skin') as HTMLSelectElement;
+	const weaponKills = new Map<number, number>();
+	const refreshSkinOptions = (weaponSelect: HTMLSelectElement, skinSelect: HTMLSelectElement) => {
+		const weapon = +weaponSelect.value;
+		const kills = weaponKills.get(weapon) ?? 0;
+		for (const option of [...skinSelect.options]) {
+			if (option.value === '1') option.disabled = weapon >= 0 && kills < 100;
+			if (option.value === '2') option.disabled = weapon >= 0 && kills < 500;
+		}
+		if (skinSelect.selectedOptions[0]?.disabled) skinSelect.value = '3';
+	};
+	void fetch('/api/progression', { cache: 'no-store' }).then((response) => response.ok ? response.json() : Promise.reject()).then((data: { weapons?: { weapon: number; kills: number }[] }) => {
+		for (const row of data.weapons ?? []) weaponKills.set(row.weapon, row.kills);
+		const progress = el('weapon-skin-progress');
+		const selected = +primary.value;
+		progress.textContent = selected < 0 ? '随机武器会先抽取枪械，再从该枪已解锁的皮肤中随机。' : `${WEAPONS[selected].name}：${weaponKills.get(selected) ?? 0} 杀敌 · 黄金 100 / 钻石 500`;
+		refreshSkinOptions(primary, primaryWeaponSkin);
+		refreshSkinOptions(secondary, secondaryWeaponSkin);
+	}).catch(() => { el('weapon-skin-progress').textContent = '进度暂时无法读取，服务器仍会校验已解锁皮肤。'; });
     // Restore username and loadout.
     const savedName = localStorage.getItem('pixel_strike_name') || getCookie('ps_name');
     if (savedName && name) {
@@ -186,12 +206,16 @@ export class Hud {
         this.loadoutPrimary = +primary.value;
         updateWeaponSpecs(this.loadoutPrimary);
         this.onLoadoutChange?.(this.loadoutPrimary, this.loadoutSecondary);
+		refreshSkinOptions(primary, primaryWeaponSkin);
+		const progress = el('weapon-skin-progress');
+		progress.textContent = this.loadoutPrimary < 0 ? '随机武器会先抽取枪械，再从该枪已解锁的皮肤中随机。' : `${WEAPONS[this.loadoutPrimary].name}：${weaponKills.get(this.loadoutPrimary) ?? 0} 杀敌 · 黄金 100 / 钻石 500`;
       });
     }
     secondary?.addEventListener('change', () => {
       localStorage.setItem('pixel_strike_secondary', secondary.value);
       this.loadoutSecondary = +secondary.value;
       this.onLoadoutChange?.(this.loadoutPrimary, this.loadoutSecondary);
+		refreshSkinOptions(secondary, secondaryWeaponSkin);
       if (+primary.value === -1 && +secondary.value !== -1) {
         this.characterPreview?.setWeapon(+secondary.value);
       }
@@ -263,7 +287,7 @@ export class Hud {
               this.characterPreview?.setVisible(false);
               this.root.style.display = 'block';
               deploying = false;
-              this.onJoin?.(n, this.loadoutPrimary, this.loadoutSecondary, this.characterPreview?.getSkin() ?? 0);
+              this.onJoin?.(n, this.loadoutPrimary, this.loadoutSecondary, this.characterPreview?.getSkin() ?? 0, +primaryWeaponSkin.value, +secondaryWeaponSkin.value);
             }, 140);
           }
         }, 32);
@@ -271,7 +295,7 @@ export class Hud {
         this.menu.style.display = 'none';
         this.characterPreview?.setVisible(false);
         this.root.style.display = 'block';
-        this.onJoin?.(n, this.loadoutPrimary, this.loadoutSecondary, this.characterPreview?.getSkin() ?? 0);
+        this.onJoin?.(n, this.loadoutPrimary, this.loadoutSecondary, this.characterPreview?.getSkin() ?? 0, +primaryWeaponSkin.value, +secondaryWeaponSkin.value);
       }
     };
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -88,6 +88,8 @@ let lastWeaponSlot = 1;
 let grenadePrimed = false;
 let userPrimaryChoice = -1;
 let userSecondaryChoice = -1;
+let userPrimaryWeaponSkin = 3;
+let userSecondaryWeaponSkin = 3;
 const PRIMARY_IDS = [3, 4, 2, 5, 8, 9, 10, 11, 12];
 const SECONDARY_IDS = [0, 1, 7];
 
@@ -99,6 +101,8 @@ function resolveLoadout(p: number, s: number): { primary: number; secondary: num
 
 let primaryWeapon = 3;
 let secondaryWeapon = 0;
+let primaryWeaponSkin = 0;
+let secondaryWeaponSkin = 0;
 const slotMags = [0, WEAPONS[3].mag, WEAPONS[0].mag, 0];
 const slotReserves = [0, WEAPONS[3].reserve, WEAPONS[0].reserve, 0];
 let cameraStepOffset = 0;
@@ -294,7 +298,8 @@ function selectSlot(slot: number) {
   weapons.cancelReload();
   if (slot !== reloadPendingSlot) reloadPendingSlot = 0;
   const weapon = slot === 1 ? primaryWeapon : slot === 2 ? secondaryWeapon : 6;
-  if (weapon !== weapons.weaponId) weapons.build(weapon);
+	const weaponSkin = slot === 1 ? primaryWeaponSkin : slot === 2 ? secondaryWeaponSkin : 0;
+	if (weapon !== weapons.weaponId || weaponSkin !== weapons.weaponSkin) weapons.build(weapon, weaponSkin);
   local.weaponId = weapon;
   mag = slot <= 2 ? slotMags[slot] : 0;
   reserve = slot <= 2 ? slotReserves[slot] : 0;
@@ -507,11 +512,13 @@ hud.onPauseClick(() => {
   if (joined && !hud.isSettingsOpen()) void captureGame();
 });
 
-hud.onJoin = (name, primary, secondary, skin) => {
+hud.onJoin = (name, primary, secondary, skin, primarySkin, secondarySkin) => {
   myName = name;
   killStreak = 0;
   userPrimaryChoice = primary;
   userSecondaryChoice = secondary;
+	userPrimaryWeaponSkin = primarySkin;
+	userSecondaryWeaponSkin = secondarySkin;
   const resolved = resolveLoadout(primary, secondary);
   primaryWeapon = resolved.primary;
   secondaryWeapon = resolved.secondary;
@@ -526,7 +533,7 @@ hud.onJoin = (name, primary, secondary, skin) => {
   weapons.group.visible = true;
   refreshWeaponHud();
   guardMatchHistory();
-  net.connect(wsUrl, name, primaryWeapon, secondaryWeapon, skin);
+  net.connect(wsUrl, name, primaryWeapon, secondaryWeapon, skin, primarySkin, secondarySkin);
   void captureGame(); // Fullscreen and pointer lock
   audio.init();
 };
@@ -535,7 +542,7 @@ hud.onLoadoutChange = (p, s) => {
   userPrimaryChoice = p;
   userSecondaryChoice = s;
   const next = resolveLoadout(p, s);
-  net.setLoadout(next.primary, next.secondary);
+  net.setLoadout(next.primary, next.secondary, userPrimaryWeaponSkin, userSecondaryWeaponSkin);
 };
 hud.onExit = () => {
   joined = false;
@@ -636,6 +643,8 @@ net.onSelf = (s) => {
   nades = s.nades;
   if (s.slot === 1) primaryWeapon = s.weapon;
   else if (s.slot === 2) secondaryWeapon = s.weapon;
+	if (s.slot === 1) primaryWeaponSkin = s.weaponSkin;
+	else if (s.slot === 2) secondaryWeaponSkin = s.weaponSkin;
   if (s.slot === 1 || s.slot === 2) {
     slotMags[s.slot] = s.mag;
     slotReserves[s.slot] = s.reserve;
@@ -647,9 +656,9 @@ net.onSelf = (s) => {
   }
   mag = s.mag;
   reserve = s.reserve;
-  if (s.weapon !== weapons.weaponId) {
+  if (s.weapon !== weapons.weaponId || s.weaponSkin !== weapons.weaponSkin) {
     weapons.cancelReload();
-    weapons.build(s.weapon);
+    weapons.build(s.weapon, s.weaponSkin);
     local.weaponId = s.weapon;
     stopAiming();
   }
@@ -704,7 +713,7 @@ function handleEvent(e: GameEvent) {
       const next = resolveLoadout(userPrimaryChoice, userSecondaryChoice);
       primaryWeapon = next.primary;
       secondaryWeapon = next.secondary;
-      net.setLoadout(next.primary, next.secondary);
+      net.setLoadout(next.primary, next.secondary, userPrimaryWeaponSkin, userSecondaryWeaponSkin);
     }
     return;
   }

--- a/client/src/net.ts
+++ b/client/src/net.ts
@@ -1,7 +1,7 @@
 import { OP, PROTOCOL_VERSION, type PlayerSnap, type RosterEntry } from './constants.js';
 
 export interface GameEvent { type:number; killer?:number; victim?:number; player?:number; weapon?:number; headshot?:number; origin?:[number,number,number]; dir?:[number,number,number]; name?:string; pickup?:number; kind?:number; ms?:number }
-export interface SelfState { ack:number; slot:number; weapon:number; mag:number; reserve:number; nades:number }
+export interface SelfState { ack:number; slot:number; weapon:number; weaponSkin:number; mag:number; reserve:number; nades:number }
 
 export class Net {
   ws!:WebSocket; yourId=0; connected=false; lastServerTick=0;
@@ -12,9 +12,9 @@ export class Net {
   onSelf:((state:SelfState)=>void)|null=null;
   onLatency:((ms:number,outboundBps:number)=>void)|null=null;
   onDisconnect:((upgrading:boolean)=>void)|null=null; onReject:((reason:string)=>void)|null=null; onMaintenance:((retryAfter:number)=>void)|null=null;
-  private name=''; private primary=3; private secondary=0; private skin=0; private url=''; private retry=0; private closedByUser=false; private heartbeat=0; private lastPing=0; private maintenanceUntil=0; private states=new Map<number,PlayerSnap>(); private input=new Uint8Array(12); private inputView=new DataView(this.input.buffer);
+  private name=''; private primary=3; private secondary=0; private skin=0; private primaryWeaponSkin=0; private secondaryWeaponSkin=0; private url=''; private retry=0; private closedByUser=false; private heartbeat=0; private lastPing=0; private maintenanceUntil=0; private states=new Map<number,PlayerSnap>(); private input=new Uint8Array(12); private inputView=new DataView(this.input.buffer);
 
-  connect(url:string,name:string,primary:number,secondary:number,skin:number){ this.disconnect();this.url=url;this.name=name;this.primary=primary;this.secondary=secondary;this.skin=skin;this.closedByUser=false;this.open();this.heartbeat=window.setInterval(()=>{if(this.connected){this.lastPing=performance.now();this.raw(new Uint8Array([OP.Ping]))}},5000) }
+  connect(url:string,name:string,primary:number,secondary:number,skin:number,primaryWeaponSkin:number,secondaryWeaponSkin:number){ this.disconnect();this.url=url;this.name=name;this.primary=primary;this.secondary=secondary;this.skin=skin;this.primaryWeaponSkin=primaryWeaponSkin;this.secondaryWeaponSkin=secondaryWeaponSkin;this.closedByUser=false;this.open();this.heartbeat=window.setInterval(()=>{if(this.connected){this.lastPing=performance.now();this.raw(new Uint8Array([OP.Ping]))}},5000) }
   private open() {
     const ws = new WebSocket(this.url);
     this.ws = ws;
@@ -24,7 +24,7 @@ export class Net {
       this.states.clear();
       const nb = new TextEncoder().encode([...this.name].slice(0, 16).join(''));
       const fp = new TextEncoder().encode(fingerprint());
-      const b = new Uint8Array(6 + nb.length + fp.length);
+      const b = new Uint8Array(8 + nb.length + fp.length);
       b[0] = OP.Join;
       b[1] = PROTOCOL_VERSION;
       b[2] = nb.length;
@@ -32,7 +32,9 @@ export class Net {
       b[3 + nb.length] = this.primary;
       b[4 + nb.length] = this.secondary;
       b[5 + nb.length] = this.skin;
-      b.set(fp, 6 + nb.length);
+      b[6 + nb.length] = this.primaryWeaponSkin;
+      b[7 + nb.length] = this.secondaryWeaponSkin;
+      b.set(fp, 8 + nb.length);
       ws.send(b);
     };
     ws.onmessage = (e) => {
@@ -66,14 +68,14 @@ export class Net {
     if (op === OP.Reject) { const n=v.getUint8(1),reason=new TextDecoder().decode(new Uint8Array(v.buffer,v.byteOffset+2,n));this.closedByUser=true;this.onReject?.(reason);this.ws.close();return; }
     if (op === OP.Snapshot) { this.decodeSnapshot(v); return; }
     if (op === OP.Events) { this.decodeEvents(v); return; }
-    if (op === OP.Self) { this.onSelf?.({ack:v.getUint16(1,true),slot:v.getUint8(3),weapon:v.getUint8(4),mag:v.getUint8(5),reserve:v.getUint16(6,true),nades:v.getUint8(8)}); return; }
+    if (op === OP.Self) { this.onSelf?.({ack:v.getUint16(1,true),slot:v.getUint8(3),weapon:v.getUint8(4),weaponSkin:v.getUint8(5),mag:v.getUint8(6),reserve:v.getUint16(7,true),nades:v.getUint8(9)}); return; }
     if (op === OP.Roster) {
       let o=2; const rows:RosterEntry[]=[];
       for(let i=0,n=v.getUint8(1);i<n;i++){const id=v.getUint16(o,true),kills=v.getUint16(o+2,true),deaths=v.getUint16(o+4,true),len=v.getUint8(o+6);o+=7;const name=new TextDecoder().decode(new Uint8Array(v.buffer,v.byteOffset+o,len));o+=len;rows.push({id,name,kills,deaths})}
       this.onRoster?.(rows);
     }
   }
-  private decodeSnapshot(v:DataView){const tick=v.getUint32(1,true),ack=v.getUint16(5,true),n=v.getUint8(7);this.lastServerTick=tick;let o=8;const updated:PlayerSnap[]=[];for(let i=0;i<n;i++){const id=v.getUint16(o,true),mask=v.getUint16(o+2,true);o+=4;let s=this.states.get(id);if(mask===0x8000){s={id,x:v.getInt16(o,true)/100,y:v.getInt16(o+2,true)/100,z:v.getInt16(o+4,true)/100,yaw:half(v.getInt16(o+6,true)),pitch:half(v.getInt16(o+8,true)),vx:v.getInt8(o+10)/10,vz:v.getInt8(o+11)/10,hp:v.getUint8(o+12),armor:v.getUint8(o+13),state:v.getUint8(o+14),weapon:v.getUint8(o+15),shot:v.getUint8(o+16),skin:v.getUint8(o+17)};o+=18}else{if(!s)throw new Error(`delta without baseline ${id}`);if(mask&1){s.x+=v.getInt8(o++)/100;s.y+=v.getInt8(o++)/100;s.z+=v.getInt8(o++)/100}else if(mask&2){s.x=v.getInt16(o,true)/100;s.y=v.getInt16(o+2,true)/100;s.z=v.getInt16(o+4,true)/100;o+=6}if(mask&4){s.yaw=wrap(s.yaw+half(v.getInt8(o++)));s.pitch+=half(v.getInt8(o++))}else if(mask&8){s.yaw=half(v.getInt16(o,true));s.pitch=half(v.getInt16(o+2,true));o+=4}if(mask&16){s.vx=v.getInt8(o++)/10;s.vz=v.getInt8(o++)/10}if(mask&32){s.hp=v.getUint8(o++);s.armor=v.getUint8(o++)}if(mask&64)s.state=v.getUint8(o++);if(mask&128)s.weapon=v.getUint8(o++);if(mask&256)s.shot=v.getUint8(o++);if(mask&512)s.skin=v.getUint8(o++)}this.states.set(id,s);updated.push(s)}this.onSnapshot(tick,ack,updated)}
+  private decodeSnapshot(v:DataView){const tick=v.getUint32(1,true),ack=v.getUint16(5,true),n=v.getUint8(7);this.lastServerTick=tick;let o=8;const updated:PlayerSnap[]=[];for(let i=0;i<n;i++){const id=v.getUint16(o,true),mask=v.getUint16(o+2,true);o+=4;let s=this.states.get(id);if(mask===0x8000){s={id,x:v.getInt16(o,true)/100,y:v.getInt16(o+2,true)/100,z:v.getInt16(o+4,true)/100,yaw:half(v.getInt16(o+6,true)),pitch:half(v.getInt16(o+8,true)),vx:v.getInt8(o+10)/10,vz:v.getInt8(o+11)/10,hp:v.getUint8(o+12),armor:v.getUint8(o+13),state:v.getUint8(o+14),weapon:v.getUint8(o+15),shot:v.getUint8(o+16),skin:v.getUint8(o+17),weaponSkin:v.getUint8(o+18)};o+=19}else{if(!s)throw new Error(`delta without baseline ${id}`);if(mask&1){s.x+=v.getInt8(o++)/100;s.y+=v.getInt8(o++)/100;s.z+=v.getInt8(o++)/100}else if(mask&2){s.x=v.getInt16(o,true)/100;s.y=v.getInt16(o+2,true)/100;s.z=v.getInt16(o+4,true)/100;o+=6}if(mask&4){s.yaw=wrap(s.yaw+half(v.getInt8(o++)));s.pitch+=half(v.getInt8(o++))}else if(mask&8){s.yaw=half(v.getInt16(o,true));s.pitch=half(v.getInt16(o+2,true));o+=4}if(mask&16){s.vx=v.getInt8(o++)/10;s.vz=v.getInt8(o++)/10}if(mask&32){s.hp=v.getUint8(o++);s.armor=v.getUint8(o++)}if(mask&64)s.state=v.getUint8(o++);if(mask&128)s.weapon=v.getUint8(o++);if(mask&256)s.shot=v.getUint8(o++);if(mask&512)s.skin=v.getUint8(o++);if(mask&1024)s.weaponSkin=v.getUint8(o++)}this.states.set(id,s);updated.push(s)}this.onSnapshot(tick,ack,updated)}
   private decodeEvents(v: DataView) {
     const rows: GameEvent[] = [];
     let o = 2;
@@ -114,7 +116,7 @@ export class Net {
   }
   sendInput(seq:number,keys:number,yaw:number,pitch:number){const b=this.input,v=this.inputView;b[0]=OP.Input;v.setUint16(1,seq,true);b[3]=keys;v.setFloat32(4,yaw,true);v.setFloat32(8,pitch,true);this.raw(b)}
   sendFire(seq:number,tick:number,mode:number,yaw:number,pitch:number){const b=new Uint8Array(16),v=new DataView(b.buffer);b[0]=OP.Fire;v.setUint16(1,seq,true);v.setUint32(3,tick,true);b[7]=mode;v.setFloat32(8,yaw,true);v.setFloat32(12,pitch,true);this.raw(b)}
-  sendReload(){this.raw(new Uint8Array([OP.Reload]))} switchSlot(slot:number){this.raw(new Uint8Array([OP.Switch,slot]))} setLoadout(primary:number,secondary:number){this.raw(new Uint8Array([OP.Loadout,primary,secondary]))} requestRoster(){this.raw(new Uint8Array([OP.RosterRequest]))}
+  sendReload(){this.raw(new Uint8Array([OP.Reload]))} switchSlot(slot:number){this.raw(new Uint8Array([OP.Switch,slot]))} setLoadout(primary:number,secondary:number,primaryWeaponSkin:number,secondaryWeaponSkin:number){this.raw(new Uint8Array([OP.Loadout,primary,secondary,primaryWeaponSkin,secondaryWeaponSkin]))} requestRoster(){this.raw(new Uint8Array([OP.RosterRequest]))}
   sendGrenade(yaw:number,pitch:number){const b=new Uint8Array(9),v=new DataView(b.buffer);b[0]=OP.Grenade;v.setFloat32(1,yaw,true);v.setFloat32(5,pitch,true);this.raw(b)}
   forget(id:number){this.states.delete(id)}
   disconnect(){this.closedByUser=true;if(this.heartbeat){clearInterval(this.heartbeat);this.heartbeat=0}const ws=this.ws;if(ws){ws.onopen=null;ws.onmessage=null;ws.onclose=null;if(ws.readyState<2)ws.close()}this.connected=false;this.states.clear()}

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -486,7 +486,12 @@ export class RemotePlayers {
         for (const layer of this.skinLayers) layer.setColorAt(model.index, bodyColor);
         uniformColorsDirty = true;
       }
-      const wantedGunColor = WEAPONS[state.weapon]?.color ?? 0x222225;
+      const baseGunColor = WEAPONS[state.weapon]?.color ?? 0x222225;
+		const wantedGunColor = state.weaponSkin === 1
+			? gunColor.setHex(baseGunColor).lerp(new THREE.Color(0xffc928), 0.78).getHex()
+			: state.weaponSkin === 2
+				? gunColor.setHex(baseGunColor).lerp(new THREE.Color(0x72e7ff), 0.7).getHex()
+				: baseGunColor;
       if (wantedGunColor !== model.gunColor) {
         model.gunColor = wantedGunColor;
         this.gun.setColorAt(model.index, gunColor.setHex(wantedGunColor));

--- a/client/src/viewmodels.ts
+++ b/client/src/viewmodels.ts
@@ -9,6 +9,28 @@ export interface AssembledWeapon {
   muzzle: THREE.Vector3;
 }
 
+export type WeaponSkin = 0 | 1 | 2;
+
+export function applyWeaponSkin(root: THREE.Object3D, skin: number) {
+	if (skin !== 1 && skin !== 2) return;
+	const tint = new THREE.Color(skin === 1 ? 0xffc928 : 0x72e7ff);
+	root.traverse((object) => {
+		if (!(object instanceof THREE.Mesh)) return;
+		const materials = Array.isArray(object.material) ? object.material : [object.material];
+		const skinned = materials.map((source) => {
+			const material = source.clone();
+			if (material instanceof THREE.MeshLambertMaterial || material instanceof THREE.MeshBasicMaterial) {
+				material.color.lerp(tint, skin === 1 ? 0.72 : 0.62);
+				if (material instanceof THREE.MeshLambertMaterial) {
+					material.emissive.copy(tint).multiplyScalar(skin === 1 ? 0.08 : 0.16);
+				}
+			}
+			return material;
+		});
+		object.material = Array.isArray(object.material) ? skinned : skinned[0];
+	});
+}
+
 export interface Mats {
   dark: THREE.MeshLambertMaterial;
   gun: THREE.MeshLambertMaterial;

--- a/client/src/weapons.ts
+++ b/client/src/weapons.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { WEAPONS, isPistol, isSniper } from './constants.js';
 import type { SfxName } from './audio.js';
-import { assembleViewWeapon, markViewLayer, VIEWMODEL_LAYER } from './viewmodels.js';
+import { applyWeaponSkin, assembleViewWeapon, markViewLayer, VIEWMODEL_LAYER } from './viewmodels.js';
 
 interface Shell {
   mesh: THREE.Mesh;
@@ -122,6 +122,7 @@ export class Weapons {
   reloadStartedAt = 0;
   reloadingUntil = 0;
   weaponId = 3;
+  weaponSkin = 0;
 
   // Idle breath & sway
   swayX = 0;
@@ -179,8 +180,9 @@ export class Weapons {
     this.build(3);
   }
 
-  build(id: number) {
+  build(id: number, skin = this.weaponSkin) {
     this.weaponId = id;
+    this.weaponSkin = skin;
     this.drawProgress = 0;
     this.slashProgress = 0;
     this.boltCycleStartedAt = 0;
@@ -213,6 +215,7 @@ export class Weapons {
     this.handRGroup.rotation.set(0, 0, 0);
 
     const assembled = assembleViewWeapon(id, this.handLGroup, this.handRGroup);
+	applyWeaponSkin(assembled.root, skin);
     this.magazineMesh = assembled.magazine;
     this.boltMesh = assembled.bolt;
     this.muzzleLight.position.copy(assembled.muzzle);

--- a/server/hub.go
+++ b/server/hub.go
@@ -76,13 +76,13 @@ func (h *Hub) OnlineSnapshot() []AdminPlayer {
 	return players
 }
 
-func (h *Hub) JoinIfAllowed(p *Player, name string, primary, secondary, skin uint8) bool {
+func (h *Hub) JoinIfAllowed(p *Player, name string, primary, secondary, skin, primaryWeaponSkin, secondaryWeaponSkin uint8) bool {
 	h.banMu.RLock()
 	defer h.banMu.RUnlock()
 	if h.Store.IsIPBanned(p.IP) {
 		return false
 	}
-	h.Join(p, name, primary, secondary, skin)
+	h.Join(p, name, primary, secondary, skin, primaryWeaponSkin, secondaryWeaponSkin)
 	return true
 }
 
@@ -138,7 +138,7 @@ func (h *Hub) SetBotCount(count int) (int, int) {
 	return count, active
 }
 
-func (h *Hub) Join(p *Player, name string, primary, secondary, skin uint8) {
+func (h *Hub) Join(p *Player, name string, primary, secondary, skin, primaryWeaponSkin, secondaryWeaponSkin uint8) {
 	h.mu.Lock()
 	var room *Room
 	for _, candidate := range h.rooms {
@@ -174,6 +174,8 @@ func (h *Hub) Join(p *Player, name string, primary, secondary, skin uint8) {
 	}
 	p.Id = room.allocPlayerID()
 	p.Name = name
+	p.PrimaryWeaponSkin = h.Store.UnlockedWeaponSkin(name, primary, primaryWeaponSkin)
+	p.SecondaryWeaponSkin = h.Store.UnlockedWeaponSkin(name, secondary, secondaryWeaponSkin)
 	p.joined = true
 	p.Room = room
 	p.ApplyLoadout(primary, secondary)

--- a/server/main.go
+++ b/server/main.go
@@ -77,6 +77,25 @@ func main() {
 		}
 		json.NewEncoder(w).Encode(rows)
 	})
+	mux.HandleFunc("/api/progression", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		ip := trustedProxies.ClientIP(r)
+		if ip == "" {
+			http.Error(w, `{"error":"invalid client address"}`, http.StatusBadRequest)
+			return
+		}
+		progress, err := store.WeaponProgressForIP(ip)
+		if err != nil {
+			http.Error(w, `{"error":"db"}`, http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"weapons":      progress,
+			"goldKills":    GoldKillRequirement,
+			"diamondKills": DiamondKillRequirement,
+		})
+	})
 	mux.HandleFunc("/api/stats", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(runtimeStats(hub, store))

--- a/server/netstate.go
+++ b/server/netstate.go
@@ -5,10 +5,10 @@ import "math"
 const maxSnapshotBytes = 2300 // ~69 KB/s at 30 Hz, before small event traffic.
 
 type quantState struct {
-	x, y, z                              int16
-	yaw, pitch                           int16 // half-degrees
-	vx, vz                               int8  // decimetres/second
-	hp, armor, state, weapon, shot, skin uint8
+	x, y, z                                          int16
+	yaw, pitch                                       int16 // half-degrees
+	vx, vz                                           int8  // decimetres/second
+	hp, armor, state, weapon, shot, skin, weaponSkin uint8
 }
 
 func quantizeState(p *PlayerState, nowUnixNano int64) quantState {
@@ -32,7 +32,7 @@ func quantizeState(p *PlayerState, nowUnixNano int64) quantState {
 		x: q16(p.Pos.X * 100), y: q16(p.Pos.Y * 100), z: q16(p.Pos.Z * 100),
 		yaw: angleHalfDeg(p.Yaw), pitch: angleHalfDeg(p.Pitch),
 		vx: q8(p.Vel.X * 10), vz: q8(p.Vel.Z * 10),
-		hp: p.HP, armor: p.Armor, state: state, weapon: p.Weapon, shot: uint8(p.LastShotSeq), skin: p.Skin,
+		hp: p.HP, armor: p.Armor, state: state, weapon: p.Weapon, shot: uint8(p.LastShotSeq), skin: p.Skin, weaponSkin: p.WeaponSkin,
 	}
 }
 
@@ -182,6 +182,9 @@ func appendStateDelta(w *Buf, id uint16, prev, cur quantState, full bool) bool {
 		if cur.skin != prev.skin {
 			flag |= 1 << 9
 		}
+		if cur.weaponSkin != prev.weaponSkin {
+			flag |= 1 << 10
+		}
 	}
 	if full || flag == 0 && (cur.x != prev.x || cur.y != prev.y || cur.z != prev.z || cur.yaw != prev.yaw || cur.pitch != prev.pitch) {
 		flag = 1 << 15
@@ -238,6 +241,9 @@ func appendStateDelta(w *Buf, id uint16, prev, cur quantState, full bool) bool {
 	if flag&(1<<9) != 0 {
 		w.U8(cur.skin)
 	}
+	if flag&(1<<10) != 0 {
+		w.U8(cur.weaponSkin)
+	}
 	if len(w.b) > maxSnapshotBytes {
 		w.b = w.b[:start]
 		return false
@@ -259,6 +265,7 @@ func writeFullState(w *Buf, s quantState) {
 	w.U8(s.weapon)
 	w.U8(s.shot)
 	w.U8(s.skin)
+	w.U8(s.weaponSkin)
 }
 
 func inI8(v int) bool { return v >= -128 && v <= 127 }

--- a/server/player.go
+++ b/server/player.go
@@ -191,7 +191,7 @@ func (p *Player) readPump(hub *Hub) {
 		}
 		switch op {
 		case OpJoin:
-			if p.joined || len(payload) < 5 {
+			if p.joined || len(payload) < 7 {
 				return
 			}
 			if hub.Store.IsIPBanned(p.IP) {
@@ -210,20 +210,21 @@ func (p *Player) readPump(hub *Hub) {
 			}
 			name := sanitizeName(string(payload[2 : 2+n]))
 			primary, secondary, skin := payload[2+n], payload[3+n], payload[4+n]
+			primaryWeaponSkin, secondaryWeaponSkin := payload[5+n], payload[6+n]
 			if !validLoadout(primary, secondary) {
 				primary, secondary = 3, 0
 			}
 			if skin >= SkinCount {
 				skin = 0
 			}
-			if len(payload) > 5+n {
-				p.Fingerprint = sanitizeFingerprint(string(payload[5+n:]))
+			if len(payload) > 7+n {
+				p.Fingerprint = sanitizeFingerprint(string(payload[7+n:]))
 			}
 			if name == "" {
 				name = "player"
 			}
 			resolved := hub.Store.GetOrCreatePlayer(p.IP, p.Fingerprint, name)
-			if !hub.JoinIfAllowed(p, resolved, primary, secondary, skin) {
+			if !hub.JoinIfAllowed(p, resolved, primary, secondary, skin, primaryWeaponSkin, secondaryWeaponSkin) {
 				p.Send(Reject("访问已被封禁"))
 				time.Sleep(20 * time.Millisecond)
 				return
@@ -287,13 +288,15 @@ func (p *Player) readPump(hub *Hub) {
 				room.mu.Unlock()
 			}
 		case OpLoadout:
-			if len(payload) < 2 || !validLoadout(payload[0], payload[1]) {
+			if len(payload) < 4 || !validLoadout(payload[0], payload[1]) {
 				continue
 			}
 			if room := p.Room; room != nil {
 				room.mu.Lock()
 				if !p.Alive {
 					p.Primary, p.Secondary = payload[0], payload[1]
+					p.PrimaryWeaponSkin = hub.Store.UnlockedWeaponSkin(p.Name, payload[0], payload[2])
+					p.SecondaryWeaponSkin = hub.Store.UnlockedWeaponSkin(p.Name, payload[1], payload[3])
 				}
 				room.mu.Unlock()
 			}

--- a/server/proto.go
+++ b/server/proto.go
@@ -6,7 +6,7 @@ import (
 	"unicode/utf8"
 )
 
-const ProtocolVersion = 5
+const ProtocolVersion = 6
 const SkinCount uint8 = 8
 
 const (
@@ -95,14 +95,14 @@ func Maintenance(retryAfter uint8) []byte {
 }
 
 type compactSelfState struct {
-	slot, weapon, mag, nades uint8
-	reserve                  uint16
+	slot, weapon, weaponSkin, mag, nades uint8
+	reserve                              uint16
 }
 
 func compactSelf(p *PlayerState) compactSelfState {
 	mag, reserve := p.ActiveAmmo()
 	return compactSelfState{
-		slot: p.ActiveSlot, weapon: p.Weapon,
+		slot: p.ActiveSlot, weapon: p.Weapon, weaponSkin: p.WeaponSkin,
 		mag: uint8(max(0, min(mag, 255))), reserve: uint16(max(0, min(reserve, 65535))),
 		nades: uint8(max(0, min(p.Grenades, 255))),
 	}
@@ -114,6 +114,7 @@ func SelfState(p *PlayerState) []byte {
 	w.U16(p.LastInputSeq)
 	w.U8(state.slot)
 	w.U8(state.weapon)
+	w.U8(state.weaponSkin)
 	w.U8(state.mag)
 	w.U16(state.reserve)
 	w.U8(state.nades)

--- a/server/proto_test.go
+++ b/server/proto_test.go
@@ -9,17 +9,17 @@ import (
 	"unicode/utf8"
 )
 
-func TestWelcomeV5(t *testing.T) {
+func TestWelcomeV6(t *testing.T) {
 	b := Welcome(42, 0x12345678)
 	if len(b) != 8 || b[0] != OpWelcome || b[1] != ProtocolVersion || binary.LittleEndian.Uint16(b[2:]) != 42 {
 		t.Fatalf("bad welcome: %v", b)
 	}
 }
 func TestSnapshotCarriesSkin(t *testing.T) {
-	p := &Player{PlayerState: PlayerState{Id: 1, Alive: true, Skin: 7}}
+	p := &Player{PlayerState: PlayerState{Id: 1, Alive: true, Skin: 7, WeaponSkin: 2}}
 	state := quantizeState(&p.PlayerState, 0)
 	full := p.BuildSnapshot(0, []*Player{p}, []quantState{state})
-	if len(full) != 30 || full[7] != 1 || binary.LittleEndian.Uint16(full[10:]) != 0x8000 || full[29] != 7 {
+	if len(full) != 31 || full[7] != 1 || binary.LittleEndian.Uint16(full[10:]) != 0x8000 || full[29] != 7 || full[30] != 2 {
 		t.Fatalf("full skin snapshot = %v", full)
 	}
 
@@ -444,7 +444,7 @@ func TestSanitizeNameUTF8(t *testing.T) {
 	}
 }
 
-func TestFingerprintsDoNotMergePlayersBehindOneIP(t *testing.T) {
+func TestIPIsTheProgressionAccount(t *testing.T) {
 	s, err := NewStore(t.TempDir() + "/stats.db")
 	if err != nil {
 		t.Fatal(err)
@@ -452,8 +452,31 @@ func TestFingerprintsDoNotMergePlayersBehindOneIP(t *testing.T) {
 	defer s.Close()
 	a := s.GetOrCreatePlayer("203.0.113.10", "browser-a", "Alice")
 	b := s.GetOrCreatePlayer("203.0.113.10", "browser-b", "Bob")
-	if a != "Alice" || b != "Bob" {
-		t.Fatalf("shared IP merged distinct browsers: %q %q", a, b)
+	if a != "Alice" || b != "Alice" {
+		t.Fatalf("same IP did not resolve to one account: %q %q", a, b)
+	}
+}
+
+func TestWeaponSkinUnlocks(t *testing.T) {
+	s, err := NewStore(t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	name := s.GetOrCreatePlayer("203.0.113.11", "ignored", "Alice")
+	for range GoldKillRequirement {
+		s.AccumulateWeaponKill(name, 3)
+	}
+	s.Flush()
+	if got := s.UnlockedWeaponSkin(name, 3, 1); got != 1 {
+		t.Fatalf("gold skin = %d", got)
+	}
+	if got := s.UnlockedWeaponSkin(name, 3, 2); got != 0 {
+		t.Fatalf("diamond unlocked early = %d", got)
+	}
+	progress, err := s.WeaponProgress(name)
+	if err != nil || len(progress) != 1 || progress[0].Kills != GoldKillRequirement || !progress[0].Gold || progress[0].Diamond {
+		t.Fatalf("weapon progress = %#v, %v", progress, err)
 	}
 }
 

--- a/server/sim.go
+++ b/server/sim.go
@@ -84,6 +84,7 @@ type PlayerState struct {
 	HP, Armor                                                      uint8
 	Alive, IsBot, OnGround, Crouch                                 bool
 	Primary, Secondary, ActiveSlot, Weapon, Skin                   uint8
+	PrimaryWeaponSkin, SecondaryWeaponSkin, WeaponSkin             uint8
 	Mags                                                           [2]int
 	Reserves                                                       [2]int
 	CmdKeys                                                        uint8
@@ -136,6 +137,7 @@ func (p *PlayerState) ApplyLoadout(primary, secondary uint8) {
 	p.Mags = [2]int{Weapons[primary].Mag, Weapons[secondary].Mag}
 	p.Reserves = [2]int{Weapons[primary].Reserve, Weapons[secondary].Reserve}
 	p.ActiveSlot, p.Weapon, p.Grenades = 1, primary, 1
+	p.WeaponSkin = p.PrimaryWeaponSkin
 	p.Reloading = false
 }
 func (p *PlayerState) SwitchSlot(slot uint8) bool {
@@ -143,10 +145,13 @@ func (p *PlayerState) SwitchSlot(slot uint8) bool {
 	switch slot {
 	case 1:
 		weapon = p.Primary
+		p.WeaponSkin = p.PrimaryWeaponSkin
 	case 2:
 		weapon = p.Secondary
+		p.WeaponSkin = p.SecondaryWeaponSkin
 	case 3:
 		weapon = 6
+		p.WeaponSkin = 0
 	default:
 		return false
 	}
@@ -415,6 +420,9 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	victim.Deaths++
 	if !attacker.IsBot {
 		r.Store.Accumulate(attacker.Name, 1, 0)
+		if isGun(weapon) {
+			r.Store.AccumulateWeaponKill(attacker.Name, weapon)
+		}
 	}
 	if !victim.IsBot {
 		r.Store.Accumulate(victim.Name, 0, 1)

--- a/server/store.go
+++ b/server/store.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"log"
 	"math"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,9 +35,23 @@ type IPBan struct {
 }
 
 type delta struct {
-	name   string
-	kills  int
-	deaths int
+	name        string
+	kills       int
+	deaths      int
+	weapon      int
+	weaponKills int
+}
+
+const (
+	GoldKillRequirement    = 100
+	DiamondKillRequirement = 500
+)
+
+type WeaponProgress struct {
+	Weapon  uint8 `json:"weapon"`
+	Kills   int   `json:"kills"`
+	Gold    bool  `json:"gold"`
+	Diamond bool  `json:"diamond"`
 }
 
 func NewStore(path string) (*Store, error) {
@@ -59,6 +75,12 @@ func NewStore(path string) (*Store, error) {
 			ip TEXT PRIMARY KEY,
 			reason TEXT NOT NULL DEFAULT '',
 			created_at INTEGER NOT NULL)`,
+		`CREATE TABLE IF NOT EXISTS weapon_kills(
+			account TEXT NOT NULL,
+			weapon INTEGER NOT NULL,
+			kills INTEGER NOT NULL DEFAULT 0,
+			updated_at INTEGER NOT NULL,
+			PRIMARY KEY(account, weapon))`,
 	} {
 		if _, err := db.Exec(schema); err != nil {
 			return nil, err
@@ -151,6 +173,14 @@ func (s *Store) writer() {
 				log.Printf("store upsert: %v", err)
 				return
 			}
+			if d.weapon >= 0 && d.weaponKills > 0 {
+				if _, err := tx.Exec(`INSERT INTO weapon_kills(account,weapon,kills,updated_at) VALUES(?,?,?,strftime('%s','now'))
+					ON CONFLICT(account,weapon) DO UPDATE SET kills=kills+excluded.kills, updated_at=excluded.updated_at`, d.name, d.weapon, d.weaponKills); err != nil {
+					_ = tx.Rollback()
+					log.Printf("store weapon upsert: %v", err)
+					return
+				}
+			}
 		}
 		if err := tx.Commit(); err != nil {
 			log.Printf("store commit: %v", err)
@@ -163,21 +193,27 @@ func (s *Store) writer() {
 		case <-ticker.C:
 			flush()
 		case d := <-s.ch:
-			acc := batch[d.name]
+			key := d.name + "\x00" + strconv.Itoa(d.weapon)
+			acc := batch[key]
 			acc.name = d.name
 			acc.kills += d.kills
 			acc.deaths += d.deaths
-			batch[d.name] = acc
+			acc.weaponKills += d.weaponKills
+			acc.weapon = d.weapon
+			batch[key] = acc
 		case done := <-s.flushCh:
 			// Drain all pending deltas in channel before flushing
 			for {
 				select {
 				case d := <-s.ch:
-					acc := batch[d.name]
+					key := d.name + "\x00" + strconv.Itoa(d.weapon)
+					acc := batch[key]
 					acc.name = d.name
 					acc.kills += d.kills
 					acc.deaths += d.deaths
-					batch[d.name] = acc
+					acc.weaponKills += d.weaponKills
+					acc.weapon = d.weapon
+					batch[key] = acc
 				default:
 					goto drained
 				}
@@ -191,11 +227,14 @@ func (s *Store) writer() {
 			for {
 				select {
 				case d := <-s.ch:
-					acc := batch[d.name]
+					key := d.name + "\x00" + strconv.Itoa(d.weapon)
+					acc := batch[key]
 					acc.name = d.name
 					acc.kills += d.kills
 					acc.deaths += d.deaths
-					batch[d.name] = acc
+					acc.weaponKills += d.weaponKills
+					acc.weapon = d.weapon
+					batch[key] = acc
 				default:
 					flush()
 					close(done)
@@ -209,9 +248,17 @@ func (s *Store) writer() {
 // Accumulate queues a stat change; persisted on the next 30s tick.
 func (s *Store) Accumulate(name string, kills, deaths int) {
 	select {
-	case s.ch <- delta{name, kills, deaths}:
+	case s.ch <- delta{name: name, kills: kills, deaths: deaths, weapon: -1}:
 	default:
 		log.Printf("store queue full, dropping stats for %q", name)
+	}
+}
+
+func (s *Store) AccumulateWeaponKill(name string, weapon uint8) {
+	select {
+	case s.ch <- delta{name: name, weapon: int(weapon), weaponKills: 1}:
+	default:
+		log.Printf("store queue full, dropping weapon kill for %q", name)
 	}
 }
 
@@ -227,10 +274,7 @@ func (s *Store) Flush() {
 
 // Invalidate drops the cached account for a disconnecting player.
 func (s *Store) Invalidate(ip, fp string) {
-	key := fp
-	if key == "" {
-		key = ip
-	}
+	key := ip
 	if key == "" {
 		return
 	}
@@ -317,10 +361,10 @@ func (s *Store) ListIPBans() []IPBan {
 }
 
 func (s *Store) GetOrCreatePlayer(ip, fp, name string) string {
-	key := fp
-	if key == "" {
-		key = ip
-	}
+	// The experiment intentionally treats the public client IP as the account.
+	// Fingerprints are retained only for backwards-compatible schema data and
+	// never split one IP into multiple progression accounts.
+	key := ip
 	if key != "" {
 		s.cacheMu.RLock()
 		cached, ok := s.cache[key]
@@ -331,11 +375,7 @@ func (s *Store) GetOrCreatePlayer(ip, fp, name string) string {
 
 		var existingName string
 		var err error
-		if fp != "" {
-			err = s.db.QueryRow(`SELECT name FROM stats WHERE fingerprint = ? LIMIT 1`, fp).Scan(&existingName)
-		} else {
-			err = s.db.QueryRow(`SELECT name FROM stats WHERE ip != '' AND ip = ? LIMIT 1`, ip).Scan(&existingName)
-		}
+		err = s.db.QueryRow(`SELECT name FROM stats WHERE ip != '' AND ip = ? ORDER BY updated_at DESC LIMIT 1`, ip).Scan(&existingName)
 		if err == nil && existingName != "" {
 			// Backfill whichever of ip/fingerprint was missing so both stay
 			// uniquely bound to this one account row.
@@ -363,6 +403,64 @@ func (s *Store) GetOrCreatePlayer(ip, fp, name string) string {
 		s.cacheMu.Unlock()
 	}
 	return resolved
+}
+
+func (s *Store) AccountForIP(ip string) (string, bool) {
+	var name string
+	err := s.db.QueryRow(`SELECT name FROM stats WHERE ip != '' AND ip=? ORDER BY updated_at DESC LIMIT 1`, ip).Scan(&name)
+	return name, err == nil && name != ""
+}
+
+func (s *Store) WeaponProgressForIP(ip string) ([]WeaponProgress, error) {
+	name, ok := s.AccountForIP(ip)
+	if !ok {
+		return []WeaponProgress{}, nil
+	}
+	return s.WeaponProgress(name)
+}
+
+func (s *Store) WeaponProgress(name string) ([]WeaponProgress, error) {
+	rows, err := s.db.Query(`SELECT weapon, kills FROM weapon_kills WHERE account=? ORDER BY weapon`, name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []WeaponProgress{}
+	for rows.Next() {
+		var p WeaponProgress
+		if err := rows.Scan(&p.Weapon, &p.Kills); err != nil {
+			return nil, err
+		}
+		p.Gold = p.Kills >= GoldKillRequirement
+		p.Diamond = p.Kills >= DiamondKillRequirement
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) UnlockedWeaponSkin(name string, weapon, requested uint8) uint8 {
+	if requested == 0 {
+		return 0
+	}
+	var kills int
+	_ = s.db.QueryRow(`SELECT kills FROM weapon_kills WHERE account=? AND weapon=?`, name, weapon).Scan(&kills)
+	if requested == 3 {
+		maxSkin := 0
+		if kills >= GoldKillRequirement {
+			maxSkin = 1
+		}
+		if kills >= DiamondKillRequirement {
+			maxSkin = 2
+		}
+		return uint8(rand.IntN(maxSkin + 1))
+	}
+	if requested == 2 && kills >= DiamondKillRequirement {
+		return 2
+	}
+	if requested == 1 && kills >= GoldKillRequirement {
+		return 1
+	}
+	return 0
 }
 
 type LeaderRow struct {


### PR DESCRIPTION
## 变更内容

为 Pixel Strike 增加基于客户端 IP 的武器皮肤进度系统。

### 主要功能

- 真人玩家按客户端 IP 绑定进度账号。
- 每把枪独立累计击杀数。
- 击杀达到 100 次解锁黄金皮肤。
- 击杀达到 500 次解锁钻石皮肤。
- 加入游戏时可以选择主武器和副武器的皮肤。
- 支持从当前已解锁的皮肤中随机选择。
- 服务端会校验皮肤是否已经解锁，避免客户端绕过限制。
- 新增 `/api/progression` 接口，用于读取当前玩家的武器击杀进度。
- 将武器皮肤状态同步到客户端自身状态和其他玩家的快照中。
- 升级通信协议版本并补充相关协议测试。
- 更新 README，补充武器皮肤系统说明。

## 实现说明

- 机器人击杀不会计入武器皮肤进度。
- 刀不参与枪械皮肤进度统计。
- 武器击杀进度保存在 SQLite 的 `weapon_kills` 表中。
- 客户端和服务端需要一起升级到新的协议版本。

## 验证建议

合并前建议执行：

```bash
cd server
go test ./...

cd ../client
npm run build