### PR TITLE
feat(ui): 准星自定义设置 + 模拟练习场

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -443,6 +443,9 @@
     }
     #join-btn:hover { background: var(--accent-hi); transform: translate(-1px, -1px); box-shadow: inset 0 -5px 0 #87521b, 7px 7px 0 #080a08; }
     #join-btn:active { transform: translate(2px, 3px); box-shadow: inset 0 -3px 0 #87521b, 2px 2px 0 #080a08; }
+    .deploy-action-wrap { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: stretch; }
+    #practice-join-btn { min-height: 58px; padding: 8px 18px; font: 700 15px var(--font-display); letter-spacing: .05em; white-space: nowrap; }
+    #settings-modal .dialog-actions { grid-template-columns: 1fr 1fr 1fr; }
 
     .section-head { display: flex; justify-content: space-between; align-items: end; gap: 10px; }
     .section-head h2 { font: 25px var(--font-display); letter-spacing: .04em; }
@@ -703,28 +706,47 @@
       position: fixed;
       left: 50%;
       top: 50%;
-      width: 2px;
-      height: 2px;
+      width: 0;
+      height: 0;
       transform: translate(-50%, -50%);
       pointer-events: none;
       contain: layout style;
       --spread: 3px;
       --crosshair-color: #f4f1e4;
+      --ch-size: 7px;
+      --ch-thickness: 2px;
+      --ch-dot: 2px;
     }
-    .ch-line, .ch-dot { position: absolute; left: 0; top: 0; background: var(--crosshair-color); box-shadow: 0 0 0 1px rgb(11 13 11 / .88); }
+    .ch-line, .ch-dot, .ch-ring { position: absolute; left: 0; top: 0; }
+    .ch-line, .ch-dot { background: var(--crosshair-color); }
     .ch-line { will-change: transform; transition: background-color 90ms linear, opacity 90ms linear; }
-    .ch-top, .ch-bot { width: 2px; height: 7px; }
-    .ch-top { transform: translate3d(0, calc(-100% - var(--spread)), 0); }
-    .ch-bot { transform: translate3d(0, calc(2px + var(--spread)), 0); }
-    .ch-left, .ch-right { width: 7px; height: 2px; }
-    .ch-left { transform: translate3d(calc(-100% - var(--spread)), 0, 0); }
-    .ch-right { transform: translate3d(calc(2px + var(--spread)), 0, 0); }
-    .ch-dot { width: 2px; height: 2px; background: var(--accent-hi); box-shadow: 0 0 0 1px rgb(11 13 11 / .9), 0 0 5px rgb(255 185 46 / .34); }
+    .ch-ring { box-sizing: border-box; }
+    .ch-top, .ch-bot { width: var(--ch-thickness); height: var(--ch-size); }
+    .ch-top { transform: translate3d(calc(var(--ch-thickness) / -2), calc(-100% - var(--spread)), 0); }
+    .ch-bot { transform: translate3d(calc(var(--ch-thickness) / -2), var(--spread), 0); }
+    .ch-left, .ch-right { width: var(--ch-size); height: var(--ch-thickness); }
+    .ch-left { transform: translate3d(calc(-100% - var(--spread)), calc(var(--ch-thickness) / -2), 0); }
+    .ch-right { transform: translate3d(var(--spread), calc(var(--ch-thickness) / -2), 0); }
+    .ch-dot { width: var(--ch-dot); height: var(--ch-dot); transform: translate3d(calc(var(--ch-dot) / -2), calc(var(--ch-dot) / -2), 0); box-shadow: 0 0 0 1px rgb(11 13 11 / .9), 0 0 5px rgb(255 185 46 / .34); }
+    .ch-ring { width: var(--ch-size); height: var(--ch-size); border: var(--ch-thickness) solid var(--crosshair-color); border-radius: 50%; transform: translate3d(calc(var(--ch-size) / -2), calc(var(--ch-size) / -2), 0); }
+    .crosshair-widget:not([data-custom-color]) .ch-dot, .crosshair-widget[data-custom-color="off"] .ch-dot { background: var(--accent-hi); }
+    .crosshair-widget[data-outline="on"] .ch-line { box-shadow: 0 0 0 1px rgb(11 13 11 / .88); }
+    .crosshair-widget[data-outline="off"] .ch-line { box-shadow: none; }
+    .crosshair-widget:not([data-outline]) .ch-line { box-shadow: 0 0 0 1px rgb(11 13 11 / .88); }
+    .crosshair-widget[data-dot="off"] .ch-dot { display: none; }
+    .crosshair-widget[data-style="cross"] .ch-dot { display: none; }
+    .crosshair-widget[data-style="t"] .ch-bot { display: none; }
+    .crosshair-widget[data-style="dot"] .ch-line, .crosshair-widget[data-style="dot"] .ch-ring { display: none; }
+    .crosshair-widget[data-style="dot"] .ch-dot { width: var(--ch-size); height: var(--ch-size); transform: translate3d(calc(var(--ch-size) / -2), calc(var(--ch-size) / -2), 0); }
+    .crosshair-widget[data-style="ring"] .ch-line, .crosshair-widget[data-style="ring"] .ch-dot { display: none; }
+    .crosshair-widget[data-style="none"] .ch-line, .crosshair-widget[data-style="none"] .ch-dot, .crosshair-widget[data-style="none"] .ch-ring { display: none; }
+    .crosshair-widget:not([data-style="ring"]) .ch-ring { display: none; }
     #crosshair[data-accuracy="warm"] { --crosshair-color: #efc464; }
     #crosshair[data-accuracy="wide"] { --crosshair-color: #df8068; }
     #crosshair[data-accuracy="wide"] .ch-line { opacity: .86; }
     #crosshair.reloading .ch-line { background: var(--accent-hi); opacity: 0.55; }
