### PR TITLE
feat: 💘 一见钟情 · 战场羁绊系统 — FPS × GalGame

### DIFF
--- a/client/src/hud.ts
+++ b/client/src/hud.ts
@@ -129,6 +129,7 @@ export class Hud {
   private toastTimer = 0;
   private flightTimer = 0;
   private revengeTimer = 0;
+  private bondTimer = 0;
   private reconnectTimer = 0;
   private refreshWeaponProgress: (() => void) | null = null;
 
@@ -909,6 +910,25 @@ export class Hud {
     this.revengeTimer = window.setTimeout(() => {
       banner.classList.remove('show', 'revenge');
     }, 4000);
+  }
+
+  showBondEvent(kind: number, name: string, score: number) {
+    const banner = el('flight-announcement');
+    const BOND_MESSAGES: Record<number, string> = {
+      0: `💕 ${name || '羁绊者'} 守护了TA · 羁绊值 ${score}`,
+      1: `🔥 ${name || '羁绊者'} 为TA报仇了 · 羁绊值 ${score}`,
+      2: `⚡ ${name || '羁绊者'} 心有灵犀 · 羁绊值 ${score}`,
+      3: `💘 ${name || '特战队员'} 缔结战场羁绊`,
+    };
+    banner.textContent = BOND_MESSAGES[kind] ?? BOND_MESSAGES[0];
+    banner.classList.add('bond');
+    banner.classList.remove('revenge', 'show');
+    void banner.offsetWidth;
+    banner.classList.add('show');
+    clearTimeout(this.bondTimer);
+    this.bondTimer = window.setTimeout(() => {
+      banner.classList.remove('show', 'bond');
+    }, 3200);
   }
 
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1126,6 +1126,10 @@ function handleEvent(e: GameEvent) {
     hud.showRevengeAnnouncement(e.name ?? nameOf(e.player));
     return;
   }
+  if (e.type === 15) {
+    hud.showBondEvent(e.kind ?? 0, e.name ?? nameOf(e.player), e.streak ?? 0);
+    return;
+  }
   if (e.type === 0) {
     // EvKill
     const killer = nameOf(e.killer);

--- a/client/src/net.ts
+++ b/client/src/net.ts
@@ -124,6 +124,15 @@ export class Net {
           e.name = new TextDecoder().decode(new Uint8Array(v.buffer, v.byteOffset + o + 3, len));
           o += 3 + len; break;
         }
+        case 15: {
+          e.player = v.getUint16(o, true);
+          e.victim = v.getUint16(o + 2, true);
+          e.kind = v.getUint8(o + 4);
+          e.streak = v.getUint8(o + 5);
+          const len = v.getUint8(o + 6);
+          e.name = new TextDecoder().decode(new Uint8Array(v.buffer, v.byteOffset + o + 7, len));
+          o += 7 + len; break;
+        }
       }
       rows.push(e);
     }

