### PR TITLE
优化快照同步与枪感，并加入连杀按需奖励

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -83,24 +83,36 @@ export interface WeaponDef {
 }
 
 export const WEAPONS: WeaponDef[] = [
-  { id: 0, name: 'Glock-18', dmg: 21, headMult: 3.0, rpm: 480, mag: 30, reserve: 180, reloadMs: 1400, speedMult: 1.0, spread: 0.24, moveSpread: 1.05, bloom: 0.09, adsFov: 67, automatic: false, color: 0x222225, length: 0.35 },
-  { id: 1, name: 'Desert Eagle', dmg: 44, headMult: 2.45, rpm: 250, mag: 11, reserve: 53, reloadMs: 1800, speedMult: 0.98, spread: 0.14, moveSpread: 1.65, bloom: 0.30, adsFov: 62, automatic: false, color: 0x9b9890, length: 0.42 },
-  { id: 2, name: 'MP5-SD', dmg: 21, headMult: 3.0, rpm: 820, mag: 45, reserve: 180, reloadMs: 1800, speedMult: 1.0, spread: 0.34, moveSpread: 1.15, bloom: 0.05, adsFov: 58, automatic: true, color: 0x34485a, length: 0.55 },
-  { id: 3, name: 'AK-47', dmg: 33, headMult: 4.0, rpm: 600, mag: 45, reserve: 135, reloadMs: 2200, speedMult: 0.92, spread: 0.26, moveSpread: 1.6, bloom: 0.14, adsFov: 54, automatic: true, color: 0x79502f, length: 0.75 },
-  { id: 4, name: 'M4A4', dmg: 29, headMult: 3.5, rpm: 690, mag: 45, reserve: 135, reloadMs: 2100, speedMult: 0.93, spread: 0.20, moveSpread: 1.35, bloom: 0.09, adsFov: 52, automatic: true, color: 0x3b463b, length: 0.75 },
-  { id: 5, name: 'AWP', dmg: 103, headMult: 1.25, rpm: 32, mag: 8, reserve: 45, reloadMs: 2800, speedMult: 0.76, spread: 0.015, moveSpread: 4.4, bloom: 0, adsFov: 26, automatic: false, color: 0x35463a, length: 1.05 },
+  { id: 0, name: 'Glock-18', dmg: 23, headMult: 3.0, rpm: 500, mag: 30, reserve: 180, reloadMs: 1400, speedMult: 1.0, spread: 0.42, moveSpread: 1.15, bloom: 0.10, adsFov: 67, automatic: false, color: 0x222225, length: 0.35 },
+  { id: 1, name: 'Desert Eagle', dmg: 44, headMult: 2.45, rpm: 250, mag: 11, reserve: 53, reloadMs: 1800, speedMult: 0.98, spread: 0.32, moveSpread: 1.80, bloom: 0.30, adsFov: 62, automatic: false, color: 0x9b9890, length: 0.42 },
+  { id: 2, name: 'MP5-SD', dmg: 22, headMult: 3.0, rpm: 820, mag: 45, reserve: 180, reloadMs: 1800, speedMult: 1.0, spread: 0.52, moveSpread: 1.25, bloom: 0.07, adsFov: 58, automatic: true, color: 0x34485a, length: 0.55 },
+  { id: 3, name: 'AK-47', dmg: 33, headMult: 4.0, rpm: 600, mag: 45, reserve: 135, reloadMs: 2200, speedMult: 0.92, spread: 0.50, moveSpread: 1.70, bloom: 0.16, adsFov: 54, automatic: true, color: 0x79502f, length: 0.75 },
+  { id: 4, name: 'M4A4', dmg: 29, headMult: 3.5, rpm: 690, mag: 45, reserve: 135, reloadMs: 2100, speedMult: 0.93, spread: 0.38, moveSpread: 1.40, bloom: 0.10, adsFov: 52, automatic: true, color: 0x3b463b, length: 0.75 },
+  { id: 5, name: 'AWP', dmg: 103, headMult: 1.25, rpm: 32, mag: 8, reserve: 45, reloadMs: 2800, speedMult: 0.76, spread: 0.06, moveSpread: 4.4, bloom: 0, adsFov: 26, automatic: false, color: 0x35463a, length: 1.05 },
   { id: 6, name: 'Knife', dmg: 34, headMult: 1.0, rpm: 150, mag: 0, reserve: 0, reloadMs: 0, speedMult: 1.08, spread: 0, moveSpread: 0, bloom: 0, adsFov: 75, automatic: false, color: 0x777777, length: 0.3 },
-  { id: 7, name: 'USP-S', dmg: 24, headMult: 3.6, rpm: 400, mag: 18, reserve: 36, reloadMs: 1700, speedMult: 1.0, spread: 0.11, moveSpread: 1.0, bloom: 0.16, adsFov: 64, automatic: false, color: 0x2a3340, length: 0.38 },
-  { id: 8, name: 'UMP-45', dmg: 25, headMult: 2.8, rpm: 620, mag: 38, reserve: 150, reloadMs: 2100, speedMult: 0.97, spread: 0.42, moveSpread: 1.25, bloom: 0.08, adsFov: 56, automatic: true, color: 0x4a4036, length: 0.58 },
-  { id: 9, name: 'FAMAS', dmg: 28, headMult: 3.2, rpm: 720, mag: 38, reserve: 135, reloadMs: 2200, speedMult: 0.94, spread: 0.28, moveSpread: 1.45, bloom: 0.11, adsFov: 52, automatic: true, color: 0x5a6848, length: 0.7 },
-  { id: 10, name: 'AUG', dmg: 27, headMult: 3.5, rpm: 600, mag: 45, reserve: 135, reloadMs: 2300, speedMult: 0.88, spread: 0.16, moveSpread: 1.1, bloom: 0.08, adsFov: 40, automatic: true, color: 0x3d4a3a, length: 0.78 },
-  { id: 11, name: 'SSG 08', dmg: 72, headMult: 2.0, rpm: 48, mag: 12, reserve: 120, reloadMs: 2600, speedMult: 0.80, spread: 0.025, moveSpread: 3.4, bloom: 0, adsFov: 30, automatic: false, color: 0x2f3a48, length: 1.0 },
-  { id: 12, name: 'XM1014', dmg: 14, headMult: 1.25, rpm: 180, mag: 8, reserve: 36, reloadMs: 2600, speedMult: 0.93, spread: 2.6, moveSpread: 3.6, bloom: 0.28, adsFov: 66, automatic: false, color: 0x6a5a3a, length: 0.72, pellets: 6 },
+  { id: 7, name: 'USP-S', dmg: 24, headMult: 3.6, rpm: 400, mag: 18, reserve: 36, reloadMs: 1700, speedMult: 1.0, spread: 0.30, moveSpread: 1.05, bloom: 0.16, adsFov: 64, automatic: false, color: 0x2a3340, length: 0.38 },
+  { id: 8, name: 'UMP-45', dmg: 27, headMult: 2.8, rpm: 620, mag: 38, reserve: 150, reloadMs: 2100, speedMult: 0.97, spread: 0.56, moveSpread: 1.30, bloom: 0.08, adsFov: 56, automatic: true, color: 0x4a4036, length: 0.58 },
+  { id: 9, name: 'FAMAS', dmg: 29, headMult: 3.2, rpm: 720, mag: 38, reserve: 135, reloadMs: 2200, speedMult: 0.94, spread: 0.42, moveSpread: 1.40, bloom: 0.12, adsFov: 52, automatic: true, color: 0x5a6848, length: 0.7 },
+  { id: 10, name: 'AUG', dmg: 27, headMult: 3.5, rpm: 600, mag: 45, reserve: 135, reloadMs: 2300, speedMult: 0.88, spread: 0.32, moveSpread: 1.15, bloom: 0.09, adsFov: 40, automatic: true, color: 0x3d4a3a, length: 0.78 },
+  { id: 11, name: 'SSG 08', dmg: 72, headMult: 2.0, rpm: 48, mag: 12, reserve: 120, reloadMs: 2600, speedMult: 0.80, spread: 0.08, moveSpread: 3.4, bloom: 0, adsFov: 30, automatic: false, color: 0x2f3a48, length: 1.0 },
+  { id: 12, name: 'XM1014', dmg: 17, headMult: 1.2, rpm: 200, mag: 7, reserve: 32, reloadMs: 2100, speedMult: 0.96, spread: 1.85, moveSpread: 2.4, bloom: 0.10, adsFov: 64, automatic: true, color: 0x6a5a3a, length: 0.72, pellets: 8 },
 ];
 
 export const isSniper = (id: number) => id === 5 || id === 11;
 export const isPistol = (id: number) => id === 0 || id === 1 || id === 7;
 export const isGun = (id: number) => id !== 6;