-    #crosshair.reloading .ch-dot { background: var(--accent-hi); transform: scale(1.6); box-shadow: 0 0 6px var(--accent-hi); }
+    #crosshair.reloading .ch-dot { background: var(--accent-hi); transform: translate3d(calc(var(--ch-dot) / -2), calc(var(--ch-dot) / -2), 0) scale(1.6); box-shadow: 0 0 6px var(--accent-hi); }
+    #crosshair[data-style="dot"].reloading .ch-dot { transform: translate3d(calc(var(--ch-size) / -2), calc(var(--ch-size) / -2), 0) scale(1.6); }
     #grenade-ready {
       position: fixed;
       left: 50%;
@@ -1116,7 +1138,77 @@
     #disconnect-overlay.upgrade .disconnect-progress::after { width: 100%; background: var(--accent); animation: upgrade-progress var(--upgrade-duration, 2s) linear forwards; transform-origin: left; }
     .dialog-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 16px; }
     .dialog-actions button { min-height: 42px; }
-    .settings-stack { display: grid; gap: 13px; margin-top: 16px; }
+    .settings-stack { display: grid; gap: 18px; margin-top: 16px; }
+    .settings-group { display: grid; gap: 11px; }
+    .settings-group-label {
+      margin: 0;
+      padding-bottom: 6px;
+      border-bottom: 1px solid var(--line);
+      color: var(--accent-hi);
+      font: 700 11px var(--font-mono);
+      letter-spacing: .14em;
+      text-transform: uppercase;
+    }
+    #settings-modal .dialog { max-height: calc(100dvh - 36px); overflow-y: auto; }
+    .ch-color-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .ch-swatch {
+      position: relative;
+      width: 26px;
+      height: 26px;
+      border: 1px solid var(--line-strong);
+      border-radius: 0;
+      background: var(--panel-2);
+    }
+    .ch-swatch.active { border-color: var(--accent-hi); box-shadow: 0 0 0 2px var(--accent); }
+    .ch-swatch[data-color=""]::before, .ch-swatch[data-color=""]::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      background: var(--muted);
+    }
+    .ch-swatch[data-color=""]::before { width: 13px; height: 2px; transform: translate(-50%, -50%); }
+    .ch-swatch[data-color=""]::after { width: 2px; height: 13px; transform: translate(-50%, -50%); }
+    #ch-color-input {
+      width: 34px;
+      height: 30px;
+      padding: 0;
+      border: 1px solid var(--line-strong);
+      border-radius: 0;
+      background: transparent;
+      cursor: pointer;
+    }
+    .ch-toggle-grid { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; }
+    .ch-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--muted);
+      font: 700 11px var(--font-mono);
+      letter-spacing: .05em;
+      cursor: pointer;
+    }
+    .ch-toggle input { width: 16px; height: 16px; accent-color: var(--accent); cursor: pointer; }
+    .ch-preview-box {
+      position: relative;
+      min-height: 96px;
+      border: 1px dashed var(--line);
+      background: radial-gradient(circle at 50% 50%, #0d1413 0%, #131a16 100%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+    #crosshair-preview {
+      position: relative;
+      width: 0;
+      height: 0;
+      --spread: 3px;
+      --crosshair-color: #f4f1e4;
+      --ch-size: 7px;
+      --ch-thickness: 2px;
+      --ch-dot: 2px;
+    }
     input[type="range"] {
       width: 100%;
       accent-color: var(--accent);
@@ -1186,6 +1278,8 @@
       .deploy-title { font-size: 44px; }
       .deploy-title span:last-child { font-size: .7em; }
       .loadout-grid, .dialog-actions { grid-template-columns: 1fr; }
+      #settings-modal .dialog-actions { grid-template-columns: 1fr; }
+      .deploy-action-wrap { grid-template-columns: 1fr; }
       .field.full { grid-column: auto; }
       .stat-grid { grid-template-columns: 1fr 1fr; }
       .metric { padding-inline: 7px; }
@@ -1322,6 +1416,7 @@
 
           <div class="deploy-action-wrap" style="margin-top: 10px;">
             <button id="join-btn" type="button">进入战场</button>
+            <button id="practice-join-btn" class="ghost-button" type="button" title="在空地图中测试准星与手感，不连接服务器">模拟练习</button>
           </div>
         </section>
 
@@ -1387,9 +1482,9 @@
       </svg>
     </div>
     <div id="player-labels" aria-hidden="true"></div>
-    <div id="crosshair" aria-hidden="true">
+    <div id="crosshair" class="crosshair-widget" aria-hidden="true">
       <div class="ch-line ch-top"></div><div class="ch-line ch-bot"></div>
-      <div class="ch-line ch-left"></div><div class="ch-line ch-right"></div><div class="ch-dot"></div>
+      <div class="ch-line ch-left"></div><div class="ch-line ch-right"></div><div class="ch-dot"></div><div class="ch-ring"></div>
     </div>
     <div id="sniper-scope" aria-hidden="true">
       <div class="scope-lens">
@@ -1517,38 +1612,106 @@
   <div id="settings-modal" class="overlay" role="dialog" aria-modal="true" aria-labelledby="settings-title">
     <div class="dialog">
       <div class="dialog-label">CLIENT SETTINGS</div>
-      <h2 id="settings-title">控制与画质</h2>
+      <h2 id="settings-title">设置</h2>
       <div class="settings-stack">
-        <div class="field">
-          <label for="sens-slider">鼠标灵敏度</label>
-          <input id="sens-slider" type="range" min="10" max="100" value="45">
-        </div>
-        <div class="field">
-          <label for="ads-sens-slider">开镜灵敏度</label>
-          <input id="ads-sens-slider" type="range" min="25" max="125" value="85">
-        </div>
-        <div class="field">
-          <label for="vol-slider">音效音量</label>
-          <input id="vol-slider" type="range" min="0" max="100" value="80">
-        </div>
-        <div class="field">
-          <label for="quality-select">渲染画质</label>
-          <select class="control" id="quality-select">
-            <option value="low">流畅 / 0.75 ×</option>
-            <option value="medium" selected>平衡 / 1.0 ×</option>
-            <option value="high">超清 / DPR 1.5</option>
-          </select>
-        </div>
-        <div class="field">
-          <label for="fov-slider">视野 FOV</label>
-          <input id="fov-slider" type="range" min="55" max="100" value="62">
-        </div>
-        <div class="field">
-          <label for="bob-slider">持枪手感</label>
-          <input id="bob-slider" type="range" min="0" max="100" value="55">
-        </div>
+        <section class="settings-group">
+          <h3 class="settings-group-label">瞄准 / AIM</h3>
+          <div class="field">
+            <label for="sens-slider">鼠标灵敏度</label>
+            <input id="sens-slider" type="range" min="10" max="100" value="45">
+          </div>
+          <div class="field">
+            <label for="ads-sens-slider">开镜灵敏度</label>
+            <input id="ads-sens-slider" type="range" min="25" max="125" value="85">
+          </div>
+        </section>
+
+        <section class="settings-group">
+          <h3 class="settings-group-label">准星 / CROSSHAIR</h3>
+          <div class="field">
+            <label for="ch-style-select">准星样式</label>
+            <select class="control" id="ch-style-select">
+              <option value="cross-dot" selected>十字 + 中心点</option>
+              <option value="cross">经典十字</option>
+              <option value="t">T 形</option>
+              <option value="dot">单点</option>
+              <option value="ring">圆环</option>
+              <option value="none">关闭准星</option>
+            </select>
+          </div>
+          <div class="field">
+            <label>准星颜色</label>
+            <div class="ch-color-row">
+              <button class="ch-swatch active" type="button" data-color="" aria-label="默认动态颜色" title="默认（随精度动态变色）"></button>
+              <button class="ch-swatch" type="button" data-color="#f4f1e4" style="background:#f4f1e4" aria-label="经典白" title="经典白"></button>
+              <button class="ch-swatch" type="button" data-color="#ef4444" style="background:#ef4444" aria-label="红" title="红"></button>
+              <button class="ch-swatch" type="button" data-color="#22c55e" style="background:#22c55e" aria-label="绿" title="绿"></button>
+              <button class="ch-swatch" type="button" data-color="#38bdf8" style="background:#38bdf8" aria-label="蓝" title="蓝"></button>
+              <button class="ch-swatch" type="button" data-color="#eab308" style="background:#eab308" aria-label="黄" title="黄"></button>
+              <button class="ch-swatch" type="button" data-color="#f97316" style="background:#f97316" aria-label="橙" title="橙"></button>
+              <input id="ch-color-input" type="color" value="#f4f1e4" aria-label="自定义颜色" title="自定义颜色">
+            </div>
+          </div>
+          <div class="field">
+            <label for="ch-size-slider">准星大小</label>
+            <input id="ch-size-slider" type="range" min="4" max="20" value="7">
+          </div>
+          <div class="field">
+            <label for="ch-thick-slider">准星粗细</label>
+            <input id="ch-thick-slider" type="range" min="1" max="5" value="2">
+          </div>
+          <div class="field">
+            <label for="ch-gap-slider">准星间距</label>
+            <input id="ch-gap-slider" type="range" min="0" max="12" value="3">
+          </div>
+          <div class="ch-toggle-grid">
+            <label class="ch-toggle"><input id="ch-dot-toggle" type="checkbox" checked><span>中心点</span></label>
+            <label class="ch-toggle"><input id="ch-outline-toggle" type="checkbox" checked><span>描边</span></label>
+            <label class="ch-toggle"><input id="ch-dynamic-toggle" type="checkbox" checked><span>动态准星</span></label>
+          </div>
+          <div class="field">
+            <label>准星预览</label>
+            <div class="ch-preview-box">
+              <div id="crosshair-preview" class="crosshair-widget" aria-hidden="true">
+                <div class="ch-line ch-top"></div><div class="ch-line ch-bot"></div>
+                <div class="ch-line ch-left"></div><div class="ch-line ch-right"></div>
+                <div class="ch-dot"></div><div class="ch-ring"></div>
+              </div>
+            </div>
+          </div>
+          <button class="ghost-button" id="ch-reset-btn" type="button">恢复默认准星</button>
+        </section>
+
+        <section class="settings-group">
+          <h3 class="settings-group-label">音效 / AUDIO</h3>
+          <div class="field">
+            <label for="vol-slider">音效音量</label>
+            <input id="vol-slider" type="range" min="0" max="100" value="80">
+          </div>
+        </section>
+
+        <section class="settings-group">
+          <h3 class="settings-group-label">画面 / GRAPHICS</h3>
+          <div class="field">
+            <label for="quality-select">渲染画质</label>
+            <select class="control" id="quality-select">
+              <option value="low">流畅 / 0.75 ×</option>
+              <option value="medium" selected>平衡 / 1.0 ×</option>
+              <option value="high">超清 / DPR 1.5</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="fov-slider">视野 FOV</label>
+            <input id="fov-slider" type="range" min="55" max="100" value="62">
+          </div>
+          <div class="field">
+            <label for="bob-slider">持枪手感</label>
+            <input id="bob-slider" type="range" min="0" max="100" value="55">
+          </div>
+        </section>
       </div>
       <div class="dialog-actions">
+        <button class="secondary-button" id="practice-btn" type="button" title="用当前准星设置在空地图中测试手感">进入模拟</button>
         <button class="secondary-button" id="close-settings-btn" type="button">保存并返回</button>
         <button class="danger-button" id="exit-btn" type="button">退出战场</button>
       </div>

--- a/client/src/hud.ts
+++ b/client/src/hud.ts
@@ -68,10 +68,19 @@ export class Hud {
   hipFov = 62;
   bobScale = 0.55;
   quality: 'low' | 'medium' | 'high' = 'medium';
+  crosshairStyle: string = 'cross-dot';
+  crosshairColor: string = '';
+  crosshairSize = 7;
+  crosshairThickness = 2;
+  crosshairGap = 3;
+  crosshairDot = true;
+  crosshairOutline = true;
+  crosshairDynamic = true;
   private loadoutPrimary = -1;
   private loadoutSecondary = -1;
   characterPreview: CharacterPreview | null = null;
   onJoin: ((name: string, primary: number, secondary: number, skin: number, primaryWeaponSkin: number, secondaryWeaponSkin: number) => void) | null = null;
+  onPractice: (() => void) | null = null;
   onVolumeChange: ((v: number) => void) | null = null;
   onFovChange: ((fov: number) => void) | null = null;
   onQualityChange: ((q: 'low' | 'medium' | 'high') => void) | null = null;
@@ -110,6 +119,7 @@ export class Hud {
   private lastShield = false;
   private lastScope: boolean | null = null;
   private lastCrosshair = -1;
+  private lastDynamic = true;
   private lastDeathCountdown = -2;
   private lastReloading: boolean | null = null;
   private lastReloadPct = -1;
@@ -273,18 +283,14 @@ export class Hud {
             clearInterval(timer);
             setTimeout(() => {
               deployOverlay.style.display = 'none';
-              this.menu.style.display = 'none';
-              this.characterPreview?.setVisible(false);
-              this.root.style.display = 'block';
+              this.enterGameUI();
               deploying = false;
               this.onJoin?.(n, this.loadoutPrimary, this.loadoutSecondary, this.characterPreview?.getSkin() ?? 0, +primaryWeaponSkin.value, +secondaryWeaponSkin.value);
             }, 140);
           }
         }, 32);
       } else {
-        this.menu.style.display = 'none';
-        this.characterPreview?.setVisible(false);
-        this.root.style.display = 'block';
+        this.enterGameUI();
         this.onJoin?.(n, this.loadoutPrimary, this.loadoutSecondary, this.characterPreview?.getSkin() ?? 0, +primaryWeaponSkin.value, +secondaryWeaponSkin.value);
       }
     };