--- a/server/proto.go
+++ b/server/proto.go
@@ -47,6 +47,7 @@ const (
 	EvFlightToggle
 	EvStreakBuff
 	EvRevenge
+	EvBondEvent
 )
 
 type Event struct {
@@ -195,6 +196,14 @@ func Events(evts []Event) []byte {
 			w.U16(e.Ms)
 		case EvRevenge:
 			w.U16(e.Player)
+			nb := safeNameBytes(e.Name)
+			w.U8(uint8(len(nb)))
+			w.b = append(w.b, nb...)
+		case EvBondEvent:
+			w.U16(e.Player)
+			w.U16(e.Victim)
+			w.U8(e.Kind)
+			w.U8(e.Dmg)
 			nb := safeNameBytes(e.Name)
 			w.U8(uint8(len(nb)))
 			w.b = append(w.b, nb...)

--- a/server/room.go
+++ b/server/room.go
@@ -35,6 +35,12 @@ func NewRoom(id int, w *World, s *Store) *Room {
 func (r *Room) Remove(p *Player) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// Clear bond: if this player had a bond mate, break the bond
+	if p.BondMate != 0 {
+		if mate := r.findPlayer(p.BondMate); mate != nil {
+			mate.BondMate = 0
+		}
+	}
 	for i, q := range r.Players {
 		if q == p {
 			r.Players = append(r.Players[:i], r.Players[i+1:]...)
@@ -177,7 +183,7 @@ func (r *Room) eventsFor(target *Player, evts []Event) []Event {
 	for _, e := range evts {
 		send := false
 		switch e.Type {
-		case EvKill, EvPlayerName, EvPlayerLeave, EvFlightToggle, EvRevenge:
+		case EvKill, EvPlayerName, EvPlayerLeave, EvFlightToggle, EvRevenge, EvBondEvent:
 			send = true
 		case EvStreakBuff:
 			send = e.Player == target.Id

--- a/server/sim.go
+++ b/server/sim.go
@@ -79,6 +79,8 @@ const (
 	FlightSpeed                 = WalkSpeed
 	MaxFlightHeight             = StandingHeight * 25
 	RevengeDeathThreshold uint8 = 10
+	BondCoverRange              = 20.0
+	BondAvengeWindow            = 30 * time.Second
 )
 
 type PlayerState struct {
@@ -102,6 +104,10 @@ type PlayerState struct {
 	NoKillDeaths                                                   uint8
 	RevengeReady, RevengeActive                                    bool
 	RevengeShots                                                   uint8
+	BondMate                                                       uint16
+	BondScore                                                      uint16
+	LastKiller                                                     uint16
+	KilledAt                                                       time.Time
 	LastInputSeq, LastShotSeq                                      uint16
 	HasShot                                                        bool
 	LastShotAt                                                     time.Time
@@ -602,6 +608,41 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	if !victim.IsBot {
 		r.Store.Accumulate(victim.Account, 0, 1)
 	}
+
+	// Bond system: record who killed this player for avenging
+	victim.LastKiller = attacker.Id
+	victim.KilledAt = now
+
+	// Bond check: did the attacker just avenge their bond mate?
+	if attacker.BondMate != 0 && attacker.BondMate != attacker.Id {
+		if mate := r.findPlayer(attacker.BondMate); mate != nil {
+			if mate.LastKiller == victim.Id && now.Sub(mate.KilledAt) < BondAvengeWindow {
+				attacker.BondScore++
+				r.Emit(Event{Type: EvBondEvent, Player: attacker.Id, Victim: mate.Id, Kind: 1, Dmg: attacker.BondScore, Name: attacker.Name})
+			}
+		}
+	}
+
+	// Bond check: is the attacker covering their bond mate (nearby)?
+	if attacker.BondMate != 0 && attacker.BondMate != attacker.Id {
+		if mate := r.findPlayer(attacker.BondMate); mate != nil && mate.Alive {
+			dx := attacker.Pos.X - mate.Pos.X
+			dz := attacker.Pos.Z - mate.Pos.Z
+			if dx*dx+dz*dz <= BondCoverRange*BondCoverRange {
+				attacker.BondScore++
+				r.Emit(Event{Type: EvBondEvent, Player: attacker.Id, Victim: mate.Id, Kind: 0, Dmg: attacker.BondScore, Name: attacker.Name})
+			}
+		}
+	}
+
+	// Bond check: streak resonance (both on 2+ streak)
+	if attacker.BondMate != 0 && attacker.BondMate != attacker.Id && attacker.Streak >= 2 {
+		if mate := r.findPlayer(attacker.BondMate); mate != nil && mate.Alive && mate.Streak >= 2 {
+			attacker.BondScore++
+			r.Emit(Event{Type: EvBondEvent, Player: attacker.Id, Victim: mate.Id, Kind: 2, Dmg: attacker.BondScore, Name: attacker.Name})
+		}
+	}
+
 	victim.Alive, victim.Reloading = false, false
 	victim.RevengeActive, victim.RevengeShots = false, 0
 	victim.InvincibleUntil = time.Time{}
@@ -827,10 +868,26 @@ func (r *Room) Respawn(p *PlayerState, now time.Time) {
 		r.Emit(Event{Type: EvRevenge, Player: p.Id, Name: p.Name})
 	}
 	p.RevengeReady = false
+	p.LastKiller = 0
 	p.LandingUntil, p.AimStarted = time.Time{}, time.Time{}
 	p.SpeedUntil, p.DmgUntil, p.RecoilUntil = time.Time{}, time.Time{}, time.Time{}
 	p.Streak = 0
 	p.RespawnAt = time.Time{}
+
+	// Bond system: auto-pair unbonded human players
+	if p.BondMate == 0 && !p.IsBot {
+		for _, other := range r.Players {
+			o := &other.PlayerState
+			if o.Id == p.Id || o.IsBot || o.BondMate != 0 || !o.Alive {
+				continue
+			}
+			p.BondMate = o.Id
+			o.BondMate = p.Id
+			r.Emit(Event{Type: EvBondEvent, Player: p.Id, Victim: o.Id, Kind: 3, Name: p.Name})
+			break
+		}
+	}
+
 	r.Emit(Event{Type: EvRespawn, Player: p.Id, Origin: p.Pos})
 }
 


### PR DESCRIPTION
## 💘 一见钟情 · 战场羁绊系统

FPS × GalGame 的第一次碰撞！在枪林弹雨中，遇见你的战场羁绊。

### 三种羁绊事件

| 事件 | 触发条件 | 横幅 |
|---|---|---|
| 💕 **守护** | 在羁绊对象 20m 内击杀敌人 | `💕 玩家名 守护了TA · 羁绊值 N` |
| 🔥 **复仇** | 击杀 30 秒内杀死羁绊对象的敌人 | `🔥 玩家名 为TA报仇了 · 羁绊值 N` |
| ⚡ **共鸣** | 双方同时连杀 ≥2 | `⚡ 玩家名 心有灵犀 · 羁绊值 N` |

### 自动配对

- 真人玩家重生时，自动与第一个未配对的真人建立羁绊
- 结成羁绊时全屏广播 `💘 玩家名 缔结战场羁绊`
- 玩家离开时自动解除羁绊
- Bot 不参与羁绊

### 技术实现

- **协议**: 新增 `EvBondEvent` (type 15)，字段: `player(u16) + victim(u16) + kind(u8) + score(u8) + name_len(u8) + name`
- **服务端**: `PlayerState` 新增 `BondMate`/`BondScore`/`LastKiller`/`KilledAt`，在 `Damage()` 中检测羁绊触发，在 `Respawn()` 中自动配对
- **客户端**: 复用 `flight-announcement` 横幅，新增 `.bond` CSS class（粉色渐变背景）

### 改动文件

| 文件 | 改动 |
|---|---|
| `server/proto.go` | 新增 `EvBondEvent` 事件类型及序列化 |
| `server/room.go` | 羁绊广播、离开解除、事件过滤 |
| `server/sim.go` | PlayerState 新增羁绊字段、Damage 检测、Respawn 配对 |
| `client/src/net.ts` | 解码 type 15 事件 |
| `client/src/hud.ts` | `showBondEvent()` 横幅显示 |
| `client/src/main.ts` | 处理羁绊事件 |

### 验证

- `cd server && go test ./...` 通过
- `cd client && npm run build` 通过

---

**Made with ❤️ and AWP headshots**