+export const isShotgun = (id: number) => id === 12;
+
+export const XM_PELLETS: readonly [number, number][] = [
+  [0.18, -0.12],
+  [1.00, 0.10],
+  [0.62, 0.78],
+  [-0.22, 0.98],
+  [-0.92, 0.38],
+  [-0.85, -0.52],
+  [-0.08, -1.00],
+  [0.78, -0.62],
+];
 export const scopeSettleMs = (id: number) => id === 5 ? 320 : id === 11 ? 240 : 0;
 
 export const KEY = {

--- a/client/src/hud.ts
+++ b/client/src/hud.ts
@@ -598,13 +598,14 @@ export class Hud {
     this.hitTimer = window.setTimeout(() => { this.hit.className = ''; }, head ? 220 : 150);
   }
 
-  showKillStreak(count: number, head = false) {
+  showKillStreak(count: number, head = false, reward = '') {
     if (count < 2) return;
     const title = count === 2 ? '双杀' : count === 3 ? '三杀' : count === 4 ? '疯狂四杀' : `${count} 连杀`;
-    this.streak.innerHTML = `<strong>${title}</strong><span>${head ? '爆头 · ' : ''}连续击杀 ${count} 人</span>`;
+    const extra = reward ? ` · ${reward}` : '';
+    this.streak.innerHTML = `<strong>${title}</strong><span>${head ? '爆头 · ' : ''}连续击杀 ${count} 人${extra}</span>`;
     this.streak.className = 'active';
     clearTimeout(this.streakTimer);
-    this.streakTimer = window.setTimeout(() => { this.streak.className = ''; }, 1500);
+    this.streakTimer = window.setTimeout(() => { this.streak.className = ''; }, 1800);
   }
 
   setCrosshair(spread: number) {
@@ -646,7 +647,7 @@ export class Hud {
     setTimeout(() => row.remove(), 4200);
   }
 
-  showPickupNotice(message: string, kind: 'ammo' | 'health' | 'speed') {
+  showPickupNotice(message: string, kind: 'ammo' | 'health' | 'speed' | 'buff') {
     const toast = el('pickup-toast');
     toast.textContent = message;
     toast.dataset.kind = kind;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -6,7 +6,7 @@ import { Weapons } from './weapons.js';
 import { Hud } from './hud.js';
 import { AudioEngine, type SfxName } from './audio.js';
 import { ParticleSystem } from './particles.js';
-import { KEY, PHYS, WEAPONS, isSniper, scopeSettleMs, type MapData, type PlayerSnap, type RosterEntry, type WeaponDef } from './constants.js';
+import { KEY, PHYS, WEAPONS, XM_PELLETS, isGun, isPistol, isShotgun, isSniper, scopeSettleMs, type MapData, type PlayerSnap, type RosterEntry, type WeaponDef } from './constants.js';
 import bundledMap from '../../map.json';
 
 const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -52,6 +52,7 @@ let alive = false;
 let myName = '';
 let killerId = -1;
 let killStreak = 0;
+let recoilBoostUntil = 0;
 let respawnAt = 0;
 let screenShake = 0;
 let aiming = false;
@@ -716,6 +717,7 @@ function handleEvent(e: GameEvent) {
       reloadPendingSlot = 0;
       weapons.cancelReload();
       speedBoostUntil = 0;
+      recoilBoostUntil = 0;
       local.flying = false;
       hud.setFlightState(false, false);
       clearCombatInput();
@@ -770,6 +772,7 @@ function handleEvent(e: GameEvent) {
     cameraEyeHeight = PHYS.eyeHeight;
     landingPenaltyUntil = 0;
     speedBoostUntil = 0;
+    recoilBoostUntil = 0;
     patternShots = 0;
     reloadPendingSlot = 0;
     weapons.cancelReload();
@@ -851,6 +854,30 @@ function handleEvent(e: GameEvent) {
     if (e.kind === 1) hud.showFlightAnnouncement(e.name || nameOf(e.player));
     return;
   }
+  if (e.type === 13 && e.player === net.yourId) {
+    const kind = e.kind ?? 0;
+    const ms = e.ms ?? 8000;
+    const parts: string[] = [];
+    if (kind & 1) {
+      reloadPendingSlot = 0;
+      weapons.cancelReload();
+      parts.push('弹药补充');
+    }
+    if (kind & 2) parts.push('生命恢复');
+    if (kind & 4) {
+      speedBoostUntil = performance.now() + ms;
+      parts.push('移速提升');
+    }
+    if (kind & 8) {
+      recoilBoostUntil = performance.now() + ms;
+      parts.push('后坐降低');
+    }
+    if (kind & 16) parts.push('伤害提升');
+    const label = parts.join(' · ') || '连杀奖励';
+    hud.showPickupNotice(label, kind & 1 ? 'ammo' : kind & 2 ? 'health' : kind & 4 ? 'speed' : 'buff');
+    audio.play(kind & 2 ? 'hitmarker' : 'weapon_switch', 0.75, 1.15);
+    return;
+  }
 }
 
 function nameOf(id?: number): string {
@@ -869,8 +896,9 @@ remotes.onShot = (s, position, burstShots) => {
   }
   if (!world) return;
   const o = remoteShotOrigin.set(position.x, position.y + (s.state & 4 ? 1.12 : 1.6), position.z);
-  const shotSample = (WEAPONS[s.weapon]?.pellets ?? 1) > 1 ? s.shot * 17 : s.shot;
-  const d = shotDirection(remoteShotDir, s.yaw, s.pitch, remoteSpread(s, burstShots), shotSample, s.weapon, s.id);
+  const shotgun = isShotgun(s.weapon);
+  const shotSample = shotgun ? s.shot : ((WEAPONS[s.weapon]?.pellets ?? 1) > 1 ? s.shot * 17 : s.shot);
+  const d = shotDirection(remoteShotDir, s.yaw, s.pitch, remoteSpread(s, burstShots), shotSample, s.weapon, s.id, shotgun ? 0 : undefined);
   const dist = world.raycastDistance(o, d, 180);
   weapons.spawnTracer(o, d, dist);
   playSpatial(fireSound(s.weapon), position.x, position.z, 0.65, 120, 0.97 + Math.random() * 0.06);
@@ -1051,7 +1079,9 @@ function fire(mode: number, t: number) {
   if (weapons.weaponId !== 6) {
     audio.play(fireSound(weapons.weaponId), 1, 0.985 + Math.random() * 0.03, 0, true);
     for (let i = 0; i < pellets; i++) {
-      const pelletDir = i === 0 ? dir : shotDirection(localPelletDir, local.yaw, local.pitch, spread, shotSample * 17 + i, weapons.weaponId, net.yourId);
+      const pelletDir = i === 0 && !isShotgun(weapons.weaponId)
+        ? dir
+        : shotDirection(localPelletDir, local.yaw, local.pitch, spread, isShotgun(weapons.weaponId) ? shotSample : shotSample * 17 + i, weapons.weaponId, net.yourId, isShotgun(weapons.weaponId) ? i : undefined);
       const dist = world?.raycastDistance(origin, pelletDir, 180) ?? 180;
       weapons.spawnTracer(origin, pelletDir, dist);
       if (dist < 180) {
@@ -1089,11 +1119,18 @@ function deathCam() {
 function weaponSpread(def: WeaponDef, vx: number, vz: number, onGround: boolean, crouching: boolean, landing: boolean, ads: boolean, burstShots: number): number {
   const moveFactor = Math.min(1, Math.hypot(vx, vz) / 3);
   let spread = def.spread + (def.moveSpread - def.spread) * moveFactor;
-  spread += Math.min(0.22, burstShots * def.bloom * 0.12);
+  spread += Math.min(0.28, burstShots * def.bloom * 0.14);
   if (!onGround) spread = Math.max(spread, def.moveSpread * 1.55 + 0.45);
-  if (crouching) spread *= 0.55;
-  if (ads && !isSniper(def.id)) spread *= 0.48;
+  if (crouching) spread *= 0.72;
+  if (ads && !isSniper(def.id)) spread *= isShotgun(def.id) ? 0.85 : 0.62;
   if (landing) spread = Math.max(spread, def.moveSpread * 1.12);
+  if (isGun(def.id)) {
+    let floor = 0.28;
+    if (isShotgun(def.id)) floor = 1.25;
+    else if (isSniper(def.id)) floor = ads ? 0.07 : 0;
+    else if (isPistol(def.id)) floor = 0.22;
+    if (floor > 0 && spread < floor) spread = floor;
+  }
   return spread;
 }
 
@@ -1114,7 +1151,8 @@ function remoteSpread(s: PlayerSnap, burstShots: number): number {
 
 function applyRecoil(weapon: number, shot: number, ads: boolean) {
   const i = Math.max(0, shot - 1);
-  const scale = ads ? 0.45 : 1;
+  let scale = ads ? 0.45 : 1;
+  if (performance.now() < recoilBoostUntil) scale *= 0.50;
   let pitch = 0;
   let yaw = 0;
   switch (weapon) {
@@ -1130,10 +1168,14 @@ function applyRecoil(weapon: number, shot: number, ads: boolean) {
       pitch = 0.0055 + Math.min(i, 8) * 0.0005;
       yaw = Math.sin(i * 1.7) * 0.0015;
       break;
-    case 3:
-      pitch = 0.019 + Math.min(i, 7) * 0.0026;
-      yaw = i < 8 ? (i % 2 ? 0.0034 : -0.0026) : -0.0055;
+    case 3: {
+      const akUp = [0.014, 0.015, 0.0165, 0.0175, 0.018, 0.0165, 0.015, 0.0135, 0.012, 0.011, 0.0105, 0.01, 0.0095, 0.009, 0.009, 0.0085];
+      const akSide = [0.0003, 0.0007, -0.0005, 0.0016, 0.0022, -0.0010, 0.0028, 0.0018, -0.0034, -0.0040, 0.0036, 0.0044, -0.0042, 0.0032, -0.0046, 0.0038];
+      const idx = Math.min(i, akUp.length - 1);
+      pitch = akUp[idx];
+      yaw = akSide[idx];
       break;
+    }
     case 4:
       pitch = 0.014 + Math.min(i, 7) * 0.0018;
       yaw = i < 8 ? (i % 2 ? 0.0024 : -0.0024) : 0.0038;
@@ -1161,8 +1203,8 @@ function applyRecoil(weapon: number, shot: number, ads: boolean) {
       pitch = 0.034;
       break;
     case 12:
-      pitch = 0.050;
-      yaw = i % 2 ? 0.007 : -0.007;
+      pitch = 0.016;
+      yaw = i % 2 ? 0.003 : -0.0026;
       break;
     default:
       return;
@@ -1171,17 +1213,27 @@ function applyRecoil(weapon: number, shot: number, ads: boolean) {
   local.yaw -= yaw * scale;
 }
 
-function shotDirection(out: THREE.Vector3, yaw: number, pitch: number, spread: number, shot: number, weapon: number, shooter: number): THREE.Vector3 {
+function shotDirection(out: THREE.Vector3, yaw: number, pitch: number, spread: number, shot: number, weapon: number, shooter: number, pellet?: number): THREE.Vector3 {
   const cp = Math.cos(pitch);
   out.set(-Math.sin(yaw) * cp, Math.sin(pitch), -Math.cos(yaw) * cp);
   if (spread <= 0) return out;
+  shotRight.set(-out.z, 0, out.x).normalize();
+  shotUp.crossVectors(shotRight, out);
+  if (isShotgun(weapon) && pellet !== undefined) {
+    const o = XM_PELLETS[pellet % XM_PELLETS.length];
+    let seed = (Math.imul(shot * 31 + pellet, 747796405) + Math.imul(weapon + 1, 2891336453) + Math.imul(shooter, 2246822519)) >>> 0;
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+    const jx = (seed / 4294967296 - 0.5) * 0.28;
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+    const jy = (seed / 4294967296 - 0.5) * 0.28;
+    const ring = Math.tan(spread * Math.PI / 180);
+    return out.addScaledVector(shotRight, (o[0] + jx) * ring).addScaledVector(shotUp, (o[1] + jy) * ring).normalize();
+  }
   let seed = (Math.imul(shot, 747796405) + Math.imul(weapon + 1, 2891336453) + Math.imul(shooter, 2246822519)) >>> 0;
   seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
   const radius = Math.sqrt(seed / 4294967296) * Math.tan(spread * Math.PI / 180);
   seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
   const angle = seed / 4294967296 * Math.PI * 2;
-  shotRight.set(-out.z, 0, out.x).normalize();
-  shotUp.crossVectors(shotRight, out);
   return out.addScaledVector(shotRight, Math.cos(angle) * radius).addScaledVector(shotUp, Math.sin(angle) * radius).normalize();
 }
 

--- a/client/src/net.ts
+++ b/client/src/net.ts
@@ -1,6 +1,6 @@
 import { OP, PROTOCOL_VERSION, type PlayerSnap, type RosterEntry } from './constants.js';
 
-export interface GameEvent { type:number; killer?:number; victim?:number; player?:number; weapon?:number; headshot?:number; origin?:[number,number,number]; dir?:[number,number,number]; name?:string; pickup?:number; kind?:number; ms?:number }
+export interface GameEvent { type:number; killer?:number; victim?:number; player?:number; weapon?:number; headshot?:number; origin?:[number,number,number]; dir?:[number,number,number]; name?:string; pickup?:number; kind?:number; ms?:number; streak?:number }
 export interface SelfState { ack:number; slot:number; weapon:number; weaponSkin:number; mag:number; reserve:number; nades:number }
 
 export class Net {
@@ -75,7 +75,7 @@ export class Net {
       this.onRoster?.(rows);
     }
   }
-  private decodeSnapshot(v:DataView){const tick=v.getUint32(1,true),ack=v.getUint16(5,true),n=v.getUint8(7);this.lastServerTick=tick;let o=8;const updated:PlayerSnap[]=[];for(let i=0;i<n;i++){const id=v.getUint16(o,true),mask=v.getUint16(o+2,true);o+=4;let s=this.states.get(id);if(mask===0x8000){s={id,x:v.getInt16(o,true)/100,y:v.getInt16(o+2,true)/100,z:v.getInt16(o+4,true)/100,yaw:half(v.getInt16(o+6,true)),pitch:half(v.getInt16(o+8,true)),vx:v.getInt8(o+10)/10,vz:v.getInt8(o+11)/10,hp:v.getUint8(o+12),armor:v.getUint8(o+13),state:v.getUint8(o+14),weapon:v.getUint8(o+15),shot:v.getUint8(o+16),skin:v.getUint8(o+17),weaponSkin:v.getUint8(o+18)};o+=19}else{if(!s)throw new Error(`delta without baseline ${id}`);if(mask&1){s.x+=v.getInt8(o++)/100;s.y+=v.getInt8(o++)/100;s.z+=v.getInt8(o++)/100}else if(mask&2){s.x=v.getInt16(o,true)/100;s.y=v.getInt16(o+2,true)/100;s.z=v.getInt16(o+4,true)/100;o+=6}if(mask&4){s.yaw=wrap(s.yaw+half(v.getInt8(o++)));s.pitch+=half(v.getInt8(o++))}else if(mask&8){s.yaw=half(v.getInt16(o,true));s.pitch=half(v.getInt16(o+2,true));o+=4}if(mask&16){s.vx=v.getInt8(o++)/10;s.vz=v.getInt8(o++)/10}if(mask&32){s.hp=v.getUint8(o++);s.armor=v.getUint8(o++)}if(mask&64)s.state=v.getUint8(o++);if(mask&128)s.weapon=v.getUint8(o++);if(mask&256)s.shot=v.getUint8(o++);if(mask&512)s.skin=v.getUint8(o++);if(mask&1024)s.weaponSkin=v.getUint8(o++)}this.states.set(id,s);updated.push(s)}this.onSnapshot(tick,ack,updated)}
+  private decodeSnapshot(v:DataView){const tick=v.getUint32(1,true),ack=v.getUint16(5,true),n=v.getUint8(7);this.lastServerTick=tick;let o=8;const updated:PlayerSnap[]=[];for(let i=0;i<n;i++){const id=v.getUint16(o,true),mask=v.getUint16(o+2,true);o+=4;let s=this.states.get(id);if(mask===0x8000){s={id,x:v.getInt16(o,true)/100,y:v.getInt16(o+2,true)/100,z:v.getInt16(o+4,true)/100,yaw:half(v.getInt16(o+6,true)),pitch:half(v.getInt16(o+8,true)),vx:v.getInt8(o+10)/10,vz:v.getInt8(o+11)/10,hp:v.getUint8(o+12),armor:v.getUint8(o+13),state:v.getUint8(o+14),weapon:v.getUint8(o+15),shot:v.getUint8(o+16),skin:v.getUint8(o+17),weaponSkin:v.getUint8(o+18)};o+=19}else{if(!s){if(mask&1)o+=3;else if(mask&2)o+=6;if(mask&4)o+=2;else if(mask&8)o+=4;if(mask&16)o+=2;if(mask&32)o+=2;if(mask&64)o+=1;if(mask&128)o+=1;if(mask&256)o+=1;if(mask&512)o+=1;if(mask&1024)o+=1;continue}if(mask&1){s.x+=v.getInt8(o++)/100;s.y+=v.getInt8(o++)/100;s.z+=v.getInt8(o++)/100}else if(mask&2){s.x=v.getInt16(o,true)/100;s.y=v.getInt16(o+2,true)/100;s.z=v.getInt16(o+4,true)/100;o+=6}if(mask&4){s.yaw=wrap(s.yaw+half(v.getInt8(o++)));s.pitch+=half(v.getInt8(o++))}else if(mask&8){s.yaw=half(v.getInt16(o,true));s.pitch=half(v.getInt16(o+2,true));o+=4}if(mask&16){s.vx=v.getInt8(o++)/10;s.vz=v.getInt8(o++)/10}if(mask&32){s.hp=v.getUint8(o++);s.armor=v.getUint8(o++)}if(mask&64)s.state=v.getUint8(o++);if(mask&128)s.weapon=v.getUint8(o++);if(mask&256)s.shot=v.getUint8(o++);if(mask&512)s.skin=v.getUint8(o++);if(mask&1024)s.weaponSkin=v.getUint8(o++)}this.states.set(id,s);updated.push(s)}this.onSnapshot(tick,ack,updated)}
   private decodeEvents(v: DataView) {
     const rows: GameEvent[] = [];
     let o = 2;
@@ -115,6 +115,9 @@ export class Net {
           e.name = new TextDecoder().decode(new Uint8Array(v.buffer, v.byteOffset + o + 4, len));
           o += 4 + len; break;
         }
+        case 13:
+          e.player = v.getUint16(o, true); e.kind = v.getUint8(o + 2);
+          e.streak = v.getUint8(o + 3); e.ms = v.getUint16(o + 4, true); o += 6; break;
       }
       rows.push(e);
     }

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -70,9 +70,10 @@ export class LocalPlayer {
       this.vel.z = vz;
       return;
     }
-    if (errorSq < 0.0004) return;
-    const cy = this.onGround || this.flying ? (target.y - this.pos.y) * 0.15 : 0;
-    correction.set((target.x - this.pos.x) * 0.15, cy, (target.z - this.pos.z) * 0.15);
+    if (errorSq < 0.0025) return;
+    const pull = 0.10;
+    const cy = this.onGround || this.flying ? (target.y - this.pos.y) * pull : 0;
+    correction.set((target.x - this.pos.x) * pull, cy, (target.z - this.pos.z) * pull);
     if (boxes) moveAABB(this.pos, correction, 1, boxes, this.height(), false);
     else this.pos.add(correction);
   }
@@ -428,7 +429,6 @@ export class RemotePlayers {
     const dt = Math.min(0.05, Math.max(0.001, (now - this.lastUpdate) / 1000));
     this.lastUpdate = now;
     if (this.models.size === 0) return;
-    const alpha = 1 - Math.exp(-dt * 16);
     let uniformColorsDirty = false, gunColorsDirty = false;
 
     for (const model of this.models.values()) {
@@ -443,11 +443,12 @@ export class RemotePlayers {
       model.visible = true;
 
       const age = Math.min(0.2, Math.max(0, (now - model.sampleAt) / 1000));
+      const follow = 1 - Math.exp(-dt * (age < 0.08 ? 20 : 11));
       goal.set(state.x + state.vx * age, state.y, state.z + state.vz * age);
       if (model.position.distanceToSquared(goal) > 64) model.position.copy(goal);
-      else model.position.lerp(goal, alpha);
-      model.yaw = angleLerp(model.yaw, state.yaw, alpha);
-      model.pitch += (state.pitch - model.pitch) * alpha;
+      else model.position.lerp(goal, follow);
+      model.yaw = angleLerp(model.yaw, state.yaw, follow);
+      model.pitch += (state.pitch - model.pitch) * follow;
 
       const speed = Math.sqrt(state.vx * state.vx + state.vz * state.vz);
       model.walk += speed * dt * 2.2;

--- a/client/src/weapons.ts
+++ b/client/src/weapons.ts
@@ -27,8 +27,8 @@ interface SoundCue {
 }
 
 const RELOAD_PITCH: Record<number, number> = { 0: 1.12, 1: 0.82, 2: 1.18, 3: 0.92, 4: 1, 5: 0.72, 7: 1.08, 8: 1.05, 9: 0.95, 10: 0.9, 11: 0.7, 12: 0.85 };
-const FIRE_KICK = [0.26, 0.62, 0.18, 0.46, 0.37, 0.82, 0, 0.16, 0.31, 0.4, 0.34, 0.66, 0.76] as const;
-const RECOIL_RECOVERY = [18, 11, 22, 12, 15, 8, 18, 20, 17, 14, 16, 10, 11] as const;
+const FIRE_KICK = [0.26, 0.62, 0.18, 0.39, 0.37, 0.82, 0, 0.16, 0.31, 0.4, 0.34, 0.66, 0.34] as const;
+const RECOIL_RECOVERY = [18, 11, 22, 13, 15, 8, 18, 20, 17, 14, 16, 10, 16] as const;
 function createMuzzleFlashTexture(): THREE.Texture {
   const canvas = new OffscreenCanvas(64, 64);
   const ctx = canvas.getContext('2d')!;

--- a/server/bot.go
+++ b/server/bot.go
@@ -7,6 +7,15 @@ import (
 )
 
 // Expanded 12 Bot roster across all sectors of the map
+const maxBotSkill = 2
+
+var botPrimaries = []uint8{3, 4, 2, 8, 9, 10, 12, 11}
+var botSecondaries = []uint8{0, 7, 1}
+
+func botSkill(id uint16) int {
+	return int(id) % (maxBotSkill + 1)
+}
+
 var BotNames = []string{
 	"[BOT] Phoenix",
 	"[BOT] Hunter",
@@ -36,6 +45,14 @@ type BotAI struct {
 	TargetDist float64
 	NextNadeAt time.Time
 	ShotSeq    uint16
+	RevengeID    uint16
+	RevengeUntil time.Time
+	HearPos      Vec3
+	HearUntil    time.Time
+	NextGlanceAt time.Time
+	GlanceUntil  time.Time
+	GlanceYaw    float64
+	LastHurtAt   time.Time
 }
 
 func (r *Room) SetBotCount(count int) {
@@ -80,19 +97,21 @@ func (r *Room) SetBotCount(count int) {
 		for i := len(currentBots); i < count; i++ {
 			name := BotNames[i]
 			id := r.allocPlayerID()
+			primary := botPrimaries[i%len(botPrimaries)]
+			secondary := botSecondaries[i%len(botSecondaries)]
 			bot := &Player{
 				PlayerState: PlayerState{
 					Id:         id,
 					Name:       name,
 					HP:         MaxHP,
 					Alive:      false,
-					Primary:    3,
-					Secondary:  0,
+					Primary:    primary,
+					Secondary:  secondary,
 					ActiveSlot: 1,
-					Weapon:     3,
+					Weapon:     primary,
 					Skin:       uint8(i % int(SkinCount)),
-					Mags:       [2]int{Weapons[3].Mag, Weapons[0].Mag},
-					Reserves:   [2]int{Weapons[3].Reserve, Weapons[0].Reserve},
+					Mags:       [2]int{Weapons[primary].Mag, Weapons[secondary].Mag},
+					Reserves:   [2]int{Weapons[primary].Reserve, Weapons[secondary].Reserve},
 					Grenades:   1,
 					IsBot:      true,
 				},
@@ -102,6 +121,7 @@ func (r *Room) SetBotCount(count int) {
 			r.Players = append(r.Players, bot)
 			r.botAIs[id] = &BotAI{
 				NextWaypointAt: time.Now(),
+				NextGlanceAt:   time.Now().Add(time.Duration(700+rand.IntN(2200)) * time.Millisecond),
 			}
 			r.Respawn(&bot.PlayerState, time.Now())
 			r.Emit(Event{Type: EvPlayerName, Player: bot.Id, Name: bot.Name})
@@ -124,7 +144,13 @@ func (r *Room) StepBots(now time.Time) {
 		p := &pl.PlayerState
 
 		mag, _ := p.ActiveAmmo()
-		// 1. Check if need reload
+		if mag <= 0 && p.ActiveSlot == 1 && p.Mags[1] > 0 {
+			p.SwitchSlot(2)
+			mag, _ = p.ActiveAmmo()
+		} else if mag <= 0 && p.ActiveSlot == 2 && p.Mags[0] > 0 && p.Reserves[0] == 0 {
+			p.SwitchSlot(1)
+			mag, _ = p.ActiveAmmo()
+		}
 		if mag <= 0 && !p.Reloading {
 			r.StartReload(p, now)
 		}
@@ -150,38 +176,79 @@ func (r *Room) StepBots(now time.Time) {
 				ai.TargetDist = 0
 			}
 		}
+		if now.After(ai.RevengeUntil) {
+			ai.RevengeID = 0
+		}
+		if (r.tick+uint32(p.Id))%7 == 0 {
+			for _, other := range r.Players {
+				if other.Id == p.Id || !other.Alive || other.ProtectedAt(now) || other.Crouch {
+					continue
+				}
+				speed := math.Hypot(other.Vel.X, other.Vel.Z)
+				if speed < 1.1 || !(other.OnGround || other.Flying) {
+					continue
+				}
+				dx, dz := other.Pos.X-p.Pos.X, other.Pos.Z-p.Pos.Z
+				if dx*dx+dz*dz > 18*18 {
+					continue
+				}
+				ai.HearPos = other.Pos
+				ai.HearUntil = now.Add(900 * time.Millisecond)
+			}
+		}
 		if ai.Target == nil || (r.tick+uint32(p.Id))%12 == 0 {
 			previousTarget := ai.Target
 			ai.Target = nil
-			bestDistSq := 32.0 * 32.0
+			bestDistSq := 36.0 * 36.0
 			eyePos := Vec3{p.Pos.X, p.Pos.Y + EyeHeight, p.Pos.Z}
-			for _, other := range r.Players {
+			huntingRevenge := ai.RevengeID != 0 && now.Before(ai.RevengeUntil)
+			for i := range r.Players {
+				other := &r.Players[i].PlayerState
 				if other.Id == p.Id || !other.Alive || other.ProtectedAt(now) {
 					continue
 				}
 				dx := other.Pos.X - p.Pos.X
 				dz := other.Pos.Z - p.Pos.Z
 				distSq := dx*dx + dz*dz
-				if distSq > bestDistSq {
+				revenge := huntingRevenge && other.Id == ai.RevengeID
+				maxSq := bestDistSq
+				if revenge {
+					maxSq = 64.0 * 64.0
+					ai.TargetPos = other.Pos
+					ai.NextWaypointAt = now.Add(800 * time.Millisecond)
+				}
+				if distSq > maxSq {
 					continue
 				}
 				targetEye := Vec3{other.Pos.X, other.Pos.Y + EyeHeight*0.8, other.Pos.Z}
 				dir := Vec3{targetEye.X - eyePos.X, targetEye.Y - eyePos.Y, targetEye.Z - eyePos.Z}
 				dLen := math.Sqrt(dir.X*dir.X + dir.Y*dir.Y + dir.Z*dir.Z)
-				if dLen > 0.001 {
-					dir.X /= dLen
-					dir.Y /= dLen
-					dir.Z /= dLen
-					hit, hitDist := r.World.Raycast(eyePos, dir, dLen)
-					if !hit || hitDist >= dLen-0.6 {
-						bestDistSq = distSq
-						ai.Target = &other.PlayerState
-					}
+				if dLen <= 0.001 {
+					continue
+				}
+				dir.X /= dLen
+				dir.Y /= dLen
+				dir.Z /= dLen
+				hit, hitDist := r.World.Raycast(eyePos, dir, dLen)
+				if hit && hitDist < dLen-0.6 {
+					continue
+				}
+				if revenge || distSq < bestDistSq {
+					bestDistSq = distSq
+					ai.Target = other
 				}
 			}
 			ai.TargetDist = math.Sqrt(bestDistSq)
 			if ai.Target != nil && ai.Target != previousTarget {
-				ai.FireCooldown = now.Add(time.Duration(450+rand.IntN(451)) * time.Millisecond)
+				skill := botSkill(p.Id)
+				delay := 280 + rand.IntN(280) - skill*50
+				if delay < 140 {
+					delay = 140
+				}
+				if huntingRevenge && ai.Target.Id == ai.RevengeID {
+					delay = 120 + rand.IntN(120)
+				}
+				ai.FireCooldown = now.Add(time.Duration(delay) * time.Millisecond)
 			}
 		}
 		targetEnemy := ai.Target
@@ -233,8 +300,16 @@ func (r *Room) StepBots(now time.Time) {
 			for yawDiff < -math.Pi {
 				yawDiff += 2 * math.Pi
 			}
-			p.Yaw += yawDiff * 0.12
-			p.Pitch += (targetPitch - p.Pitch) * 0.12
+			skill := botSkill(p.Id)
+			turn := 0.18 + 0.05*float64(skill)
+			if now.Sub(ai.LastHurtAt) < 700*time.Millisecond {
+				fwdX, fwdZ := -math.Sin(p.Yaw), -math.Cos(p.Yaw)
+				if dx*fwdX+dz*fwdZ < 0 {
+					turn = math.Min(0.42, 0.32+0.05*float64(skill))
+				}
+			}
+			p.Yaw += yawDiff * turn
+			p.Pitch += (targetPitch - p.Pitch) * turn
 
 			// Combat movement: strafe and advance/retreat
 			if now.After(ai.NextStrafeAt) {
@@ -246,10 +321,16 @@ func (r *Room) StepBots(now time.Time) {
 				}
 			}
 
-			if bestDist > 14 {
+			if bestDist > 12 {
 				moveKeys |= KeyForward
-			} else if bestDist < 5 {
+			} else if bestDist < 4 {
 				moveKeys |= KeyBack
+			}
+			if bestDist > 10 && isGun(p.Weapon) && !isShotgun(p.Weapon) {
+				moveKeys |= KeyAim
+			}
+			if bestDist > 8 && bestDist < 16 && skill >= 1 && rand.Float64() < 0.01 {
+				moveKeys |= KeyCrouch
 			}
 
 			if ai.StrafeDir > 0 {
@@ -259,12 +340,12 @@ func (r *Room) StepBots(now time.Time) {
 			}
 
 			// Jump randomly to dodge fire
-			if rand.Float64() < 0.008 && p.OnGround {
+			if rand.Float64() < 0.012 && p.OnGround {
 				moveKeys |= KeyJump
 			}
 
 			// Lob a grenade at mid-range enemies pinned behind cover
-			if p.Grenades > 0 && now.After(ai.NextNadeAt) && bestDist > 6 && bestDist < 18 {
+			if p.Grenades > 0 && now.After(ai.NextNadeAt) && bestDist > 5 && bestDist < 20 {
 				gdx := targetEnemy.Pos.X - p.Pos.X
 				gdz := targetEnemy.Pos.Z - p.Pos.Z
 				gdy := (targetEnemy.Pos.Y + 0.9) - (p.Pos.Y + EyeHeight)
@@ -274,23 +355,35 @@ func (r *Room) StepBots(now time.Time) {
 				ai.NextNadeAt = now.Add(time.Duration(9+rand.IntN(8)) * time.Second)
 			}
 
-			// Fire weapon
-			if !p.Reloading && mag > 0 && now.After(ai.FireCooldown) {
-				aimYaw := p.Yaw + (rand.Float64()-0.5)*0.12
-				aimPitch := p.Pitch + (rand.Float64()-0.5)*0.08
+			if !p.Reloading && mag > 0 && now.After(ai.FireCooldown) && math.Abs(yawDiff) < 0.20-0.03*float64(skill) {
+				jitter := 0.09 - 0.025*float64(skill)
+				aimYaw := p.Yaw + (rand.Float64()-0.5)*jitter
+				aimPitch := p.Pitch + (rand.Float64()-0.5)*jitter*0.7
+				mode := uint8(0)
+				if moveKeys&KeyAim != 0 {
+					mode |= 0x80
+				}
 				ai.ShotSeq++
-				if r.TryFire(p, aimYaw, aimPitch, 0, r.tick, ai.ShotSeq, now) {
+				if r.TryFire(p, aimYaw, aimPitch, mode, r.tick, ai.ShotSeq, now) {
 					w := Weapons[p.Weapon]
-					ai.FireCooldown = now.Add(time.Duration(60000.0/w.Rpm*1.6+float64(50+rand.IntN(111))) * time.Millisecond)
+					pace := 1.38 - 0.10*float64(skill)
+					ai.FireCooldown = now.Add(time.Duration(60000.0/w.Rpm*pace+float64(30+rand.IntN(80))) * time.Millisecond)
 				}
 			}
 		} else {
-			// Patrol mode: navigate across whole map
+			hearing := now.Before(ai.HearUntil)
+			if hearing {
+				ai.TargetPos = ai.HearPos
+				ai.NextWaypointAt = now.Add(400 * time.Millisecond)
+			}
 			waypointDX, waypointDZ := p.Pos.X-ai.TargetPos.X, p.Pos.Z-ai.TargetPos.Z
-			if now.After(ai.NextWaypointAt) || waypointDX*waypointDX+waypointDZ*waypointDZ < 9 {
+			if !hearing && (now.After(ai.NextWaypointAt) || waypointDX*waypointDX+waypointDZ*waypointDZ < 9) {
 				ai.NextWaypointAt = now.Add(time.Duration(4+rand.IntN(6)) * time.Second)
-				if len(r.World.Spawns) > 0 {
-					// 65% chance to patrol central engagement zone
+				if ai.RevengeID != 0 && now.Before(ai.RevengeUntil) {
+					if hunted := r.findPlayer(ai.RevengeID); hunted != nil && hunted.Alive {
+						ai.TargetPos = hunted.Pos
+					}
+				} else if len(r.World.Spawns) > 0 {
 					if rand.Float64() < 0.65 {
 						ai.TargetPos = Vec3{(rand.Float64() - 0.5) * 48.0, 0, (rand.Float64() - 0.5) * 48.0}
 					} else {
@@ -303,12 +396,31 @@ func (r *Room) StepBots(now time.Time) {
 			dx := ai.TargetPos.X - p.Pos.X
 			dz := ai.TargetPos.Z - p.Pos.Z
 			targetYaw := math.Atan2(-dx, -dz)
-			p.Yaw += (targetYaw - p.Yaw) * 0.2
+			if now.After(ai.NextGlanceAt) && !hearing {
+				sign := 1.0
+				if rand.Float64() < 0.5 {
+					sign = -1
+				}
+				ai.GlanceYaw = p.Yaw + sign*(2.2+rand.Float64()*0.7)
+				ai.GlanceUntil = now.Add(280 * time.Millisecond)
+				ai.NextGlanceAt = now.Add(time.Duration(2800+rand.IntN(4200)) * time.Millisecond)
+			}
+			if now.Before(ai.GlanceUntil) && !hearing {
+				p.Yaw = yawToward(p.Yaw, ai.GlanceYaw, 0.28)
+			} else if hearing {
+				fwdX, fwdZ := -math.Sin(p.Yaw), -math.Cos(p.Yaw)
+				if dx*fwdX+dz*fwdZ < 0.2 {
+					p.Yaw = yawToward(p.Yaw, targetYaw, 0.34)
+				} else {
+					p.Yaw = yawToward(p.Yaw, targetYaw, 0.22)
+				}
+				moveKeys |= KeyForward
+			} else {
+				p.Yaw = yawToward(p.Yaw, targetYaw, 0.2)
+				moveKeys |= KeyForward
+			}
 			p.Pitch = 0
 
-			moveKeys |= KeyForward
-
-			// Multi-ray obstacle avoidance (front, left 30°, right 30°)
 			frontHit, _ := r.World.Raycast(Vec3{p.Pos.X, p.Pos.Y + 0.4, p.Pos.Z}, Vec3{-math.Sin(p.Yaw), 0, -math.Cos(p.Yaw)}, 1.5)
 			if frontHit && p.OnGround {
 				moveKeys |= KeyJump
@@ -316,5 +428,63 @@ func (r *Room) StepBots(now time.Time) {
 		}
 
 		p.CmdKeys = moveKeys
+	}
+}
+
+func yawToward(cur, want, rate float64) float64 {
+	diff := want - cur
+	for diff > math.Pi {
+		diff -= 2 * math.Pi
+	}
+	for diff < -math.Pi {
+		diff += 2 * math.Pi
+	}
+	return cur + diff*rate
+}
+
+func (r *Room) botKilled(victim, killer *PlayerState, now time.Time) {
+	if victim == nil || killer == nil || !victim.IsBot || victim.Id == killer.Id {
+		return
+	}
+	ai := r.botAIs[victim.Id]
+	if ai == nil {
+		return
+	}
+	ai.RevengeID = killer.Id
+	ai.RevengeUntil = now.Add(22 * time.Second)
+	ai.HearPos = killer.Pos
+	ai.HearUntil = now.Add(4 * time.Second)
+	ai.Target = nil
+}
+
+func (r *Room) botTookHit(victim, attacker *PlayerState, now time.Time) {
+	if victim == nil || attacker == nil || !victim.IsBot {
+		return
+	}
+	ai := r.botAIs[victim.Id]
+	if ai == nil {
+		return
+	}
+	ai.LastHurtAt = now
+	ai.HearPos = attacker.Pos
+	ai.HearUntil = now.Add(2 * time.Second)
+}
+
+func (r *Room) alertBotsSound(origin Vec3, shooter *PlayerState, now time.Time, radius float64) {
+	rSq := radius * radius
+	for _, pl := range r.Players {
+		if !pl.IsBot || !pl.Alive || (shooter != nil && pl.Id == shooter.Id) {
+			continue
+		}
+		dx, dz := pl.Pos.X-origin.X, pl.Pos.Z-origin.Z
+		if dx*dx+dz*dz > rSq {
+			continue
+		}
+		ai := r.botAIs[pl.Id]
+		if ai == nil {
+			continue
+		}
+		ai.HearPos = origin
+		ai.HearUntil = now.Add(1400 * time.Millisecond)
 	}
 }

--- a/server/hub.go
+++ b/server/hub.go
@@ -30,7 +30,7 @@ type AdminPlayer struct {
 	Deaths uint16 `json:"deaths"`
 }
 
-func NewHub(w *World, s *Store) *Hub { return &Hub{World: w, Store: s, botCount: 6} }
+func NewHub(w *World, s *Store) *Hub { return &Hub{World: w, Store: s, botCount: 8} }
 
 func (h *Hub) Broadcast(msg []byte) {
 	h.mu.Lock()

--- a/server/netstate.go
+++ b/server/netstate.go
@@ -1,8 +1,12 @@
 package main
 
-import "math"
+import (
+	"math"
+	"sort"
+	"time"
+)
 
-const maxSnapshotBytes = 2300 // ~69 KB/s at 30 Hz, before small event traffic.
+const maxSnapshotBytes = 4096 // ~123 KB/s at 30 Hz, still far under the 100 Mbps budget.
 
 type quantState struct {
 	x, y, z                                          int16
@@ -81,31 +85,29 @@ func (p *Player) BuildSnapshot(tick uint32, players []*Player, states []quantSta
 	countAt := len(w.b) - 1
 	count := 0
 
+	type cand struct {
+		i      int
+		distSq float64
+	}
+	cands := make([]cand, 0, len(players))
 	for i, other := range players {
-		isSelf := other.Id == p.Id
-		dx := other.Pos.X - p.Pos.X
-		dz := other.Pos.Z - p.Pos.Z
-		distSq := dx*dx + dz*dz
-		if !isSelf {
-			switch {
-			case distSq <= 48*48:
-			case distSq <= 112*112:
-				if tick%6 != 0 {
-					continue
-				}
-			case distSq <= 180*180:
-				moving := other.Vel.X*other.Vel.X+other.Vel.Z*other.Vel.Z > .0025
-				if moving && tick%12 != 0 || !moving && tick%60 != 0 {
-					continue
-				}
-			default:
-				continue
-			}
+		if ok, distSq := snapshotVisible(&p.PlayerState, &other.PlayerState, tick); ok {
+			cands = append(cands, cand{i: i, distSq: distSq})
 		}
+	}
+	sort.Slice(cands, func(a, b int) bool {
+		if cands[a].distSq != cands[b].distSq {
+			return cands[a].distSq < cands[b].distSq
+		}
+		return players[cands[a].i].Id < players[cands[b].i].Id
+	})
+
+	for _, c := range cands {
 		if len(w.b) >= maxSnapshotBytes {
 			break
 		}
-		cur := states[i]
+		other := players[c.i]
+		cur := states[c.i]
 		prev, seen := p.netCache[other.Id]
 		full := !seen || tick-p.netFullAt[other.Id] >= 120
 		if !appendStateDelta(w, other.Id, prev, cur, full) {
@@ -119,6 +121,33 @@ func (p *Player) BuildSnapshot(tick uint32, players []*Player, states []quantSta
 	}
 	w.b[countAt] = byte(count)
 	return w.Bytes()
+}
+
+func snapshotVisible(self, other *PlayerState, tick uint32) (bool, float64) {
+	if other.Id == self.Id {
+		return true, -1
+	}
+	dx := other.Pos.X - self.Pos.X
+	dz := other.Pos.Z - self.Pos.Z
+	distSq := dx*dx + dz*dz
+	recentShot := !other.LastShotAt.IsZero() && time.Since(other.LastShotAt) < 800*time.Millisecond
+	switch {
+	case distSq <= 42*42:
+		return true, distSq
+	case distSq <= 100*100:
+		return tick%4 == 0 || recentShot, distSq
+	case distSq <= 220*220:
+		if recentShot {
+			return tick%4 == 0, distSq
+		}
+		moving := other.Vel.X*other.Vel.X+other.Vel.Z*other.Vel.Z > .0025
+		if moving {
+			return tick%8 == 0, distSq
+		}
+		return tick%20 == 0, distSq
+	default:
+		return recentShot && tick%8 == 0, distSq
+	}
 }
 
 func (p *Player) snapshotBuffer(size int) []byte {

--- a/server/proto.go
+++ b/server/proto.go
@@ -45,6 +45,7 @@ const (
 	EvPickupSpawn
 	EvPickupTaken
 	EvFlightToggle
+	EvStreakBuff
 )
 
 type Event struct {
@@ -186,6 +187,11 @@ func Events(evts []Event) []byte {
 			nb := safeNameBytes(e.Name)
 			w.U8(uint8(len(nb)))
 			w.b = append(w.b, nb...)
+		case EvStreakBuff:
+			w.U16(e.Player)
+			w.U8(e.Kind)
+			w.U8(e.Dmg)
+			w.U16(e.Ms)
 		}
 	}
 	return w.Bytes()

--- a/server/proto_test.go
+++ b/server/proto_test.go
@@ -91,9 +91,9 @@ func TestBalanceValues(t *testing.T) {
 	if RespawnDelayS != 3*time.Second || WalkSpeed != 6.4 || GroundAccel != 44 || StopAccel != 60 || AirAccel != 9.5 || JumpVel != 8.4 || MaxRewindTicks != 8 {
 		t.Fatalf("unexpected movement balance")
 	}
-	wantDamage := []float64{21, 44, 21, 33, 29, 103, 34, 24, 25, 28, 27, 72, 14}
-	wantMag := []int{30, 11, 45, 45, 45, 8, 0, 18, 38, 38, 45, 12, 8}
-	wantReserve := []int{180, 53, 180, 135, 135, 45, 0, 36, 150, 135, 135, 120, 36}
+	wantDamage := []float64{23, 44, 22, 33, 29, 103, 34, 24, 27, 29, 27, 72, 17}
+	wantMag := []int{30, 11, 45, 45, 45, 8, 0, 18, 38, 38, 45, 12, 7}
+	wantReserve := []int{180, 53, 180, 135, 135, 45, 0, 36, 150, 135, 135, 120, 32}
 	for i, weapon := range Weapons {
 		if weapon.Dmg != wantDamage[i] || weapon.Mag != wantMag[i] || weapon.Reserve != wantReserve[i] {
 			t.Fatalf("%s balance = %.0f %d/%d", weapon.Name, weapon.Dmg, weapon.Mag, weapon.Reserve)
@@ -290,8 +290,20 @@ func TestArsenalRolesStaySeparated(t *testing.T) {
 		t.Fatalf("SSG should not body one-shot: %.1f", ssg.Dmg*ssg.ArmorPen)
 	}
 	xm := Weapons[12]
+	if float64(xm.Pellets)*xm.Dmg < MaxHP {
+		t.Fatalf("XM should one-tap unarmored if the cone connects: %.1f", float64(xm.Pellets)*xm.Dmg)
+	}
 	if float64(xm.Pellets)*xm.Dmg*xm.ArmorPen >= MaxHP {
 		t.Fatalf("XM should not armor-dump with all pellets: %.1f", float64(xm.Pellets)*xm.Dmg*xm.ArmorPen)
+	}
+	if xm.Rpm < 180 || !xm.Automatic {
+		t.Fatal("XM follow-up is still too slow")
+	}
+	if xm.SpreadDeg > 2.0 {
+		t.Fatalf("XM cone still too wide: %.2f", xm.SpreadDeg)
+	}
+	if Weapons[8].SpreadDeg > Weapons[2].SpreadDeg+0.05 {
+		t.Fatal("UMP spread is still unusable next to MP5")
 	}
 	if Weapons[2].SpreadDeg >= .7 {
 		t.Fatal("MP5 spread still unusable")
@@ -324,6 +336,17 @@ func TestWeaponSpreadStaysControllable(t *testing.T) {
 	if ads >= hipSpray {
 		t.Fatalf("ADS did not tighten inaccuracy: ads=%.3f hip=%.3f", ads, hipSpray)
 	}
+	adsFirst := weaponSpread(ak, 0, 0, true, false, false, true, 0)
+	if adsFirst < 0.26 {
+		t.Fatalf("ADS first shot is still a laser: %.3f", adsFirst)
+	}
+	if adsFirst >= first-0.05 {
+		t.Fatalf("ADS should still tighten first shot: ads=%.3f hip=%.3f", adsFirst, first)
+	}
+	awpScoped := weaponSpread(Weapons[5], 0, 0, true, false, false, true, 0)
+	if awpScoped < 0.06 {
+		t.Fatalf("scoped AWP has no spread: %.3f", awpScoped)
+	}
 }
 
 func TestPatternDirStaysInsideSpread(t *testing.T) {
@@ -337,6 +360,27 @@ func TestPatternDirStaysInsideSpread(t *testing.T) {
 	}
 	if patternDir(aim, 2, 1, 3, 7) == patternDir(aim, 2, 1, 3, 8) {
 		t.Fatal("different players received the same spread pattern")
+	}
+}
+
+func TestSnapshotOrdersNearbyPlayersFirst(t *testing.T) {
+	recv := &Player{PlayerState: PlayerState{Id: 5, Alive: true, Pos: Vec3{}}}
+	far := &Player{PlayerState: PlayerState{Id: 1, Alive: true, Pos: Vec3{Z: 90}}}
+	near := &Player{PlayerState: PlayerState{Id: 2, Alive: true, Pos: Vec3{Z: 8}}}
+	players := []*Player{far, recv, near}
+	states := make([]quantState, 3)
+	for i, p := range players {
+		states[i] = quantizeState(&p.PlayerState, 0)
+	}
+	snap := recv.BuildSnapshot(0, players, states)
+	if snap[7] != 3 {
+		t.Fatalf("expected 3 players, got %d", snap[7])
+	}
+	id0 := binary.LittleEndian.Uint16(snap[8:])
+	id1 := binary.LittleEndian.Uint16(snap[8+23:])
+	id2 := binary.LittleEndian.Uint16(snap[8+46:])
+	if id0 != 5 || id1 != 2 || id2 != 1 {
+		t.Fatalf("snapshot order = %d,%d,%d want self,near,far", id0, id1, id2)
 	}
 }
 
@@ -421,6 +465,73 @@ func TestBestSpawnNeverReturnsUnscoredOrigin(t *testing.T) {
 	}
 	if got := r.BestSpawn(&PlayerState{}); got == (Vec3{}) {
 		t.Fatal("crowded spawn selection returned unscored origin")
+	}
+}
+
+func TestStreakBuffsRespectCaps(t *testing.T) {
+	p := &PlayerState{Streak: 20}
+	if p.streakDamageMul() > streakDmgCap+1e-9 {
+		t.Fatalf("damage mul %v exceeds cap", p.streakDamageMul())
+	}
+	if p.streakSpeedMul() > streakSpeedCap+1e-9 {
+		t.Fatalf("speed mul %v exceeds cap", p.streakSpeedMul())
+	}
+	if p.streakScale() > streakScaleCap {
+		t.Fatalf("scale %d exceeds cap", p.streakScale())
+	}
+	if botSkill(99) > maxBotSkill {
+		t.Fatalf("bot skill %d exceeds cap", botSkill(99))
+	}
+}
+
+func TestStreakPicksHealWhenLowAndAmmoWhenDry(t *testing.T) {
+	r := &Room{history: make(map[uint16]*poseHistory)}
+	now := time.Unix(1, 0)
+	hurt := &PlayerState{Id: 1, Alive: true, IsBot: true, HP: 30, Armor: 10, Primary: 3, Secondary: 0, ActiveSlot: 1, Weapon: 3, Mags: [2]int{30, 12}, Reserves: [2]int{90, 24}}
+	victim := &PlayerState{Id: 11, Alive: true, IsBot: true, HP: 1}
+	hurt.Streak = 1
+	r.Damage(hurt, victim, 80, false, 3, now)
+	if hurt.HP <= 30 {
+		t.Fatalf("low HP should get heal, hp=%d", hurt.HP)
+	}
+	var healKind uint8
+	for _, e := range r.pending {
+		if e.Type == EvStreakBuff {
+			healKind = e.Kind
+		}
+	}
+	if healKind&StreakHeal == 0 {
+		t.Fatalf("expected heal, got kind=%d", healKind)
+	}
+
+	r.pending = nil
+	dry := &PlayerState{Id: 2, Alive: true, IsBot: true, HP: MaxHP, Armor: 100, Primary: 3, Secondary: 0, ActiveSlot: 1, Weapon: 3, Mags: [2]int{0, 12}, Reserves: [2]int{0, 24}}
+	victim2 := &PlayerState{Id: 12, Alive: true, IsBot: true, HP: 1}
+	dry.Streak = 1
+	r.Damage(dry, victim2, 80, false, 3, now)
+	if dry.Mags[0] == 0 {
+		t.Fatal("empty mag should get ammo")
+	}
+	var ammoKind uint8
+	for _, e := range r.pending {
+		if e.Type == EvStreakBuff {
+			ammoKind = e.Kind
+		}
+	}
+	if ammoKind&StreakAmmo == 0 {
+		t.Fatalf("expected ammo, got kind=%d", ammoKind)
+	}
+}
+
+func TestBotMarksRevengeOnDeath(t *testing.T) {
+	killer := &Player{PlayerState: PlayerState{Id: 1, Alive: true, IsBot: true, HP: MaxHP}}
+	victim := &Player{PlayerState: PlayerState{Id: 2, Alive: true, IsBot: true, HP: 1}}
+	r := &Room{Players: []*Player{killer, victim}, botAIs: map[uint16]*BotAI{2: {}}, history: make(map[uint16]*poseHistory)}
+	now := time.Now()
+	r.Damage(&killer.PlayerState, &victim.PlayerState, 80, false, 3, now)
+	ai := r.botAIs[2]
+	if ai == nil || ai.RevengeID != 1 || !now.Before(ai.RevengeUntil) {
+		t.Fatalf("bot did not mark revenge: %+v", ai)
 	}
 }
 

--- a/server/room.go
+++ b/server/room.go
@@ -98,51 +98,58 @@ func (r *Room) Run() {
 		}
 		r.FinishReloads(now)
 		r.Step(now)
-		var evts []Event
-		if r.tick%2 == 0 {
-			evts = r.pending
-			r.pending = nil
-		}
+		evts := r.pending
+		r.pending = nil
+		needSnap := r.tick%2 == 0
 		var outs []outbound
-		if r.tick%2 == 0 {
+		if needSnap || len(evts) > 0 {
 			players := r.Players
 			outs = r.outboundBuf[:0]
-			r.quantizedBuf = quantizePlayers(r.quantizedBuf, players, now.UnixNano())
+			if needSnap {
+				r.quantizedBuf = quantizePlayers(r.quantizedBuf, players, now.UnixNano())
+			}
 			var periodicRoster []byte
-			if r.tick%600 == 0 {
+			if needSnap && r.tick%600 == 0 {
 				periodicRoster = Roster(players)
 			}
 			for _, p := range players {
 				if p.IsBot || !p.ready {
 					continue
 				}
-				out := outbound{p: p, snapshot: p.BuildSnapshot(r.tick, players, r.quantizedBuf)}
-				self := compactSelf(&p.PlayerState)
-				if r.tick%60 == 0 || !p.hasLastSelf || self != p.lastSelf {
-					out.self = SelfState(&p.PlayerState)
-					p.lastSelf, p.hasLastSelf = self, true
+				out := outbound{p: p}
+				if needSnap {
+					out.snapshot = p.BuildSnapshot(r.tick, players, r.quantizedBuf)
+					self := compactSelf(&p.PlayerState)
+					if r.tick%60 == 0 || !p.hasLastSelf || self != p.lastSelf {
+						out.self = SelfState(&p.PlayerState)
+						p.lastSelf, p.hasLastSelf = self, true
+					}
+					if periodicRoster != nil {
+						out.roster = periodicRoster
+					} else if p.rosterRequested {
+						out.roster = Roster(players)
+					}
+					if periodicRoster != nil || p.rosterRequested {
+						p.rosterRequested = false
+					}
 				}
 				if len(evts) > 0 {
 					if filtered := r.eventsFor(p, evts); len(filtered) > 0 {
 						out.events = Events(filtered)
 					}
 				}
-				if periodicRoster != nil {
-					out.roster = periodicRoster
-				} else if p.rosterRequested {
-					out.roster = Roster(players)
+				if out.snapshot != nil || out.self != nil || out.events != nil || out.roster != nil {
+					outs = append(outs, out)
 				}
-				if periodicRoster != nil || p.rosterRequested {
-					p.rosterRequested = false
-				}
-				outs = append(outs, out)
 			}
 		}
 		r.tick++
 		r.mu.Unlock()
 		for i := range outs {
 			out := &outs[i]
-			out.p.Send(out.snapshot)
+			if out.snapshot != nil {
+				out.p.Send(out.snapshot)
+			}
 			if out.self != nil {
 				out.p.Send(out.self)
 			}
@@ -172,6 +179,8 @@ func (r *Room) eventsFor(target *Player, evts []Event) []Event {
 		switch e.Type {
 		case EvKill, EvPlayerName, EvPlayerLeave, EvFlightToggle:
 			send = true
+		case EvStreakBuff:
+			send = e.Player == target.Id
 		case EvHit:
 			send = e.Player == target.Id || e.Victim == target.Id
 		case EvRespawn:

--- a/server/sim.go
+++ b/server/sim.go
@@ -28,23 +28,24 @@ type WeaponDef struct {
 }
 
 var Weapons = []WeaponDef{
-	{0, "Glock-18", 21, 3.0, 480, .24, 1.05, .09, 1.0, .58, 30, 180, 1400, false, 1},
-	{1, "Desert Eagle", 44, 2.45, 250, .14, 1.65, .30, .98, .93, 11, 53, 1800, false, 1},
-	{2, "MP5-SD", 21, 3.0, 820, .34, 1.15, .05, 1.0, .65, 45, 180, 1800, true, 1},
-	{3, "AK-47", 33, 4.0, 600, .26, 1.6, .14, .92, .78, 45, 135, 2200, true, 1},
-	{4, "M4A4", 29, 3.5, 690, .20, 1.35, .09, .93, .72, 45, 135, 2100, true, 1},
-	{5, "AWP", 103, 1.25, 32, .015, 4.4, 0, .76, .98, 8, 45, 2800, false, 1},
+	{0, "Glock-18", 23, 3.0, 500, .42, 1.15, .10, 1.0, .58, 30, 180, 1400, false, 1},
+	{1, "Desert Eagle", 44, 2.45, 250, .32, 1.80, .30, .98, .93, 11, 53, 1800, false, 1},
+	{2, "MP5-SD", 22, 3.0, 820, .52, 1.25, .07, 1.0, .65, 45, 180, 1800, true, 1},
+	{3, "AK-47", 33, 4.0, 600, .50, 1.70, .16, .92, .78, 45, 135, 2200, true, 1},
+	{4, "M4A4", 29, 3.5, 690, .38, 1.40, .10, .93, .72, 45, 135, 2100, true, 1},
+	{5, "AWP", 103, 1.25, 32, .06, 4.4, 0, .76, .98, 8, 45, 2800, false, 1},
 	{6, "Knife", 34, 1, 150, 0, 0, 0, 1.08, 1, 0, 0, 0, false, 1},
-	{7, "USP-S", 24, 3.6, 400, .11, 1.0, .16, 1.0, .62, 18, 36, 1700, false, 1},
-	{8, "UMP-45", 25, 2.8, 620, .42, 1.25, .08, .97, .70, 38, 150, 2100, true, 1},
-	{9, "FAMAS", 28, 3.2, 720, .28, 1.45, .11, .94, .68, 38, 135, 2200, true, 1},
-	{10, "AUG", 27, 3.5, 600, .16, 1.1, .08, .88, .75, 45, 135, 2300, true, 1},
-	{11, "SSG 08", 72, 2.0, 48, .025, 3.4, 0, .80, .82, 12, 120, 2600, false, 1},
-	{12, "XM1014", 14, 1.25, 180, 2.6, 3.6, .28, .93, .62, 8, 36, 2600, false, 6},
+	{7, "USP-S", 24, 3.6, 400, .30, 1.05, .16, 1.0, .62, 18, 36, 1700, false, 1},
+	{8, "UMP-45", 27, 2.8, 620, .56, 1.30, .08, .97, .72, 38, 150, 2100, true, 1},
+	{9, "FAMAS", 29, 3.2, 720, .42, 1.40, .12, .94, .68, 38, 135, 2200, true, 1},
+	{10, "AUG", 27, 3.5, 600, .32, 1.15, .09, .88, .75, 45, 135, 2300, true, 1},
+	{11, "SSG 08", 72, 2.0, 48, .08, 3.4, 0, .80, .82, 12, 120, 2600, false, 1},
+	{12, "XM1014", 17, 1.2, 200, 1.85, 2.4, .10, .96, .70, 7, 32, 2100, true, 8},
 }
 
-func isGun(id uint8) bool    { return int(id) < len(Weapons) && id != 6 }
-func isSniper(id uint8) bool { return id == 5 || id == 11 }
+func isGun(id uint8) bool      { return int(id) < len(Weapons) && id != 6 }
+func isSniper(id uint8) bool   { return id == 5 || id == 11 }
+func isShotgun(id uint8) bool  { return id == 12 }
 func isPrimary(id uint8) bool {
 	switch id {
 	case 2, 3, 4, 5, 8, 9, 10, 11, 12:
@@ -93,7 +94,8 @@ type PlayerState struct {
 	CmdKeys                                                        uint8
 	Reloading                                                      bool
 	ReloadEnd, NextFire, InvincibleUntil, RespawnAt, NextGrenadeAt time.Time
-	LandingUntil, AimStarted, SpeedUntil                           time.Time
+	LandingUntil, AimStarted, SpeedUntil, DmgUntil, RecoilUntil    time.Time
+	Streak                                                         uint8
 	Grenades                                                       int
 	Kills, Deaths                                                  uint16
 	LastInputSeq, LastShotSeq                                      uint16
@@ -235,7 +237,7 @@ func (r *Room) Move(p *PlayerState, now time.Time) {
 	}
 	speed := WalkSpeed * Weapons[min(int(p.Weapon), len(Weapons)-1)].SpeedMult
 	if now.Before(p.SpeedUntil) {
-		speed *= speedBoostMultiplier
+		speed *= p.streakSpeedMul()
 	}
 	if p.Crouch {
 		speed *= CrouchSpeed
@@ -373,7 +375,11 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 	for n := 0; n < pellets; n++ {
 		shotDir := dir
 		if isGun(uint8(weapon)) {
-			shotDir = patternDir(dir, spread, spreadSample(shotSeq, pellets, n), weapon, p.Id)
+			if isShotgun(uint8(weapon)) {
+				shotDir = shotgunDir(dir, spread, n, int(uint8(shotSeq)), weapon, p.Id)
+			} else {
+				shotDir = patternDir(dir, spread, spreadSample(shotSeq, pellets, n), weapon, p.Id)
+			}
 		}
 		_, worldDist := r.World.Raycast(origin, shotDir, maxDist)
 		var target *PlayerState
@@ -408,20 +414,31 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 			}
 		} else if headshot {
 			dmg *= def.HeadMult
-		} else if hitY <= .65 {
+		} else if hitY <= .65 && !isShotgun(uint8(weapon)) {
 			dmg *= .75
+		}
+		if isShotgun(uint8(weapon)) && targetDist > 8 {
+			dmg *= math.Max(0.38, 1-(targetDist-8)/16)
 		}
 		r.Damage(p, target, dmg, headshot, uint8(weapon), now)
 		if !target.Alive && pellets == 1 {
 			break
 		}
 	}
+	hear := 38.0
+	if weapon == 6 {
+		hear = 14
+	}
+	r.alertBotsSound(origin, p, now, hear)
 	return true
 }
 
 func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool, weapon uint8, now time.Time) {
 	if !victim.Alive || victim.ProtectedAt(now) {
 		return
+	}
+	if now.Before(attacker.DmgUntil) {
+		dmg *= attacker.streakDamageMul()
 	}
 	actual := dmg
 	if victim.Armor > 0 && isGun(weapon) {
@@ -437,11 +454,21 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	}
 	r.Emit(Event{Type: EvHit, Player: attacker.Id, Victim: victim.Id, Dmg: d, Headshot: hs})
 	if victim.HP > 0 {
+		r.botTookHit(victim, attacker, now)
 		return
 	}
+	r.botKilled(victim, attacker, now)
 	r.Emit(Event{Type: EvKill, Killer: attacker.Id, Victim: victim.Id, Weapon: weapon, Headshot: hs})
 	attacker.Kills++
 	victim.Deaths++
+	if attacker.Id != victim.Id {
+		if attacker.Streak < 255 {
+			attacker.Streak++
+		}
+		r.applyStreakReward(attacker, now)
+	}
+	victim.Streak = 0
+	victim.DmgUntil, victim.RecoilUntil, victim.SpeedUntil = time.Time{}, time.Time{}, time.Time{}
 	if !attacker.IsBot {
 		r.Store.Accumulate(attacker.Account, 1, 0)
 		if !victim.IsBot && isGun(weapon) {
@@ -453,6 +480,178 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	}
 	victim.Alive, victim.Reloading = false, false
 	victim.RespawnAt = now.Add(RespawnDelayS)
+}
+
+func (p *PlayerState) streakScale() int {
+	return min(int(p.Streak), streakScaleCap)
+}
+
+func (p *PlayerState) streakDamageMul() float64 {
+	return math.Min(streakDmgCap, 1.16+0.03*float64(p.streakScale()))
+}
+
+func (p *PlayerState) streakSpeedMul() float64 {
+	return math.Min(streakSpeedCap, 1.30+0.02*float64(p.streakScale()))
+}
+
+func (p *PlayerState) grantStreakAmmo() {
+	ids := [2]uint8{p.Primary, p.Secondary}
+	for i, id := range ids {
+		if int(id) >= len(Weapons) {
+			continue
+		}
+		def := Weapons[id]
+		add := max(def.Mag/2, 5)
+		space := def.Mag - p.Mags[i]
+		if space > 0 {
+			take := min(space, add)
+			p.Mags[i] += take
+			add -= take
+		}
+		p.Reserves[i] = min(def.Reserve, p.Reserves[i]+add)
+	}
+}
+
+type streakNeed struct {
+	kind  uint8
+	score int
+}
+
+func (p *PlayerState) streakNeeds(now time.Time) []streakNeed {
+	needs := make([]streakNeed, 0, 5)
+	if s := p.healPressure(); s > 0 {
+		needs = append(needs, streakNeed{StreakHeal, s})
+	}
+	if s := p.ammoPressure(); s > 0 {
+		needs = append(needs, streakNeed{StreakAmmo, s})
+	}
+	if now.After(p.SpeedUntil) || p.SpeedUntil.Sub(now) < 3*time.Second {
+		needs = append(needs, streakNeed{StreakSpeed, 28})
+	}
+	if (now.After(p.RecoilUntil) || p.RecoilUntil.Sub(now) < 3*time.Second) && isGun(p.Weapon) && !isSniper(p.Weapon) {
+		needs = append(needs, streakNeed{StreakRecoil, 32})
+	}
+	if now.After(p.DmgUntil) || p.DmgUntil.Sub(now) < 3*time.Second {
+		needs = append(needs, streakNeed{StreakDamage, 26})
+	}
+	return needs
+}
+
+func (p *PlayerState) healPressure() int {
+	if p.HP <= 25 {
+		return 120
+	}
+	if p.HP <= 45 {
+		return 95
+	}
+	if p.HP <= 70 {
+		return 58
+	}
+	if p.HP < MaxHP {
+		return 22
+	}
+	if p.Armor <= 15 {
+		return 42
+	}
+	if p.Armor <= 40 {
+		return 24
+	}
+	return 0
+}
+
+func (p *PlayerState) ammoPressure() int {
+	best := 0
+	ids := [2]uint8{p.Primary, p.Secondary}
+	for i, id := range ids {
+		if int(id) >= len(Weapons) {
+			continue
+		}
+		def := Weapons[id]
+		if def.Mag <= 0 {
+			continue
+		}
+		mag, res := p.Mags[i], p.Reserves[i]
+		score := 0
+		if mag == 0 && res == 0 {
+			score = 100
+		} else if mag == 0 {
+			score = 82
+		} else if mag*100/def.Mag <= 20 {
+			score = 68
+		} else if mag*100/def.Mag <= 40 {
+			score = 40
+		} else if res*100/max(def.Reserve, 1) <= 20 {
+			score = 22
+		}
+		if p.ActiveSlot == uint8(i+1) && score > 0 {
+			score += 12
+		}
+		if score > best {
+			best = score
+		}
+	}
+	return best
+}
+
+func (r *Room) applyStreakReward(p *PlayerState, now time.Time) {
+	n := int(p.Streak)
+	if n < 2 {
+		return
+	}
+	needs := p.streakNeeds(now)
+	if len(needs) == 0 {
+		needs = []streakNeed{{StreakDamage, 1}}
+	}
+	for i := 1; i < len(needs); i++ {
+		for j := i; j > 0 && needs[j].score > needs[j-1].score; j-- {
+			needs[j], needs[j-1] = needs[j-1], needs[j]
+		}
+	}
+	picks := 1
+	if n >= 5 {
+		picks = 2
+	}
+	if n >= 8 {
+		picks = streakPickCap
+	}
+	if picks > len(needs) {
+		picks = len(needs)
+	}
+	kind := uint8(0)
+	n = min(n, streakScaleCap)
+	dur := min(streakDurationCap, time.Duration(6+n)*time.Second)
+	ms := uint16(dur / time.Millisecond)
+	healAmt := min(streakHealCap, 32+n*4)
+	for i := 0; i < picks; i++ {
+		if needs[i].score <= 0 && i > 0 {
+			break
+		}
+		switch needs[i].kind {
+		case StreakAmmo:
+			p.grantStreakAmmo()
+			kind |= StreakAmmo
+		case StreakHeal:
+			p.HP = uint8(min(MaxHP, int(p.HP)+healAmt))
+			p.Armor = uint8(min(100, int(p.Armor)+min(40, 15+n*4)))
+			kind |= StreakHeal
+		case StreakSpeed:
+			if now.Add(dur).After(p.SpeedUntil) {
+				p.SpeedUntil = now.Add(dur)
+			}
+			kind |= StreakSpeed
+		case StreakRecoil:
+			if now.Add(dur).After(p.RecoilUntil) {
+				p.RecoilUntil = now.Add(dur)
+			}
+			kind |= StreakRecoil
+		case StreakDamage:
+			if now.Add(dur).After(p.DmgUntil) {
+				p.DmgUntil = now.Add(dur)
+			}
+			kind |= StreakDamage
+		}
+	}
+	r.Emit(Event{Type: EvStreakBuff, Player: p.Id, Kind: kind, Dmg: p.Streak, Ms: ms})
 }
 
 func (r *Room) StartReload(p *PlayerState, now time.Time) bool {
@@ -496,7 +695,8 @@ func (r *Room) Respawn(p *PlayerState, now time.Time) {
 	p.ApplyLoadout(p.Primary, p.Secondary)
 	p.InvincibleUntil = now.Add(SpawnProtectS)
 	p.LandingUntil, p.AimStarted = time.Time{}, time.Time{}
-	p.SpeedUntil = time.Time{}
+	p.SpeedUntil, p.DmgUntil, p.RecoilUntil = time.Time{}, time.Time{}, time.Time{}
+	p.Streak = 0
 	p.RespawnAt = time.Time{}
 	r.Emit(Event{Type: EvRespawn, Player: p.Id, Origin: p.Pos})
 }
@@ -553,8 +753,19 @@ const (
 )
 
 const (
-	speedBoostDuration   = 8 * time.Second
-	speedBoostMultiplier = 1.35
+	speedBoostDuration     = 8 * time.Second
+	speedBoostMultiplier   = 1.35
+	streakDmgCap           = 1.35
+	streakSpeedCap         = 1.45
+	streakHealCap          = 55
+	streakDurationCap      = 10 * time.Second
+	streakScaleCap         = 8
+	streakPickCap          = 3
+	StreakAmmo           uint8 = 1
+	StreakHeal           uint8 = 2
+	StreakSpeed          uint8 = 4
+	StreakRecoil         uint8 = 8
+	StreakDamage         uint8 = 16
 )
 
 type Pickup struct {
@@ -791,20 +1002,40 @@ func AimDir(yaw, pitch float64) Vec3 {
 func weaponSpread(def WeaponDef, vx, vz float64, onGround, crouching, landing, aiming bool, burstShots int) float64 {
 	moveFactor := math.Min(1, math.Hypot(vx, vz)/3)
 	spread := def.SpreadDeg + (def.MoveSpreadDeg-def.SpreadDeg)*moveFactor
-	// Bloom used to dump the whole spray into a random cone, which made
-	// recoil unreadable. Keep a tiny residual so long sprays aren't lasers.
-	spread += math.Min(.22, float64(burstShots)*def.BloomDeg*.12)
+	spread += math.Min(.28, float64(burstShots)*def.BloomDeg*.14)
 	if !onGround {
 		spread = math.Max(spread, def.MoveSpreadDeg*1.55+.45)
 	}
 	if crouching {
-		spread *= .55
+		spread *= .72
 	}
 	if aiming && !isSniper(def.Id) {
-		spread *= .48
+		if isShotgun(def.Id) {
+			spread *= .85
+		} else {
+			spread *= .62
+		}
 	}
 	if landing {
 		spread = math.Max(spread, def.MoveSpreadDeg*1.12)
+	}
+	if isGun(def.Id) {
+		floor := 0.28
+		switch {
+		case isShotgun(def.Id):
+			floor = 1.25
+		case isSniper(def.Id):
+			if aiming {
+				floor = 0.07
+			} else {
+				floor = 0
+			}
+		case def.Id == 0 || def.Id == 1 || def.Id == 7:
+			floor = 0.22
+		}
+		if floor > 0 && spread < floor {
+			spread = floor
+		}
 	}
 	return spread
 }
@@ -829,6 +1060,35 @@ func patternDir(dir Vec3, deg float64, shot, weapon int, shooter uint16) Vec3 {
 	right := norm(cross(dir, Vec3{0, 1, 0}))
 	up := cross(right, dir)
 	a, b := math.Cos(angle)*radius, math.Sin(angle)*radius
+	return norm(Vec3{dir.X + right.X*a + up.X*b, dir.Y + right.Y*a + up.Y*b, dir.Z + right.Z*a + up.Z*b})
+}
+
+var xmPattern = [][2]float64{
+	{0.18, -0.12},
+	{1.00, 0.10},
+	{0.62, 0.78},
+	{-0.22, 0.98},
+	{-0.92, 0.38},
+	{-0.85, -0.52},
+	{-0.08, -1.00},
+	{0.78, -0.62},
+}
+
+func shotgunDir(dir Vec3, deg float64, pellet, shot, weapon int, shooter uint16) Vec3 {
+	if deg <= 0 {
+		return dir
+	}
+	o := xmPattern[pellet%len(xmPattern)]
+	seed := uint32(shot*31+pellet)*747796405 + uint32(weapon+1)*2891336453 + uint32(shooter)*2246822519
+	seed = seed*1664525 + 1013904223
+	jx := (float64(seed)/4294967296 - 0.5) * 0.28
+	seed = seed*1664525 + 1013904223
+	jy := (float64(seed)/4294967296 - 0.5) * 0.28
+	ring := math.Tan(deg * math.Pi / 180)
+	a := (o[0] + jx) * ring
+	b := (o[1] + jy) * ring
+	right := norm(cross(dir, Vec3{0, 1, 0}))
+	up := cross(right, dir)
 	return norm(Vec3{dir.X + right.X*a + up.X*b, dir.Y + right.Y*a + up.Y*b, dir.Z + right.Z*a + up.Z*b})
 }
 func cross(a, b Vec3) Vec3 { return Vec3{a.Y*b.Z - a.Z*b.Y, a.Z*b.X - a.X*b.Z, a.X*b.Y - a.Y*b.X} }


### PR DESCRIPTION
## 背景

人多时快照按加入顺序截断，远处玩家会占掉近处名额，加上增量丢包后客户端直接抛错，表现为明显卡顿。
部分枪散步过小或过大，XM 弹丸完全随机，AK 连射后坐越打越乱。
人机只会正面盯人，连杀奖励也缺少反馈。

## 改动

### 同步
- 快照预算 2300 → 4096，按距离排序，优先写近处玩家
- 42m 内每帧；中距离约 15Hz；远处约 7.5Hz；刚开过枪的玩家提高优先级
- 事件改为每 tick 发出，不再跟快照绑在一起
- 客户端丢失基线时跳过增量，而不是中断解码
- 本地预测拉扯阈值放宽，远处插值按采样年龄调整

### 武器
- 所有枪保留散步下限，ADS / 下蹲不再压成激光
- XM1014 改为 8 弹丸定型花纹 + 距离衰减，近战更稳、远距离不再秒人
- AK 前几发以上抬为主、后续走固定左右轨迹，枪口 kick 略减
- UMP / MP5 / 步枪散步重新对齐，避免某把完全没法打

### 连杀奖励
- 从 2 连杀起，按当前最缺的资源发：回血、补弹、加速、减后坐、加伤
- 5 连杀最多 2 项，8 连杀最多 3 项
- 伤害 ×1.35、移速 ×1.45、回血 55、持续 10s，连杀缩放上限 8
- 新增事件 `EvStreakBuff`（type 13，只发给获奖玩家），HUD 显示具体奖励

### 人机
- 大厅默认 8 人，混用步枪 / 冲锋 / 霰弹 / 狙
- 被杀后记仇 22 秒，会听枪声、被打会回头，巡逻时会瞥身后
- 弹匣空了切手枪；中远距离会开镜；没瞄上不乱打
- 技能分 0–2，反应和后坐抖动有上限

## 协议

仍为 v6。只新增事件类型 13，旧字段不变。需要前后端一起更新，单独更一端会忽略该奖励提示。

## 测试

- `go test ./...` 通过
- 覆盖：快照近→远顺序、散步下限、XM 弹丸、连杀按需选择、奖励上限、人机记仇