@@ -361,15 +367,198 @@ export class Hud {
       localStorage.setItem('ps_gun_bob', bob.value);
     });
 
+    const chStyle = el('ch-style-select') as HTMLSelectElement;
+    const chColorInput = el('ch-color-input') as HTMLInputElement;
+    const chSize = el('ch-size-slider') as HTMLInputElement;
+    const chThick = el('ch-thick-slider') as HTMLInputElement;
+    const chGap = el('ch-gap-slider') as HTMLInputElement;
+    const chDot = el('ch-dot-toggle') as HTMLInputElement;
+    const chOutline = el('ch-outline-toggle') as HTMLInputElement;
+    const chDynamic = el('ch-dynamic-toggle') as HTMLInputElement;
+    const chReset = el('ch-reset-btn') as HTMLButtonElement;
+
+    this.crosshairStyle = localStorage.getItem('ps_ch_style') ?? 'cross-dot';
+    this.crosshairColor = localStorage.getItem('ps_ch_color') ?? '';
+    this.crosshairSize = +(localStorage.getItem('ps_ch_size') ?? '7');
+    this.crosshairThickness = +(localStorage.getItem('ps_ch_thick') ?? '2');
+    this.crosshairGap = +(localStorage.getItem('ps_ch_gap') ?? '3');
+    this.crosshairDot = (localStorage.getItem('ps_ch_dot') ?? '1') !== '0';
+    this.crosshairOutline = (localStorage.getItem('ps_ch_outline') ?? '1') !== '0';
+    this.crosshairDynamic = (localStorage.getItem('ps_ch_dynamic') ?? '1') !== '0';
+
+    if (chStyle) chStyle.value = this.crosshairStyle;
+    if (chColorInput) chColorInput.value = this.crosshairColor || '#f4f1e4';
+    if (chSize) chSize.value = String(this.crosshairSize);
+    if (chThick) chThick.value = String(this.crosshairThickness);
+    if (chGap) chGap.value = String(this.crosshairGap);
+    if (chDot) chDot.checked = this.crosshairDot;
+    if (chOutline) chOutline.checked = this.crosshairOutline;
+    if (chDynamic) chDynamic.checked = this.crosshairDynamic;
+    for (const s of document.querySelectorAll<HTMLButtonElement>('.ch-swatch')) {
+      s.classList.toggle('active', s.dataset.color === this.crosshairColor);
+    }
+
+    const saveCrosshair = () => {
+      localStorage.setItem('ps_ch_style', this.crosshairStyle);
+      localStorage.setItem('ps_ch_size', String(this.crosshairSize));
+      localStorage.setItem('ps_ch_thick', String(this.crosshairThickness));
+      localStorage.setItem('ps_ch_gap', String(this.crosshairGap));
+      localStorage.setItem('ps_ch_dot', this.crosshairDot ? '1' : '0');
+      localStorage.setItem('ps_ch_outline', this.crosshairOutline ? '1' : '0');
+      localStorage.setItem('ps_ch_dynamic', this.crosshairDynamic ? '1' : '0');
+    };
+
+    chStyle?.addEventListener('change', () => {
+      this.crosshairStyle = chStyle.value;
+      saveCrosshair();
+      this.applyCrosshair();
+      this.updateCrosshairPreview();
+    });
+    chSize?.addEventListener('input', () => {
+      this.crosshairSize = +chSize.value;
+      saveCrosshair();
+      this.applyCrosshair();
+      this.updateCrosshairPreview();
+    });
+    chThick?.addEventListener('input', () => {
+      this.crosshairThickness = +chThick.value;
+      saveCrosshair();
+      this.applyCrosshair();
+      this.updateCrosshairPreview();
+    });
+    chGap?.addEventListener('input', () => {
+      this.crosshairGap = +chGap.value;
+      saveCrosshair();
+      this.applyCrosshair();
+      this.updateCrosshairPreview();
+    });
+    chDot?.addEventListener('change', () => {
+      this.crosshairDot = chDot.checked;
+      saveCrosshair();
+      this.applyCrosshair();
+      this.updateCrosshairPreview();
+    });
+    chOutline?.addEventListener('change', () => {
+      this.crosshairOutline = chOutline.checked;
+      saveCrosshair();
+      this.applyCrosshair();
+      this.updateCrosshairPreview();
+    });
+    chDynamic?.addEventListener('change', () => {
+      this.crosshairDynamic = chDynamic.checked;
+      saveCrosshair();
+      this.applyCrosshair();
+      this.updateCrosshairPreview();
+    });
+    for (const s of document.querySelectorAll<HTMLButtonElement>('.ch-swatch')) {
+      s.addEventListener('click', () => this.setCrosshairColor(s.dataset.color ?? ''));
+    }
+    chColorInput?.addEventListener('input', () => this.setCrosshairColor(chColorInput.value));
+    chReset?.addEventListener('click', () => this.resetCrosshair());
+
+    this.applyCrosshair();
+    this.updateCrosshairPreview();
+
     el('open-settings-btn')?.addEventListener('click', () => this.toggleSettings(true));
     el('close-settings-btn')?.addEventListener('click', () => this.toggleSettings(false));
     el('exit-btn')?.addEventListener('click', () => this.onExit?.());
