### PR TITLE
fix: harden bond events before deployment

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1012,6 +1012,14 @@
       text-shadow: 0 0 10px rgb(255 91 58 / .95), 0 0 28px rgb(255 209 102 / .75);
       box-shadow: 0 0 34px rgb(255 58 40 / .35), inset 0 0 24px rgb(255 91 58 / .16);
     }
+    #flight-announcement.bond {
+      border-block-color: rgb(244 114 182 / .9);
+      background: linear-gradient(90deg, transparent, rgb(60 10 42 / .96) 12%, rgb(91 17 62 / .98) 50%, rgb(60 10 42 / .96) 88%, transparent);
+      color: #fbcfe8;
+      text-shadow: 0 0 20px rgb(244 114 182 / .82);
+      box-shadow: 0 0 30px rgb(236 72 153 / .28);
+    }
+    #flight-announcement.bond.show { animation: pickup-flash 3.2s ease-out forwards; }
     #flight-announcement.revenge.show { animation: pickup-flash 4s ease-out forwards; }
     #pause-flight-btn.active {
       border-color: #35c9e8;

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 8;
+export const PROTOCOL_VERSION = 9;
 
 export const OP = {
   Join: 0x01,

--- a/client/src/hud.ts
+++ b/client/src/hud.ts
@@ -127,9 +127,7 @@ export class Hud {
   private lastAmmo = '';
   private hurtTimer = 0;
   private toastTimer = 0;
-  private flightTimer = 0;
-  private revengeTimer = 0;
-  private bondTimer = 0;
+  private announcementTimer = 0;
   private reconnectTimer = 0;
   private refreshWeaponProgress: (() => void) | null = null;
 
@@ -891,44 +889,39 @@ export class Hud {
   showFlightAnnouncement(name: string) {
     const banner = el('flight-announcement');
     banner.textContent = `${name || '特战队员'} 能飞`;
-    banner.classList.remove('revenge');
-    banner.classList.remove('show');
+    banner.classList.remove('revenge', 'bond', 'show');
     void banner.offsetWidth;
     banner.classList.add('show');
-    clearTimeout(this.flightTimer);
-    this.flightTimer = window.setTimeout(() => banner.classList.remove('show'), 2600);
+    clearTimeout(this.announcementTimer);
+    this.announcementTimer = window.setTimeout(() => banner.classList.remove('show'), 2600);
   }
 
   showRevengeAnnouncement(name: string) {
     const banner = el('flight-announcement');
     banner.textContent = `（${name || '玩家'}）来复仇了！`;
+    banner.classList.remove('bond', 'show');
     banner.classList.add('revenge');
-    banner.classList.remove('show');
     void banner.offsetWidth;
     banner.classList.add('show');
-    clearTimeout(this.revengeTimer);
-    this.revengeTimer = window.setTimeout(() => {
-      banner.classList.remove('show', 'revenge');
-    }, 4000);
+    clearTimeout(this.announcementTimer);
+    this.announcementTimer = window.setTimeout(() => banner.classList.remove('show', 'revenge'), 4000);
   }
 
   showBondEvent(kind: number, name: string, score: number) {
     const banner = el('flight-announcement');
-    const BOND_MESSAGES: Record<number, string> = {
-      0: `💕 ${name || '羁绊者'} 守护了TA · 羁绊值 ${score}`,
-      1: `🔥 ${name || '羁绊者'} 为TA报仇了 · 羁绊值 ${score}`,
-      2: `⚡ ${name || '羁绊者'} 心有灵犀 · 羁绊值 ${score}`,
-      3: `💘 ${name || '特战队员'} 缔结战场羁绊`,
-    };
-    banner.textContent = BOND_MESSAGES[kind] ?? BOND_MESSAGES[0];
-    banner.classList.add('bond');
+    const actor = name || (kind === 3 ? '特战队员' : '羁绊者');
+    switch (kind) {
+      case 1: banner.textContent = `🔥 ${actor} 为TA报仇了 · 羁绊值 ${score}`; break;
+      case 2: banner.textContent = `⚡ ${actor} 心有灵犀 · 羁绊值 ${score}`; break;
+      case 3: banner.textContent = `💘 ${actor} 缔结战场羁绊`; break;
+      default: banner.textContent = `💕 ${actor} 守护了TA · 羁绊值 ${score}`;
+    }
     banner.classList.remove('revenge', 'show');
+    banner.classList.add('bond');
     void banner.offsetWidth;
     banner.classList.add('show');
-    clearTimeout(this.bondTimer);
-    this.bondTimer = window.setTimeout(() => {
-      banner.classList.remove('show', 'bond');
-    }, 3200);
+    clearTimeout(this.announcementTimer);
+    this.announcementTimer = window.setTimeout(() => banner.classList.remove('show', 'bond'), 3200);
   }
 
 

--- a/server/proto.go
+++ b/server/proto.go
@@ -6,7 +6,7 @@ import (
 	"unicode/utf8"
 )
 
-const ProtocolVersion = 8
+const ProtocolVersion = 9
 const SkinCount uint8 = 8
 
 const (

--- a/server/proto_test.go
+++ b/server/proto_test.go
@@ -629,6 +629,63 @@ func TestEventsNeverSplitsUTF8Rune(t *testing.T) {
 	}
 }
 
+func TestBondAvengeSurvivesRespawnAndScoresOnce(t *testing.T) {
+	now := time.Unix(100, 0)
+	attacker := &Player{PlayerState: PlayerState{Id: 1, IsBot: true, Alive: true, BondMate: 2}}
+	mate := &Player{PlayerState: PlayerState{Id: 2, IsBot: true, BondMate: 1, LastKiller: 3, KilledAt: now, Pos: Vec3{X: 100}}}
+	killer := &Player{PlayerState: PlayerState{Id: 3, IsBot: true, Alive: true, HP: 1}}
+	r := &Room{World: &World{Spawns: [][3]float64{{100, 0, 0}}}, Players: []*Player{attacker, mate, killer}, history: make(map[uint16]*poseHistory)}
+	r.Respawn(&mate.PlayerState, now.Add(RespawnDelayS))
+	if mate.LastKiller != killer.Id {
+		t.Fatal("respawn cleared the active revenge target")
+	}
+	r.pending = nil
+	r.Damage(&attacker.PlayerState, &killer.PlayerState, 10, false, 3, now.Add(4*time.Second))
+	if attacker.BondScore != 1 || mate.LastKiller != 0 {
+		t.Fatalf("revenge score=%d last killer=%d", attacker.BondScore, mate.LastKiller)
+	}
+	bondEvents := 0
+	for _, e := range r.pending {
+		if e.Type == EvBondEvent {
+			bondEvents++
+			if e.Kind != 1 || e.Dmg != 1 {
+				t.Fatalf("bad revenge event: %#v", e)
+			}
+		}
+	}
+	if bondEvents != 1 {
+		t.Fatalf("revenge emitted %d bond events", bondEvents)
+	}
+
+	r.pending = nil
+	killer.Alive, killer.HP = true, 1
+	r.Damage(&attacker.PlayerState, &killer.PlayerState, 10, false, 3, now.Add(5*time.Second))
+	for _, e := range r.pending {
+		if e.Type == EvBondEvent {
+			t.Fatalf("same death rewarded twice: %#v", e)
+		}
+	}
+}
+
+func TestKillingBondMateIsNotCover(t *testing.T) {
+	attacker := &Player{PlayerState: PlayerState{Id: 1, IsBot: true, Alive: true, BondMate: 2}}
+	mate := &Player{PlayerState: PlayerState{Id: 2, IsBot: true, Alive: true, HP: 1, BondMate: 1}}
+	r := &Room{Players: []*Player{attacker, mate}, history: make(map[uint16]*poseHistory)}
+	r.Damage(&attacker.PlayerState, &mate.PlayerState, 10, false, 3, time.Unix(1, 0))
+	for _, e := range r.pending {
+		if e.Type == EvBondEvent {
+			t.Fatalf("killing the bond mate emitted cover: %#v", e)
+		}
+	}
+}
+
+func TestBondEventEncoding(t *testing.T) {
+	b := Events([]Event{{Type: EvBondEvent, Player: 1, Victim: 2, Kind: 1, Dmg: 7, Name: "甲"}})
+	if len(b) != 13 || b[0] != OpEvents || b[1] != 1 || b[2] != EvBondEvent || binary.LittleEndian.Uint16(b[3:]) != 1 || binary.LittleEndian.Uint16(b[5:]) != 2 || b[7] != 1 || b[8] != 7 || b[9] != 3 || string(b[10:]) != "甲" {
+		t.Fatalf("bad bond event: %v", b)
+	}
+}
+
 func TestPoseHistoryRing(t *testing.T) {
 	p := &Player{PlayerState: PlayerState{Id: 1}}
 	r := &Room{Players: []*Player{p}, history: make(map[uint16]*poseHistory)}

--- a/server/sim.go
+++ b/server/sim.go
@@ -105,7 +105,7 @@ type PlayerState struct {
 	RevengeReady, RevengeActive                                    bool
 	RevengeShots                                                   uint8
 	BondMate                                                       uint16
-	BondScore                                                      uint16
+	BondScore                                                      uint8
 	LastKiller                                                     uint16
 	KilledAt                                                       time.Time
 	LastInputSeq, LastShotSeq                                      uint16
@@ -114,6 +114,13 @@ type PlayerState struct {
 	ShotCounter                                                    uint8
 	inputWindowStart                                               time.Time
 	inputCount                                                     int
+}
+
+func (p *PlayerState) addBondScore() uint8 {
+	if p.BondScore < 255 {
+		p.BondScore++
+	}
+	return p.BondScore
 }
 
 func (p *PlayerState) ProtectedAt(now time.Time) bool {
@@ -608,38 +615,28 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	if !victim.IsBot {
 		r.Store.Accumulate(victim.Account, 0, 1)
 	}
-
-	// Bond system: record who killed this player for avenging
 	victim.LastKiller = attacker.Id
 	victim.KilledAt = now
 
-	// Bond check: did the attacker just avenge their bond mate?
+	// A kill can trigger at most one bond event; revenge takes priority over cover and resonance.
 	if attacker.BondMate != 0 && attacker.BondMate != attacker.Id {
 		if mate := r.findPlayer(attacker.BondMate); mate != nil {
-			if mate.LastKiller == victim.Id && now.Sub(mate.KilledAt) < BondAvengeWindow {
-				attacker.BondScore++
-				r.Emit(Event{Type: EvBondEvent, Player: attacker.Id, Victim: mate.Id, Kind: 1, Dmg: attacker.BondScore, Name: attacker.Name})
+			kind := uint8(255)
+			if mate.LastKiller == victim.Id && !mate.KilledAt.IsZero() && now.Sub(mate.KilledAt) < BondAvengeWindow {
+				kind = 1
+				mate.LastKiller, mate.KilledAt = 0, time.Time{}
+			} else if mate.Id != victim.Id && mate.Alive {
+				dx := attacker.Pos.X - mate.Pos.X
+				dz := attacker.Pos.Z - mate.Pos.Z
+				if dx*dx+dz*dz <= BondCoverRange*BondCoverRange {
+					kind = 0
+				} else if attacker.Streak >= 2 && mate.Streak >= 2 {
+					kind = 2
+				}
 			}
-		}
-	}
-
-	// Bond check: is the attacker covering their bond mate (nearby)?
-	if attacker.BondMate != 0 && attacker.BondMate != attacker.Id {
-		if mate := r.findPlayer(attacker.BondMate); mate != nil && mate.Alive {
-			dx := attacker.Pos.X - mate.Pos.X
-			dz := attacker.Pos.Z - mate.Pos.Z
-			if dx*dx+dz*dz <= BondCoverRange*BondCoverRange {
-				attacker.BondScore++
-				r.Emit(Event{Type: EvBondEvent, Player: attacker.Id, Victim: mate.Id, Kind: 0, Dmg: attacker.BondScore, Name: attacker.Name})
+			if kind != 255 {
+				r.Emit(Event{Type: EvBondEvent, Player: attacker.Id, Victim: mate.Id, Kind: kind, Dmg: attacker.addBondScore(), Name: attacker.Name})
 			}
-		}
-	}
-
-	// Bond check: streak resonance (both on 2+ streak)
-	if attacker.BondMate != 0 && attacker.BondMate != attacker.Id && attacker.Streak >= 2 {
-		if mate := r.findPlayer(attacker.BondMate); mate != nil && mate.Alive && mate.Streak >= 2 {
-			attacker.BondScore++
-			r.Emit(Event{Type: EvBondEvent, Player: attacker.Id, Victim: mate.Id, Kind: 2, Dmg: attacker.BondScore, Name: attacker.Name})
 		}
 	}
 
@@ -868,7 +865,7 @@ func (r *Room) Respawn(p *PlayerState, now time.Time) {
 		r.Emit(Event{Type: EvRevenge, Player: p.Id, Name: p.Name})
 	}
 	p.RevengeReady = false
-	p.LastKiller = 0
+
 	p.LandingUntil, p.AimStarted = time.Time{}, time.Time{}
 	p.SpeedUntil, p.DmgUntil, p.RecoilUntil = time.Time{}, time.Time{}, time.Time{}
 	p.Streak = 0


### PR DESCRIPTION
Follow-up for #10. Fixes the server compile error, preserves one-shot revenge state across respawn, prevents cover rewards for killing a bond mate, limits one bond event per kill, bumps protocol version, and adds the missing banner style. Also unifies announcement timers to prevent stale events hiding newer banners. Verified with go test ./... and npm run build.