### PR TITLE
feat: 大头模式 · 远程玩家脑袋 ×2（纯视觉，判定不变）

### DIFF
--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -93,6 +93,9 @@ const diamondGunColor = new THREE.Color(0x72e7ff);
 // Standing geometry spans 0.04–1.605 m; map it exactly onto the 2.1 m hitbox.
 export const STANDING_VISUAL_SCALE = 2.1 / 1.565;
 export const STANDING_VISUAL_OFFSET = -0.04 * STANDING_VISUAL_SCALE;
+// 大头模式：远程玩家头部放大倍数。纯视觉整活——命中判定仍在服务端的
+// 标准 AABB 上进行，大头并不更容易爆头（憨归憨，公平归公平）。
+export const BIG_HEAD_SCALE = 2;
 const approach = (value: number, wanted: number, amount: number) => value < wanted ? Math.min(wanted, value + amount) : Math.max(wanted, value - amount);
 const angleLerp = (a: number, b: number, t: number) => a + Math.atan2(Math.sin(b - a), Math.cos(b - a)) * t;
 
@@ -478,7 +481,7 @@ export class RemotePlayers {
       this.place(this.body, model.index, model, sin, cos, 0, bodyY, 0, 0);
 
       // Head (Pivots at neck)
-      this.place(this.head, model.index, model, sin, cos, 0, headY, 0, model.pitch);
+      this.place(this.head, model.index, model, sin, cos, 0, headY, 0, model.pitch, 0, 0, 1, BIG_HEAD_SCALE);
       // Two-handed forward triangular V-shape weapon grip (尖尖双手持枪)
       const isKnife = state.weapon === 6;
       const pistolHold = state.weapon === 0 || state.weapon === 1 || state.weapon === 7;
@@ -624,6 +627,7 @@ export class RemotePlayers {
     yawOffset = 0,
     roll = 0,
     scaleZ = 1,
+    scale = 1,
   ) {
     const yaw = model.yaw + yawOffset;
     const standing = !(model.state.state & 4);
@@ -634,7 +638,7 @@ export class RemotePlayers {
       model.position.z - lx * sin + lz * cos,
     );
     this.dummy.rotation.set(pitch, yaw, roll, 'YXZ');
-    this.dummy.scale.set(1, scaleY, scaleZ);
+    this.dummy.scale.set(scale, scaleY * scale, scale * scaleZ);
     this.dummy.updateMatrix();
     mesh.setMatrixAt(index, this.dummy.matrix);
   }


### PR DESCRIPTION
## 改了什么

整活功能③：**大头模式**。所有远程玩家的脑袋以脖子为轴点放大 2 倍——战场变成快乐星球。

- **纯视觉**：头部实例（含头盔/夜视仪/耳罩的合并几何）整体 ×2，皮肤 UV、走摆动画、俯仰跟随全部保留
- **公平性**：命中判定完全不变——服务端照旧用标准 AABB 做射线检测，大头只是看起来好打，实际头部判定范围一毫米没多（憨归憨，公平归公平 🙂）
- **零协议改动、零服务端改动**

## 实现细节

- `client/src/player.ts`：
  - `place()` 追加可选参数 `scale = 1`，实例矩阵从 `set(1, scaleY, scaleZ)` 改为 `set(scale, scaleY*scale, scale*scaleZ)`——所有既有调用（身体/手臂/腿/枪）行为逐位不变（默认 scale=1）
  - 头部调用传 `BIG_HEAD_SCALE = 2`
- 轴点安全性：头部几何 pivot 在颈部（`geo.translate(0, 0.18, 0)`），放大后向下不侵入躯干；站立的 `STANDING_VISUAL_SCALE` 修正照常作用于头部锚点
- 名牌不受遮挡：放大后头顶 ≈1.96m，名牌锚点在 2.35m
- 皮肤预览（`preview.ts`）使用独立几何实例，不受影响

## 验证

- `npm run build` 通过（仅既有的 chunk 体积告警）
- 既有调用回归审查：`place()` 全部调用点逐参数核对，默认参数路径与改动前逐位等价

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34