+    el('practice-btn')?.addEventListener('click', () => this.startPractice());
+    el('practice-join-btn')?.addEventListener('click', () => this.startPractice());
     el('pause-resume-btn')?.addEventListener('click', () => this.showPause(false));
     el('pause-flight-btn')?.addEventListener('click', () => this.onFlightToggle?.());
     el('pause-exit-btn')?.addEventListener('click', () => this.onExit?.());
   }
 
+  applyCrosshair() {
+    this.crosshair.dataset.style = this.crosshairStyle;
+    this.crosshair.dataset.outline = this.crosshairOutline ? 'on' : 'off';
+    this.crosshair.dataset.dot = this.crosshairDot ? 'on' : 'off';
+    this.crosshair.dataset.customColor = this.crosshairColor ? 'on' : 'off';
+    if (this.crosshairColor) this.crosshair.style.setProperty('--crosshair-color', this.crosshairColor);
+    else this.crosshair.style.removeProperty('--crosshair-color');
+    this.crosshair.style.setProperty('--ch-size', `${this.crosshairSize}px`);
+    this.crosshair.style.setProperty('--ch-thickness', `${this.crosshairThickness}px`);
+    this.crosshair.style.setProperty('--ch-dot', `${this.crosshairThickness}px`);
+    this.setCrosshair(this.lastCrosshair);
+  }
 
