### PR TITLE
feat: 鸡雨 · 定期空投小鸡增援（鸡口上限 18）

### DIFF
--- a/server/chicken_rain_test.go
+++ b/server/chicken_rain_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newChickenRainRoom(t *testing.T) *Room {
+	t.Helper()
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}, Spawns: [][3]float64{{0, 0, 0}, {10, 0, 10}}}, nil)
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{0, 0, 0}
+	r.Players = append(r.Players, human)
+	return r
+}
+
+func TestChickenRainAppendsChickensAndAnnounces(t *testing.T) {
+	r := newChickenRainRoom(t)
+	if len(r.Chickens) != chickenCount {
+		t.Fatalf("初始鸡口 = %d, 期望 %d", len(r.Chickens), chickenCount)
+	}
+	now := time.Now()
+	// 第一次 StepChickens 只排期不触发。
+	r.StepChickens(now)
+	if !r.nextChickenRainAt.After(now) {
+		t.Fatal("首次 StepChickens 应排期第一场鸡雨")
+	}
+	if len(r.Chickens) != chickenCount {
+		t.Fatalf("排期阶段不应增加鸡口, 实际 %d", len(r.Chickens))
+	}
+
+	// 到点触发：鸡口 +chickenRainBatch，新小鸡有生成事件，有真人在线应有播报。
+	r.nextChickenRainAt = now
+	before := len(r.pending)
+	r.StepChickens(now)
+	if len(r.Chickens) != chickenCount+chickenRainBatch {
+		t.Fatalf("鸡雨后鸡口 = %d, 期望 %d", len(r.Chickens), chickenCount+chickenRainBatch)
+	}
+	newIds := map[uint16]bool{}
+	for _, c := range r.Chickens[chickenCount:] {
+		if c.Id != uint16(300+chickenCount+len(newIds)) {
+			t.Fatalf("新小鸡 ID = %d, 期望顺序分配", c.Id)
+		}
+		newIds[c.Id] = true
+	}
+	spawned := map[uint16]bool{}
+	announced := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvChickenSpawn && newIds[e.Player] {
+			spawned[e.Player] = true
+		}
+		if e.Type == EvChat && strings.Contains(e.Message, "鸡雨") {
+			announced = true
+		}
+	}
+	if len(spawned) != chickenRainBatch {
+		t.Fatalf("新增小鸡应有各自生成事件, 实际 %d/%d: %v", len(spawned), chickenRainBatch, newIds)
+	}
+	if !announced {
+		t.Fatal("真人在线时鸡雨应有战场播报")
+	}
+
+	// 多轮鸡雨后触及上限，不再增长，但排期照常推进。
+	r.nextChickenRainAt = now
+	for len(r.Chickens) < chickenRainCap {
+		r.StepChickens(now)
+		r.nextChickenRainAt = now
+	}
+	if len(r.Chickens) != chickenRainCap {
+		t.Fatalf("鸡口应停在 %d, 实际 %d", chickenRainCap, len(r.Chickens))
+	}
+	next := r.nextChickenRainAt
+	r.chickenRain(now)
+	if len(r.Chickens) != chickenRainCap {
+		t.Fatalf("达上限后鸡雨不应继续增加鸡口, 实际 %d", len(r.Chickens))
+	}
+	if !r.nextChickenRainAt.After(next) {
+		t.Fatal("达上限后仍应推进下一场鸡雨排期")
+	}
+}
+
+func TestChickenRainRainDeadChickenStillRespawns(t *testing.T) {
+	r := newChickenRainRoom(t)
+	now := time.Now()
+	r.nextChickenRainAt = now
+	r.StepChickens(now)
+	bonus := &r.Chickens[len(r.Chickens)-1]
+	bonus.Alive = false
+	bonus.RespawnAt = now
+	r.StepChickens(now.Add(time.Second))
+	if !bonus.Alive {
+		t.Fatal("鸡雨小鸡被击杀后应与其他小鸡一样重生")
+	}
+}

