### PR TITLE
feat: 连杀梗播报 · 战场播报整活上线（含连死安慰）

### DIFF
--- a/server/killstreak_test.go
+++ b/server/killstreak_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// 在 Damage 之后统计本次调用新产生的 EvChat 事件数。
+func newChatsAfter(r *Room, before int) []Event {
+	out := make([]Event, 0, 2)
+	for _, e := range r.pending[before:] {
+		if e.Type == EvChat {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func TestKillstreakMemeAtMilestones(t *testing.T) {
+	store, err := NewStore(t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := newTeamTestRoom()
+	r.Store = store
+	attacker := newTestHuman(10, r)
+	victim := newTestHuman(11, r)
+	attacker.Name = "神枪手"
+	victim.Name = "倒霉蛋"
+	attacker.Pos = Vec3{0, 0, 0}
+	victim.Pos = Vec3{3, 0, 0}
+	r.Players = append(r.Players, attacker, victim)
+
+	milestones := map[uint8]bool{3: true, 5: true, 8: true, 10: true}
+	now := time.Now()
+	deathMemes := 0
+	for streak := uint8(1); streak <= 10; streak++ {
+		victim.HP = MaxHP
+		victim.Alive = true
+		before := len(r.pending)
+		r.Damage(&attacker.PlayerState, &victim.PlayerState, MaxHP, false, 3, now)
+		chats := newChatsAfter(r, before)
+		killMemes := 0
+		for _, c := range chats {
+			if c.Name != "战场播报" {
+				t.Fatalf("streak %d: 播报名 = %q, 期望 %q", streak, c.Name, "战场播报")
+			}
+			isDeathMeme := strings.HasPrefix(c.Message, "倒霉蛋")
+			isKillMeme := strings.Contains(c.Message, "神枪手")
+			if !isDeathMeme && !isKillMeme {
+				t.Fatalf("streak %d: 播报 neither 连杀 nor 连死: %q", streak, c.Message)
+			}
+			if isDeathMeme {
+				deathMemes++
+			} else {
+				killMemes++
+			}
+		}
+		if milestones[streak] && killMemes != 1 {
+			t.Fatalf("streak %d: 期望 1 条连杀播报, 实际 %d (%v)", streak, killMemes, chats)
+		}
+		if !milestones[streak] && killMemes != 0 {
+			t.Fatalf("streak %d: 非里程碑不应有连杀播报", streak)
+		}
+	}
+	if deathMemes != 1 {
+		t.Fatalf("连死 5 次应恰好 1 条安慰播报, 实际 %d", deathMemes)
+	}
+}
+
+func TestKillstreakMemeSilentWithoutHumans(t *testing.T) {
+	r := newTeamTestRoom()
+	attacker := newTestBot(10, r)
+	victim := newTestBot(11, r)
+	attacker.Pos = Vec3{0, 0, 0}
+	victim.Pos = Vec3{3, 0, 0}
+	r.Players = append(r.Players, attacker, victim)
+
+	now := time.Now()
+	for range 3 {
+		victim.HP = MaxHP
+		victim.Alive = true
+		before := len(r.pending)
+		r.Damage(&attacker.PlayerState, &victim.PlayerState, MaxHP, false, 3, now)
+		if chats := newChatsAfter(r, before); len(chats) > 0 {
+			t.Fatalf("纯 bot 局不应播报, 实际 %q", chats[0].Message)
+		}
+	}
+	if r.hasHuman() {
+		t.Fatal("房间只有 bot 时 hasHuman 应为 false")
+	}
+}

--- a/server/sim.go
+++ b/server/sim.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"math/rand/v2"
@@ -690,6 +691,7 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 		}
 		r.applyStreakReward(attacker, now)
 	}
+	r.announceKillfeedMemes(attacker, victim)
 	victim.Streak = 0
 	victim.UltimatePoints, victim.Ultimate = 0, 0
 	victim.BlackDreamUntil, victim.InvincibleUntilUlt, victim.GhostUntil = time.Time{}, time.Time{}, time.Time{}
@@ -734,6 +736,67 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	victim.RevengeActive, victim.RevengeShots = false, 0
 	victim.InvincibleUntil = time.Time{}
 	victim.RespawnAt = now.Add(RespawnDelayS)
+}
+
+// 连杀梗播报：服务端以「战场播报」身份走 EvChat 通道整活。
+// 仅当房间里有真人时才播，避免无人局被 bot 内战刷屏。
+var killstreakLines = map[uint8][]string{
+	3: {
+		"%s 三连杀！建议对手集体申请工伤",
+		"%s 三连杀达成，枪管正在冒烟，请勿触摸",
+		"警告：%s 已三连杀，对手的头部保险即将到期",
+	},
+	5: {
+		"%s 五连杀！这已经不是枪法了，是因果律武器",
+		"%s 五连杀达成，正在考虑要不要收手（不会）",
+		"战况通报：%s 五连杀，正朝主播方向发展",
+	},
+	8: {
+		"%s 八连杀！建议全体玩家原地表演一个投降",
+		"%s 八连杀！队友已经开始截图留念",
+	},
+	10: {
+		"%s 十连杀！战场已变成个人直播间",
+		"%s 十连杀！服务端递上一杯冰可乐",
+		"讣告（对手方）：请为 %s 的十连杀默哀三秒",
+	},
+}
+
+var deathStreakLines = []string{
+	"%s 已连死五次，正在申请工伤认定",
+	"%s 连死五次，出生点的地板都认得 TA 了",
+	"%s 已连死五次！鼓励一下：起码贡献了别人的击杀数",
+}
+
+// deathStreakMemeAt：连续死亡达到该次数时发一条安慰播报（NoKillDeaths 会在
+// RevengeDeathThreshold 次时清零，所以选一个小于它的值）。
+const deathStreakMemeAt uint8 = 5
+
+func (r *Room) hasHuman() bool {
+	for _, p := range r.Players {
+		if !p.IsBot {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Room) broadcastChat(name, message string) {
+	r.Emit(Event{Type: EvChat, Player: 0, Name: name, Message: message})
+}
+
+func (r *Room) announceKillfeedMemes(attacker, victim *PlayerState) {
+	if !r.hasHuman() {
+		return
+	}
+	if attacker.Id != victim.Id {
+		if lines := killstreakLines[attacker.Streak]; len(lines) > 0 {
+			r.broadcastChat("战场播报", fmt.Sprintf(lines[rand.IntN(len(lines))], attacker.Name))
+		}
+	}
+	if !victim.IsBot && victim.NoKillDeaths == deathStreakMemeAt {
+		r.broadcastChat("战场播报", fmt.Sprintf(deathStreakLines[rand.IntN(len(deathStreakLines))], victim.Name))
+	}
 }
 
 func (p *PlayerState) streakScale() int {


### PR DESCRIPTION
## 改了什么

整活功能①：**连杀梗播报**。服务端在结算击杀时以「战场播报」身份向全房发整活消息，零协议改动（复用现有 EvChat 全房广播）。

- **连杀里程碑**：3 / 5 / 8 / 10 连杀时各触发一条随机文案（每个里程碑 2-3 条池子），真人、bot 一视同仁都能上榜：
  - 三连杀：「建议对手集体申请工伤」「枪管正在冒烟，请勿触摸」
  - 五连杀：「这已经不是枪法了，是因果律武器」
  - 八连杀：「建议全体玩家原地表演一个投降」
  - 十连杀：「战场已变成个人直播间」「讣告（对手方）：请默哀三秒」
- **连死安慰**：真人连续死亡 5 次触发一条安慰播报（「正在申请工伤认定」「出生点的地板都认得 TA 了」），阈值 5 < RevengeDeathThreshold(10)，不会与复仇机制抢状态
- **防刷屏**：房间内没有任何真人时自动静音，bot 内战不会污染聊天

## 实现细节

- `server/sim.go`：`Damage()` 结算尾部新增 `announceKillfeedMemes()` 调用；`broadcastChat()` 以 `Player=0` + `Name="战场播报"` 发 EvChat，客户端已有的聊天渲染直接显示（`e.name` 优先于 `nameOf(e.player)`）
- 不改 `proto.go` / `netstate.go` / 客户端，无协议兼容性问题
- diff 为纯新增（63 行）+ 测试文件

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/killstreak_test.go`：
  - 里程碑断言：1-10 连杀逐档验证，3/5/8/10 恰好各 1 条、其余档 0 条，播报名与文案包含攻击者名
  - 连死 5 次恰好 1 条安慰播报
  - 纯 bot 房间静音 + `hasHuman()` 判定
- 客户端无改动，构建不受影响
- 备注一下既有问题（与本 PR 无关）：`verify.sh --smoke` 的 `botBitSet` 检查在未改动的 origin/main（f240c2c）上同样失败，其余 smoke 项（加入/聊天闭环/小鸡事件）均通过

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34