+  updateCrosshairPreview() {
+    const preview = document.getElementById('crosshair-preview');
+    if (!preview) return;
+    preview.dataset.style = this.crosshairStyle;
+    preview.dataset.outline = this.crosshairOutline ? 'on' : 'off';
+    preview.dataset.dot = this.crosshairDot ? 'on' : 'off';
+    preview.dataset.customColor = this.crosshairColor ? 'on' : 'off';
+    if (this.crosshairColor) preview.style.setProperty('--crosshair-color', this.crosshairColor);
+    else preview.style.removeProperty('--crosshair-color');
+    preview.style.setProperty('--ch-size', `${this.crosshairSize}px`);
+    preview.style.setProperty('--ch-thickness', `${this.crosshairThickness}px`);
+    preview.style.setProperty('--ch-dot', `${this.crosshairThickness}px`);
+    preview.style.setProperty('--spread', `${this.crosshairGap}px`);
+  }
+
+  private setCrosshairColor(color: string) {
+    this.crosshairColor = color;
+    localStorage.setItem('ps_ch_color', color);
+    const input = el('ch-color-input') as HTMLInputElement | null;
+    if (input) input.value = color || '#f4f1e4';
+    for (const s of document.querySelectorAll<HTMLButtonElement>('.ch-swatch')) {
+      s.classList.toggle('active', s.dataset.color === color);
+    }
+    this.applyCrosshair();
+    this.updateCrosshairPreview();
+  }
+
+  resetCrosshair() {
+    this.crosshairStyle = 'cross-dot';
+    this.crosshairColor = '';
+    this.crosshairSize = 7;
+    this.crosshairThickness = 2;
+    this.crosshairGap = 3;
+    this.crosshairDot = true;
+    this.crosshairOutline = true;
+    this.crosshairDynamic = true;
+    for (const key of ['style', 'color', 'size', 'thick', 'gap', 'dot', 'outline', 'dynamic']) {
+      localStorage.removeItem(`ps_ch_${key}`);
+    }
+    const style = el('ch-style-select') as HTMLSelectElement;
+    if (style) style.value = this.crosshairStyle;
+    const size = el('ch-size-slider') as HTMLInputElement;
+    if (size) size.value = String(this.crosshairSize);
+    const thick = el('ch-thick-slider') as HTMLInputElement;
+    if (thick) thick.value = String(this.crosshairThickness);
+    const gap = el('ch-gap-slider') as HTMLInputElement;
+    if (gap) gap.value = String(this.crosshairGap);
+    const dot = el('ch-dot-toggle') as HTMLInputElement;
+    if (dot) dot.checked = true;
+    const outline = el('ch-outline-toggle') as HTMLInputElement;
+    if (outline) outline.checked = true;
+    const dyn = el('ch-dynamic-toggle') as HTMLInputElement;
+    if (dyn) dyn.checked = true;
+    this.setCrosshairColor('');
+  }
+
+  private enterGameUI() {
+    this.menu.style.display = 'none';
+    this.characterPreview?.setVisible(false);
+    this.root.style.display = 'block';
+  }
+
+  startPractice() {
+    this.toggleSettings(false);
+    this.enterGameUI();
+    this.onPractice?.();
+  }
+
+  setPractice() {
+    const strip = el('match-strip');
+    const middle = strip?.children[1];
+    if (middle) middle.textContent = '模拟练习 · PRACTICE';
+    const shield = el('shield-badge');
+    if (shield) shield.style.display = 'none';
+    const netStats = el('net-stats');
+    if (netStats) netStats.style.display = 'none';
+  }
 
   setMap(map: MapData) {
     this.map = map;
@@ -621,11 +810,14 @@ export class Hud {
   }
 
   setCrosshair(spread: number) {
-    const px = Math.round(Math.max(2, Math.min(32, spread)));
-    if (px === this.lastCrosshair) return;
+    const dynamic = this.crosshairDynamic;
+    const gap = this.crosshairGap;
+    const px = dynamic ? Math.max(gap, Math.min(32, Math.round(spread))) : gap;
+    if (px === this.lastCrosshair && dynamic === this.lastDynamic) return;
     this.lastCrosshair = px;
+    this.lastDynamic = dynamic;
     this.crosshair.style.setProperty('--spread', `${px}px`);
-    this.crosshair.dataset.accuracy = px < 7 ? 'tight' : px < 14 ? 'warm' : 'wide';
+    this.crosshair.dataset.accuracy = dynamic ? (px < 7 ? 'tight' : px < 14 ? 'warm' : 'wide') : 'fixed';
   }
 
 
@@ -793,6 +985,13 @@ export class Hud {
     if (this.pause) this.pause.style.display = 'none';
     if (this.settings) this.settings.style.display = 'none';
     if (this.scoreboard) this.scoreboard.style.display = 'none';
+    const strip = el('match-strip');
+    const middle = strip?.children[1];
+    if (middle) middle.textContent = '黄昏要塞';
+    const shield = el('shield-badge');
+    if (shield) shield.style.display = '';
+    const netStats = el('net-stats');
+    if (netStats) netStats.style.display = '';
     this.loadLeaderboard();
     this.refreshWeaponProgress?.();
   }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -48,6 +48,7 @@ const weapons = new Weapons(camera, scene);
 weapons.onPlaySound = (name, vol, pitch) => audio.play(name, vol, pitch);
 let world: WorldView | null = null;
 let joined = false;
+let practice = false;
 let alive = false;
 let myName = '';
 let killerId = -1;
@@ -198,7 +199,7 @@ function clearCombatInput() {
   grenadePrimed = false;
   stopAiming();
   weapons.resetMotion();
-  if (joined && alive) net.sendInput(inputSeq++, 0, local.yaw, local.pitch);
+  if (joined && alive && !practice) net.sendInput(inputSeq++, 0, local.yaw, local.pitch);
   refreshWeaponHud();
 }
 
@@ -272,7 +273,7 @@ function startReload(t = performance.now(), notifyServer = true) {
   reloadPendingSlot = activeSlot;
   reloadPendingMag = weapons.ammoLocal;
   reloadPendingReserve = reserve;
-  if (notifyServer) net.sendReload();
+  if (notifyServer && !practice) net.sendReload();
   stopAiming();
 }
 
@@ -308,7 +309,7 @@ function selectSlot(slot: number) {
   mag = slot <= 2 ? slotMags[slot] : 0;
   reserve = slot <= 2 ? slotReserves[slot] : 0;
   weapons.ammoLocal = mag;
-  net.switchSlot(slot);
+  if (!practice) net.switchSlot(slot);
   audio.play('weapon_switch', 0.7);
   refreshWeaponHud();
 }
@@ -325,7 +326,7 @@ function throwGrenade() {
   nades--;
   grenadeOrigin.set(local.pos.x, local.eyeY(), local.pos.z);
   particles.spawnGrenade(net.yourId, grenadeOrigin, grenadeVelocity(grenadeVelocityVec));
-  net.sendGrenade(local.yaw, local.pitch);
+  if (!practice) net.sendGrenade(local.yaw, local.pitch);
   activeSlot = lastWeaponSlot;
   weapons.group.visible = true;
   audio.play('weapon_switch', 0.7);
@@ -516,7 +517,13 @@ hud.onPauseClick(() => {
   if (joined && !hud.isSettingsOpen()) void captureGame();
 });
 hud.onFlightToggle = () => {
-  if (joined && alive) net.toggleFlight();
+  if (!joined || !alive) return;
+  if (practice) {
+    local.flying = !local.flying;
+    hud.setFlightState(local.flying, true);
+  } else {
+    net.toggleFlight();
+  }
 };
 
 hud.onJoin = (name, primary, secondary, skin, primarySkin, secondarySkin) => {
@@ -545,14 +552,164 @@ hud.onJoin = (name, primary, secondary, skin, primarySkin, secondarySkin) => {
   audio.init();
 };
 
+interface DummyBox { x0: number; y0: number; z0: number; x1: number; y1: number; z1: number; head: boolean }
+interface DummyTarget { group: THREE.Group; boxes: DummyBox[] }
+const dummies: DummyTarget[] = [];
+
+function enterPractice() {
+  myName = '模拟练习';
+  practice = true;
+  joined = true;
+  alive = true;
+  killStreak = 0;
+  killerId = -1;
+  respawnAt = 0;
+  pointerUnlockRequested = false;
+  if (!world) {
+    const map = bundledMap as MapData;
+    world = new WorldView(scene, map);
+    world.clouds.visible = hud.quality !== 'low';
+    hud.setMap(map);
+  }
+  const map = bundledMap as MapData;
+  let spawn: [number, number, number] = map.spawns?.[0] ?? [0, 0, 0];
+  if (world && map.spawns) {
+    for (const s of map.spawns) {
+      if (canOccupy(world.boxes, local.pos.set(s[0], s[1], s[2]), PHYS.standingHeight)) {
+        spawn = s;
+        break;
+      }
+    }
+  }
+  local.pos.set(spawn[0], spawn[1], spawn[2]);
+  local.vel.set(0, 0, 0);
+  local.onGround = true;
+  local.flying = false;
+  local.yaw = Math.atan2(local.pos.x, local.pos.z);
+  local.pitch = 0;
+  const resolved = resolveLoadout(userPrimaryChoice, userSecondaryChoice);
+  primaryWeapon = resolved.primary;
+  secondaryWeapon = resolved.secondary;
+  primaryWeaponSkin = userPrimaryWeaponSkin === 3 ? 0 : userPrimaryWeaponSkin;
+  secondaryWeaponSkin = userSecondaryWeaponSkin === 3 ? 0 : userSecondaryWeaponSkin;
+  weapons.build(primaryWeapon, primaryWeaponSkin);
+  resetInventory(primaryWeapon, secondaryWeapon);
+  activeSlot = lastWeaponSlot = 1;
+  grenadePrimed = false;
+  mag = slotMags[1];
+  reserve = slotReserves[1];
+  nades = 1;
+  weapons.ammoLocal = mag;
+  weapons.group.visible = true;
+  refreshWeaponHud();
+  spawnDummies();
+  hud.setPractice();
+  hud.setFlightState(local.flying, true);
+  guardMatchHistory();
+  audio.init();
+  void lockPointer();
+}
+
+hud.onPractice = () => enterPractice();
+
+function spawnDummies() {
+  if (dummies.length || !world) return;
+  const bodyMat = new THREE.MeshStandardMaterial({ color: 0xc9822b, roughness: 0.85 });
+  const headMat = new THREE.MeshStandardMaterial({ color: 0xffce54, roughness: 0.7 });
+  const forward = new THREE.Vector3(-Math.sin(local.yaw), 0, -Math.cos(local.yaw)).normalize();
+  const right = new THREE.Vector3(-forward.z, 0, forward.x);
+  const groundY = 0;
+  const probe = new THREE.Vector3();
+  const rows: [number, number][] = [[12, 0], [18, 3.5], [12, -3.5], [24, 0], [30, 5]];
+  for (const [dist, lat] of rows) {
+    const cx = local.pos.x + forward.x * dist + right.x * lat;
+    const cz = local.pos.z + forward.z * dist + right.z * lat;
+    if (!canOccupy(world.boxes, probe.set(cx, groundY, cz), 0.6)) continue;
+    const group = new THREE.Group();
+    const boxes: DummyBox[] = [];
+    const addBox = (sx: number, sy: number, sz: number, w: number, h: number, d: number, mat: THREE.Material, head: boolean) => {
+      const mesh = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), mat);
+      mesh.position.set(cx + sx, groundY + sy + h / 2, cz + sz);
+      group.add(mesh);
+      boxes.push({
+        x0: cx + sx - w / 2, x1: cx + sx + w / 2,
+        y0: groundY + sy, y1: groundY + sy + h,
+        z0: cz + sz - d / 2, z1: cz + sz + d / 2,
+        head,
+      });
+    };
+    addBox(-0.18, 0, 0, 0.3, 0.72, 0.3, bodyMat, false);
+    addBox(0.18, 0, 0, 0.3, 0.72, 0.3, bodyMat, false);
+    addBox(0, 0.72, 0, 0.72, 0.72, 0.36, bodyMat, false);
+    addBox(-0.48, 0.78, 0, 0.22, 0.6, 0.22, bodyMat, false);
+    addBox(0.48, 0.78, 0, 0.22, 0.6, 0.22, bodyMat, false);
+    addBox(0, 1.44, 0, 0.34, 0.34, 0.34, headMat, true);
+    scene.add(group);
+    dummies.push({ group, boxes });
+  }
+}
+
+function raycastDummies(origin: THREE.Vector3, dir: THREE.Vector3, maxDist: number): { dist: number; head: boolean } | null {
+  let best = maxDist;
+  let hit: { dist: number; head: boolean } | null = null;
+  for (const t of dummies) {
+    for (const b of t.boxes) {
+      let tmin = -Infinity;
+      let tmax = Infinity;
+      if (dir.x !== 0) {
+        let t1 = (b.x0 - origin.x) / dir.x;
+        let t2 = (b.x1 - origin.x) / dir.x;
+        if (t1 > t2) { const tmp = t1; t1 = t2; t2 = tmp; }
+        tmin = Math.max(tmin, t1);
+        tmax = Math.min(tmax, t2);
+      } else if (origin.x < b.x0 || origin.x > b.x1) continue;
+      if (dir.y !== 0) {
+        let t1 = (b.y0 - origin.y) / dir.y;
+        let t2 = (b.y1 - origin.y) / dir.y;
+        if (t1 > t2) { const tmp = t1; t1 = t2; t2 = tmp; }
+        tmin = Math.max(tmin, t1);
+        tmax = Math.min(tmax, t2);
+      } else if (origin.y < b.y0 || origin.y > b.y1) continue;
+      if (dir.z !== 0) {
+        let t1 = (b.z0 - origin.z) / dir.z;
+        let t2 = (b.z1 - origin.z) / dir.z;
+        if (t1 > t2) { const tmp = t1; t1 = t2; t2 = tmp; }
+        tmin = Math.max(tmin, t1);
+        tmax = Math.min(tmax, t2);
+      } else if (origin.z < b.z0 || origin.z > b.z1) continue;
+      if (tmin <= tmax && tmin >= 0 && tmin < best) {
+        best = tmin;
+        hit = { dist: tmin, head: b.head };
+      }
+    }
+  }
+  return hit;
+}
+
+function removeDummies() {
+  for (const t of dummies) {
+    scene.remove(t.group);
+    t.group.traverse((o) => {
+      if (o instanceof THREE.Mesh) {
+        o.geometry.dispose();
+        const m = o.material;
+        if (Array.isArray(m)) m.forEach((mm) => mm.dispose());
+        else m.dispose();
+      }
+    });
+  }
+  dummies.length = 0;
+}
+
 hud.onLoadoutChange = (p, s) => {
   userPrimaryChoice = p;
   userSecondaryChoice = s;
   const next = resolveLoadout(p, s);
-  net.setLoadout(next.primary, next.secondary, userPrimaryWeaponSkin, userSecondaryWeaponSkin);
+  if (!practice) net.setLoadout(next.primary, next.secondary, userPrimaryWeaponSkin, userSecondaryWeaponSkin);
 };
 hud.onExit = () => {
   joined = false;
+  practice = false;
   alive = false;
   respawnAt = 0;
   pointerUnlockRequested = true;
@@ -563,6 +720,7 @@ hud.onExit = () => {
   net.disconnect();
   hud.exitMatch();
   for (const id of [...remotes.ids()]) remotes.remove(id);
+  removeDummies();
   states.clear();
   roster.clear();
   names.clear();
@@ -975,7 +1133,7 @@ function frame(t: number) {
     }
     if (t - lastInput >= INPUT_INTERVAL) {
       lastInput = t - ((t - lastInput) % INPUT_INTERVAL);
-      net.sendInput(inputSeq++, local.keys | (aiming ? KEY.Aim : 0), local.yaw, local.pitch);
+      if (!practice) net.sendInput(inputSeq++, local.keys | (aiming ? KEY.Aim : 0), local.yaw, local.pitch);
     }
 
     const shouldFire = activeSlot !== 4 && ((WEAPONS[weapons.weaponId]?.automatic ?? false) ? fireHeld : firePressed);
@@ -1070,7 +1228,7 @@ function fire(mode: number, t: number) {
   const shotSample = (++shotSeq) & 0xff;
   const dir = shotDirection(localShotDir, local.yaw, local.pitch, spread, pellets > 1 ? shotSample * 17 : shotSample, weapons.weaponId, net.yourId);
   weapons.onFired(t, origin);
-  net.sendFire(shotSeq, net.lastServerTick, mode | (aiming ? 0x80 : 0), local.yaw, local.pitch);
+  if (!practice) net.sendFire(shotSeq, net.lastServerTick, mode | (aiming ? 0x80 : 0), local.yaw, local.pitch);
   mag = weapons.ammoLocal;
   if (isSniper(weapons.weaponId)) {
     stopAiming();
@@ -1084,10 +1242,22 @@ function fire(mode: number, t: number) {
       const pelletDir = i === 0 && !isShotgun(weapons.weaponId)
         ? dir
         : shotDirection(localPelletDir, local.yaw, local.pitch, spread, isShotgun(weapons.weaponId) ? shotSample : shotSample * 17 + i, weapons.weaponId, net.yourId, isShotgun(weapons.weaponId) ? i : undefined);
-      const dist = world?.raycastDistance(origin, pelletDir, 180) ?? 180;
+      let dist = world?.raycastDistance(origin, pelletDir, 180) ?? 180;
+      const dummy = raycastDummies(origin, pelletDir, dist);
+      let impactColor = 0xd6b36e;
+      let impactCount = pellets > 1 ? 3 : 5;
+      if (dummy) {
+        dist = dummy.dist;
+        if (i === 0) {
+          hud.hitMarker(dummy.head);
+          audio.play(dummy.head ? 'headshot_ding' : 'hitmarker', dummy.head ? 1 : 0.65, 1, 0, dummy.head);
+        }
+        impactColor = dummy.head ? 0xf2c14e : 0xd8574f;
+        impactCount = dummy.head ? 7 : 5;
+      }
       weapons.spawnTracer(origin, pelletDir, dist, true);
       if (dist < 180) {
-        particles.spawnImpact(impactPoint.copy(origin).addScaledVector(pelletDir, dist), impactNormal, 0xd6b36e, pellets > 1 ? 3 : 5);
+        particles.spawnImpact(impactPoint.copy(origin).addScaledVector(pelletDir, dist), impactNormal, impactColor, impactCount);
       }
     }
     applyRecoil(weapons.weaponId, patternShots, aiming);
@@ -1095,6 +1265,11 @@ function fire(mode: number, t: number) {
     weapons.onKnifeSlash();
     audio.play('knife_slash', 0.85);
     const dist = world?.raycastDistance(origin, dir, 2.0) ?? 2.0;
+    const dummy = raycastDummies(origin, dir, dist);
+    if (dummy) {
+      hud.hitMarker(false);
+      audio.play('hitmarker', 0.65, 1, 0, false);
+    }
     if (dist < 2.0) {
       particles.spawnImpact(impactPoint.copy(origin).addScaledVector(dir, dist), impactNormal, 0xd6b36e, 3);
     }


### PR DESCRIPTION
## 概述
为初始界面设置弹窗新增完整的**准星自定义**能力，并新增一个纯客户端的**模拟练习场**，方便调整准星后直接进场测试手感。

## 准星设置（设置弹窗 → 准星 / CROSSHAIR）
- 样式预设：经典十字 / 十字+点 / T 形 / 单点 / 圆环 / 关闭准星
- 颜色：默认（随精度动态变色）+ 7 个预设色板 + 自定义取色器
- 大小 / 粗细 / 间距 三个滑杆
- 中心点 / 描边 / 动态准星 三个开关（关闭动态后准星固定间距）
- 弹窗内**实时预览** + 「恢复默认准星」一键还原
- 全部经 `localStorage`（`ps_ch_*`）持久化，进对局即生效；默认值与原有外观一致

## 模拟练习场
- 纯客户端模式：**不连接服务器**，秒进空地图，零延迟
- 用当前主/副武器配装，自由移动 / 射击 / 换弹 / 开镜 / 切枪 / 投雷
- 动态准星、弹道 tracer、着弹点全部生效
- 出生点附近布置 **5 个静态人形靶**（头部区分爆头判定），命中出 hitmarker / 命中音 / 金色爆头特效，刀近战也可命中
- 入口：主界面「进入战场」旁次级按钮 **「模拟练习」**，以及设置弹窗底部 **「进入模拟」**
- Esc 暂停 / 继续 / 本地飞行 / 退出回菜单

## 改动文件
- `client/index.html` — 准星 CSS 参数化（`--ch-size/--ch-thickness/--ch-dot`）、设置弹窗分组与控件、两个入口按钮
- `client/src/hud.ts` — 准星字段与 `applyCrosshair/updateCrosshairPreview/resetCrosshair`、`onPractice` 回调、`enterGameUI/startPractice/setPractice`
- `client/src/main.ts` — `practice` 标志与 `enterPractice()`、网络调用守卫、人形靶系统（`spawnDummies/raycastDummies/removeDummies`）

## 验证
`cd client && npm run build` 通过（tsc + vite）。