--- a/server/room.go
+++ b/server/room.go
@@ -17,6 +17,8 @@ type Room struct {
 	Pickups               []Pickup
 	Chickens              []Chicken
 	nextNadeId, nextIdSeq uint16
+	nextChickenId         uint16
+	nextChickenRainAt     time.Time
 	tick                  uint32
 	pending               []Event
 	botAIs                map[uint16]*BotAI

--- a/server/sim.go
+++ b/server/sim.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"math/rand/v2"
@@ -1191,6 +1192,13 @@ const (
 	chickenWanderR   = 9.0                        // roam radius around home spawn
 	chickenHitHeight = 0.62                       // AABB height for bullet tests
 	chickenHeartbeat = 5 * time.Second            // max age of an idle chicken's last broadcast
+
+	// 鸡雨：定期空投增援小鸡，鸡口缓慢膨胀到上限为止。
+	chickenRainBatch = chickenCount / 2   // 每场鸡雨空投数量
+	chickenRainCap   = chickenCount * 3   // 鸡口上限
+	chickenRainFirst = 75 * time.Second   // 开局到第一场鸡雨
+	chickenRainMin   = 90 * time.Second   // 两场鸡雨最小间隔
+	chickenRainMax   = 150 * time.Second  // 两场鸡雨最大间隔
 )
 
 // Battlefield chickens are the classic CS-style easter egg: harmless voxel
@@ -1213,9 +1221,31 @@ func (r *Room) initChickens() {
 		return
 	}
 	r.Chickens = make([]Chicken, chickenCount)
+	r.nextChickenId = 300 + chickenCount
 	for i := range r.Chickens {
 		r.Chickens[i] = Chicken{Id: uint16(300 + i)}
 		r.respawnChicken(&r.Chickens[i])
+	}
+}
+
+// chickenRain 空投一批增援小鸡。鸡是常驻的（击杀后照常重生），不做回收，
+// 只用 chickenRainCap 限制膨胀；纯 bot 局不播报但照常下雨。
+func (r *Room) chickenRain(now time.Time) {
+	r.nextChickenRainAt = now.Add(chickenRainMin + time.Duration(rand.IntN(int((chickenRainMax-chickenRainMin)/time.Second)))*time.Second)
+	if len(r.Chickens) >= chickenRainCap {
+		return
+	}
+	for range chickenRainBatch {
+		r.Chickens = append(r.Chickens, Chicken{Id: r.nextChickenId})
+		r.nextChickenId++
+		r.respawnChicken(&r.Chickens[len(r.Chickens)-1])
+	}
+	for _, p := range r.Players {
+		if !p.IsBot {
+			r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+				Message: fmt.Sprintf("🐔 鸡雨来了！小鸡增援空投中（当前 %d 只）", len(r.Chickens))})
+			return
+		}
 	}
 }
 
@@ -1267,6 +1297,11 @@ func (r *Room) chickenEvents() []Event {
 func (r *Room) StepChickens(now time.Time) {
 	if len(r.Chickens) == 0 {
 		return
+	}
+	if r.nextChickenRainAt.IsZero() {
+		r.nextChickenRainAt = now.Add(chickenRainFirst)
+	} else if !now.Before(r.nextChickenRainAt) {
+		r.chickenRain(now)
 	}
 	for i := range r.Chickens {
 		c := &r.Chickens[i]


### PR DESCRIPTION
## 改了什么

整活功能②：**鸡雨**。战场小鸡（CS 式彩蛋，#14 引入）从此不再是固定 6 只——服务端定期「空投增援」，鸡口缓慢膨胀。

- **节奏**：开局 75 秒第一场鸡雨，之后每 90-150 秒随机一场，每场空投 3 只
- **上限**：鸡口封顶 18 只（`chickenCount*3`），达上限后排期照常推进但不再增长，避免无限膨胀
- **常驻编制**：空投小鸡与原住小鸡完全同权——被做成炸鸡后照常 15-25 秒重生，无需任何回收/清理逻辑
- **播报**：真人在线时全房播报「🐔 鸡雨来了！小鸡增援空投中（当前 N 只）」；纯 bot 局静默下雨
- **零协议改动**：`EvChickenSpawn` 按 ID 增量创建实体，客户端 `world.setChicken` 天然兼容新 ID；新玩家加入时 `chickenEvents()`（hub.go 加入握手）自动带上全部鸡口

## 实现细节

- `server/room.go`：Room 新增 `nextChickenId`（小鸡 ID 连续分配，300 起段）、`nextChickenRainAt` 两个字段
- `server/sim.go`：`StepChickens()` 头部排期钩子 + `chickenRain()`；空投走既有 `respawnChicken()` 路径（含落点避让与生成事件）
- 与 #19（连杀梗播报）无共享符号，可独立合并

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/chicken_rain_test.go`：
  - 首次 StepChickens 只排期不触发
  - 空投后鸡口 +3、新 ID 顺序分配、各自有生成事件、真人在线有播报
  - 多轮触发后精确停在 18 只上限，且下一场排期继续推进
  - 鸡雨小鸡阵亡后正常重生

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34