### PR TITLE
死亡复仇

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -943,6 +943,18 @@
       pointer-events: none;
     }
     #flight-announcement.show { display: block; animation: pickup-flash 2.6s ease-out forwards; }
+    #flight-announcement.revenge {
+      min-width: min(680px, 86vw);
+      padding: 15px 30px;
+      border-block: 2px solid rgb(255 91 58 / .9);
+      background: linear-gradient(90deg, transparent, rgb(48 8 8 / .96) 10%, rgb(78 12 8 / .98) 50%, rgb(48 8 8 / .96) 90%, transparent);
+      color: #ffd166;
+      font-size: clamp(22px, 3vw, 38px);
+      letter-spacing: .12em;
+      text-shadow: 0 0 10px rgb(255 91 58 / .95), 0 0 28px rgb(255 209 102 / .75);
+      box-shadow: 0 0 34px rgb(255 58 40 / .35), inset 0 0 24px rgb(255 91 58 / .16);
+    }
+    #flight-announcement.revenge.show { animation: pickup-flash 4s ease-out forwards; }
     #pause-flight-btn.active {
       border-color: #35c9e8;
       background: rgb(53 201 232 / .13);

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 6;
+export const PROTOCOL_VERSION = 7;
 
 export const OP = {
   Join: 0x01,

--- a/client/src/hud.ts
+++ b/client/src/hud.ts
@@ -115,6 +115,7 @@ export class Hud {
   private hurtTimer = 0;
   private toastTimer = 0;
   private flightTimer = 0;
+  private revengeTimer = 0;
   private reconnectTimer = 0;
   private refreshWeaponProgress: (() => void) | null = null;
 
@@ -669,11 +670,25 @@ export class Hud {
   showFlightAnnouncement(name: string) {
     const banner = el('flight-announcement');
     banner.textContent = `${name || '特战队员'} 能飞`;
+    banner.classList.remove('revenge');
     banner.classList.remove('show');
     void banner.offsetWidth;
     banner.classList.add('show');
     clearTimeout(this.flightTimer);
     this.flightTimer = window.setTimeout(() => banner.classList.remove('show'), 2600);
+  }
+
+  showRevengeAnnouncement(name: string) {
+    const banner = el('flight-announcement');
+    banner.textContent = `（${name || '玩家'}）来复仇了！`;
+    banner.classList.add('revenge');
+    banner.classList.remove('show');
+    void banner.offsetWidth;
+    banner.classList.add('show');
+    clearTimeout(this.revengeTimer);
+    this.revengeTimer = window.setTimeout(() => {
+      banner.classList.remove('show', 'revenge');
+    }, 4000);
   }
 
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -689,6 +689,10 @@ net.onEvents = (events) => {
 };
 
 function handleEvent(e: GameEvent) {
+  if (e.type === 13) {
+    hud.showRevengeAnnouncement(e.name ?? nameOf(e.player));
+    return;
+  }
   if (e.type === 0) {
     // EvKill
     const killer = nameOf(e.killer);

--- a/client/src/net.ts
+++ b/client/src/net.ts
@@ -115,6 +115,12 @@ export class Net {
           e.name = new TextDecoder().decode(new Uint8Array(v.buffer, v.byteOffset + o + 4, len));
           o += 4 + len; break;
         }
+        case 13: {
+          e.player = v.getUint16(o, true);
+          const len = v.getUint8(o + 2);
+          e.name = new TextDecoder().decode(new Uint8Array(v.buffer, v.byteOffset + o + 3, len));
+          o += 3 + len; break;
+        }
       }
       rows.push(e);
     }

--- a/client/src/net.ts
+++ b/client/src/net.ts
@@ -124,6 +124,7 @@ export class Net {
           e.name = new TextDecoder().decode(new Uint8Array(v.buffer, v.byteOffset + o + 3, len));
           o += 3 + len; break;
         }
+      }
       rows.push(e);
     }
     this.onEvents?.(rows);

--- a/server/proto.go
+++ b/server/proto.go
@@ -6,7 +6,7 @@ import (
 	"unicode/utf8"
 )
 
-const ProtocolVersion = 6
+const ProtocolVersion = 7
 const SkinCount uint8 = 8
 
 const (
@@ -45,6 +45,7 @@ const (
 	EvPickupSpawn
 	EvPickupTaken
 	EvFlightToggle
+	EvRevenge
 )
 
 type Event struct {
@@ -183,6 +184,11 @@ func Events(evts []Event) []byte {
 		case EvFlightToggle:
 			w.U16(e.Player)
 			w.U8(e.Kind)
+			nb := safeNameBytes(e.Name)
+			w.U8(uint8(len(nb)))
+			w.b = append(w.b, nb...)
+		case EvRevenge:
+			w.U16(e.Player)
 			nb := safeNameBytes(e.Name)
 			w.U8(uint8(len(nb)))
 			w.b = append(w.b, nb...)

--- a/server/proto_test.go
+++ b/server/proto_test.go
@@ -250,6 +250,50 @@ func TestGrenadeThrowConsumesOnceAndEmitsTrajectory(t *testing.T) {
 	}
 }
 
+func TestRevengeShotHeadshotsAnyoneOnScreen(t *testing.T) {
+	now := time.Unix(1, 0)
+	attacker := &Player{PlayerState: PlayerState{
+		Id: 1, Alive: true, IsBot: true, HP: MaxHP, RevengeActive: true, RevengeShots: 10,
+		InvincibleUntil: now.Add(10 * time.Second),
+	}}
+	victim := &Player{PlayerState: PlayerState{
+		Id: 2, Alive: true, IsBot: true, HP: MaxHP, Armor: 100, Pos: Vec3{X: 8, Z: -6},
+	}}
+	attacker.ApplyLoadout(3, 0)
+	r := &Room{World: &World{}, Players: []*Player{attacker, victim}, history: make(map[uint16]*poseHistory)}
+	if !r.TryFire(&attacker.PlayerState, 0, 0, 0, 0, 1, now) {
+		t.Fatal("revenge shot rejected")
+	}
+	if victim.Alive || victim.HP != 0 {
+		t.Fatalf("on-screen target should be headshot without aiming: alive=%v hp=%d", victim.Alive, victim.HP)
+	}
+	if attacker.RevengeShots != 9 {
+		t.Fatalf("revenge ammo not consumed: %d", attacker.RevengeShots)
+	}
+	behind := &Player{PlayerState: PlayerState{Id: 3, Alive: true, IsBot: true, HP: MaxHP, Armor: 100, Pos: Vec3{Z: 8}}}
+	r.Players = []*Player{attacker, behind}
+	attacker.NextFire = time.Time{}
+	if !r.TryFire(&attacker.PlayerState, 0, 0, 0, 0, 2, now.Add(time.Second)) {
+		t.Fatal("second revenge shot rejected")
+	}
+	if !behind.Alive || behind.HP != MaxHP {
+		t.Fatal("player outside the view should not be auto-headshot")
+	}
+	if attacker.RevengeShots != 8 {
+		t.Fatalf("every gunshot should burn revenge ammo: %d", attacker.RevengeShots)
+	}
+	attacker.InvincibleUntil = now
+	attacker.NextFire = time.Time{}
+	next := &Player{PlayerState: PlayerState{Id: 4, Alive: true, IsBot: true, HP: MaxHP, Armor: 100, Pos: Vec3{X: -4, Z: -5}}}
+	r.Players = []*Player{attacker, next}
+	if !r.TryFire(&attacker.PlayerState, 0, 0, 0, 0, 3, now.Add(11*time.Second)) {
+		t.Fatal("revenge shot after invuln expired rejected")
+	}
+	if next.Alive || attacker.RevengeShots != 7 || !attacker.RevengeActive {
+		t.Fatalf("invuln expiry must not end the 10-shot budget: alive=%v shots=%d active=%v", next.Alive, attacker.RevengeShots, attacker.RevengeActive)
+	}
+}
+
 func TestKnifeAttackDoesNotRequireAmmo(t *testing.T) {
 	r := &Room{World: &World{}, history: make(map[uint16]*poseHistory)}
 	attacker := &Player{PlayerState: PlayerState{Id: 1, Alive: true, IsBot: true, HP: MaxHP, Pos: Vec3{}}}

--- a/server/room.go
+++ b/server/room.go
@@ -170,7 +170,7 @@ func (r *Room) eventsFor(target *Player, evts []Event) []Event {
 	for _, e := range evts {
 		send := false
 		switch e.Type {
-		case EvKill, EvPlayerName, EvPlayerLeave, EvFlightToggle:
+		case EvKill, EvPlayerName, EvPlayerLeave, EvFlightToggle, EvRevenge:
 			send = true
 		case EvHit:
 			send = e.Player == target.Id || e.Victim == target.Id

--- a/server/sim.go
+++ b/server/sim.go
@@ -77,6 +77,7 @@ const (
 	CrouchingHeight = 1.3
 	FlightSpeed     = WalkSpeed
 	MaxFlightHeight = StandingHeight * 25
+	RevengeDeathThreshold uint8 = 10
 )
 
 type PlayerState struct {
@@ -96,6 +97,9 @@ type PlayerState struct {
 	LandingUntil, AimStarted, SpeedUntil                           time.Time
 	Grenades                                                       int
 	Kills, Deaths                                                  uint16
+	NoKillDeaths                                                   uint8
+	RevengeReady, RevengeActive                                    bool
+	RevengeShots                                                   uint8
 	LastInputSeq, LastShotSeq                                      uint16
 	HasShot                                                        bool
 	LastShotAt                                                     time.Time
@@ -336,7 +340,9 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 	p.LastShotAt = now
 	p.ShotCounter++
 	if p.ProtectedAt(now) {
-		p.InvincibleUntil = time.Time{}
+		if !p.RevengeActive {
+			p.InvincibleUntil = time.Time{}
+		}
 	}
 
 	origin := Vec3{p.Pos.X, p.Pos.Y + EyeHeight, p.Pos.Z}
@@ -366,6 +372,23 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 	if r.tick-seenTick > MaxRewindTicks {
 		seenTick = r.tick - MaxRewindTicks
 	}
+	// Revenge is a fixed 10-bullet budget: every gunshot counts, with or without a
+	// lock. Invincibility can expire independently without ending the budget.
+	if p.RevengeActive && p.RevengeShots > 0 && isGun(uint8(weapon)) {
+		if target := r.revengeTarget(p, yaw, pitch, origin, seenTick, now); target != nil {
+			r.Damage(p, target, def.Dmg*def.HeadMult, true, uint8(weapon), now)
+			p.RevengeShots--
+			if p.RevengeShots == 0 {
+				p.RevengeActive = false
+			}
+			return true
+		}
+		p.RevengeShots--
+		if p.RevengeShots == 0 {
+			p.RevengeActive = false
+		}
+	}
+
 	pellets := 1
 	if isGun(uint8(weapon)) && def.Pellets > 1 {
 		pellets = def.Pellets
@@ -419,6 +442,97 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 	return true
 }
 
+func (r *Room) revengeTarget(attacker *PlayerState, yaw, pitch float64, origin Vec3, seenTick uint32, now time.Time) *PlayerState {
+	var best *PlayerState
+	bestScore := math.MaxFloat64
+	forward, right, up := viewAxes(yaw, pitch)
+	// Cover a full on-screen rectangle (75° vertical, 21:9 horizontal) so any
+	// enemy in view locks, not only someone near the crosshair.
+	tanV := math.Tan(37.5 * math.Pi / 180)
+	tanH := tanV * 21 / 9
+	for _, other := range r.Players {
+		target := &other.PlayerState
+		if target == attacker || !target.Alive || target.ProtectedAt(now) {
+			continue
+		}
+		pose := r.poseAt(target.Id, seenTick, target.Pos, target.Crouch)
+		height := StandingHeight
+		if pose.Crouch {
+			height = CrouchingHeight
+		}
+		visible, centerDot, dist := r.revengeVisible(origin, forward, right, up, pose.Pos, height, tanH, tanV)
+		if !visible {
+			continue
+		}
+		score := (1-centerDot)*100 + dist*.001
+		if score < bestScore {
+			best, bestScore = target, score
+		}
+	}
+	return best
+}
+
+func viewAxes(yaw, pitch float64) (forward, right, up Vec3) {
+	forward = AimDir(yaw, pitch)
+	right = norm(Vec3{-forward.Z, 0, forward.X})
+	if right.X == 0 && right.Z == 0 {
+		right = Vec3{1, 0, 0}
+	}
+	up = Vec3{
+		right.Y*forward.Z - right.Z*forward.Y,
+		right.Z*forward.X - right.X*forward.Z,
+		right.X*forward.Y - right.Y*forward.X,
+	}
+	return
+}
+
+func inViewFrustum(origin, forward, right, up, point Vec3, tanH, tanV float64) (dot, dist float64, ok bool) {
+	to := Vec3{point.X - origin.X, point.Y - origin.Y, point.Z - origin.Z}
+	dist = math.Sqrt(to.X*to.X + to.Y*to.Y + to.Z*to.Z)
+	if dist <= 0.05 {
+		return 0, dist, false
+	}
+	z := to.X*forward.X + to.Y*forward.Y + to.Z*forward.Z
+	if z <= 0.05 {
+		return 0, dist, false
+	}
+	x := to.X*right.X + to.Y*right.Y + to.Z*right.Z
+	y := to.X*up.X + to.Y*up.Y + to.Z*up.Z
+	if math.Abs(x) > z*tanH || math.Abs(y) > z*tanV {
+		return 0, dist, false
+	}
+	return z / dist, dist, true
+}
+
+func (r *Room) revengeVisible(origin, forward, right, up, pos Vec3, height, tanH, tanV float64) (bool, float64, float64) {
+	points := []Vec3{
+		{pos.X, pos.Y + height - .12, pos.Z},
+		{pos.X, pos.Y + height*.55, pos.Z},
+		{pos.X, pos.Y + .2, pos.Z},
+		{pos.X + PlayerHalf, pos.Y + height*.55, pos.Z},
+		{pos.X - PlayerHalf, pos.Y + height*.55, pos.Z},
+		{pos.X, pos.Y + height*.55, pos.Z + PlayerHalf},
+		{pos.X, pos.Y + height*.55, pos.Z - PlayerHalf},
+	}
+	bestDot, bestDist := -1.0, math.MaxFloat64
+	any := false
+	for _, point := range points {
+		dot, dist, ok := inViewFrustum(origin, forward, right, up, point, tanH, tanV)
+		if !ok {
+			continue
+		}
+		line := norm(Vec3{point.X - origin.X, point.Y - origin.Y, point.Z - origin.Z})
+		if hit, distance := r.World.Raycast(origin, line, dist); hit && distance < dist-.05 {
+			continue
+		}
+		any = true
+		if dot > bestDot {
+			bestDot, bestDist = dot, dist
+		}
+	}
+	return any, bestDot, bestDist
+}
+
 func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool, weapon uint8, now time.Time) {
 	if !victim.Alive || victim.ProtectedAt(now) {
 		return
@@ -442,6 +556,16 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	r.Emit(Event{Type: EvKill, Killer: attacker.Id, Victim: victim.Id, Weapon: weapon, Headshot: hs})
 	attacker.Kills++
 	victim.Deaths++
+	// A kill breaks the attacker's consecutive zero-kill/death streak.
+	attacker.NoKillDeaths = 0
+	if !victim.IsBot {
+		victim.NoKillDeaths++
+		if victim.NoKillDeaths >= RevengeDeathThreshold {
+			// Consume the accumulated consecutive deaths when arming revenge.
+			victim.RevengeReady = true
+			victim.NoKillDeaths = 0
+		}
+	}
 	if !attacker.IsBot {
 		r.Store.Accumulate(attacker.Account, 1, 0)
 		if !victim.IsBot && isGun(weapon) {
@@ -452,6 +576,8 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 		r.Store.Accumulate(victim.Account, 0, 1)
 	}
 	victim.Alive, victim.Reloading = false, false
+	victim.RevengeActive, victim.RevengeShots = false, 0
+	victim.InvincibleUntil = time.Time{}
 	victim.RespawnAt = now.Add(RespawnDelayS)
 }
 
@@ -495,6 +621,13 @@ func (r *Room) Respawn(p *PlayerState, now time.Time) {
 	p.CmdKeys = 0
 	p.ApplyLoadout(p.Primary, p.Secondary)
 	p.InvincibleUntil = now.Add(SpawnProtectS)
+	if p.RevengeReady && !p.IsBot {
+		p.RevengeActive = true
+		p.RevengeShots = 10
+		p.InvincibleUntil = now.Add(10 * time.Second)
+		r.Emit(Event{Type: EvRevenge, Player: p.Id, Name: p.Name})
+	}
+	p.RevengeReady = false
 	p.LandingUntil, p.AimStarted = time.Time{}, time.Time{}
 	p.SpeedUntil = time.Time{}
 	p.RespawnAt = time.Time{}


### PR DESCRIPTION
## Summary
- 真人玩家连续死亡 10 次（期间无击杀）后，下次重生进入复仇模式；bot 不计连死，也不会进入复仇。
- 复仇期间获得 10 秒无敌，以及固定 10 发枪械预算：画面内有敌人则开枪即爆头（无需瞄准），屏幕没人也扣发数；无敌结束不中断这 10 发。
- 新增 `EvRevenge` 广播与 HUD 横幅「来复仇了！」；协议版本升至 7。

## Test plan
- [ ] 真人连续死亡 10 次且中途没有击杀，重生时应看到复仇横幅，并有 10 秒无敌。
- [ ] 画面内有敌人时开枪应直接爆头；身后或完全被墙挡住的目标不应被锁定。
- [ ] 空枪、屏幕无人时仍消耗复仇发数，打满 10 发后自瞄结束。
- [ ] 无敌时间先结束时，剩余发数仍可继续自瞄爆头。
- [ ] 中途击杀他人应清零连死计数，不会误进复仇。
- [ ] bot 死亡不应进入复仇，也不会触发复仇广播。


Made with [Cursor](https://cursor.com)