### PR TITLE
feat: 击杀烟花秀 · 自己的击杀炸彩虹烟花（爆头加大号）

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1327,6 +1327,10 @@ function handleEvent(e: GameEvent) {
     const victimState = states.get(e.victim ?? -1);
     if (victimState) particles.spawnDeath(eventOrigin.set(victimState.x, victimState.y + 0.9, victimState.z), e.headshot === 1);
     else if (e.victim === net.yourId) particles.spawnDeath(eventOrigin.set(local.pos.x, local.pos.y + 0.9, local.pos.z), e.headshot === 1);
+    // 击杀烟花秀：自己完成击杀时在目标位置补一朵彩虹烟花（爆头更大一圈）
+    if (e.killer === net.yourId && e.victim !== net.yourId && victimState) {
+      particles.spawnFirework(eventOrigin.set(victimState.x, victimState.y + 0.9, victimState.z), e.headshot === 1);
+    }
     if (e.victim === net.yourId) audio.play('death', 0.65);
     else if (victimState) playSpatial('death', victimState.x, victimState.z, 0.35, 45);
     const k = roster.get(e.killer ?? -1);

--- a/client/src/particles.ts
+++ b/client/src/particles.ts
@@ -11,6 +11,7 @@ const FIRE_COLORS = [0xff2200, 0xff5500, 0xff9900, 0xffdd33, 0xfffa88];
 const SMOKE_COLORS = [0x1e1e22, 0x38383e, 0x55555c, 0x777780];
 const DEATH_COLORS = [0x00a8aa, 0x2b3577, 0xd9a377, 0x3a3a3a];
 const FEATHER_COLORS = [0xf2ede0, 0xe4ddc9, 0xd8d0bc, 0xe8a13a];
+const FIREWORK_COLORS = [0xff4d4d, 0xffb84d, 0xffe74d, 0x6dff7c, 0x4dc3ff, 0xb04dff, 0xff4dd2];
 
 interface ParticleData {
   x: number;
@@ -159,6 +160,32 @@ export class ParticleSystem {
         life: 650 + Math.random() * 500,
         size: 1.8 + Math.random() * 2.2,
         gravity: 18,
+      });
+    }
+  }
+
+  // spawnFirework：自己完成击杀时在目标位置炸开一朵彩虹烟花。
+  // big 用于爆头：更大一圈、飞得更高。纯客户端装饰，不参与任何判定。
+  spawnFirework(pos: THREE.Vector3, big = false) {
+    const count = Math.min(big ? 90 : 56, MAX_PARTICLES - this.particles.length);
+    const now = performance.now();
+    for (let i = 0; i < count; i++) {
+      // 球面均匀分布、向上偏置，形成一朵向上炸开的烟花
+      const theta = Math.random() * Math.PI * 2;
+      const phi = Math.acos(2 * Math.random() - 1);
+      const speed = (big ? 5.5 : 4) + Math.random() * (big ? 6 : 4.5);
+      this.particles.push({
+        x: pos.x,
+        y: pos.y + 0.4,
+        z: pos.z,
+        vx: Math.sin(phi) * Math.cos(theta) * speed,
+        vy: Math.abs(Math.cos(phi)) * speed * 0.9 + 2.5,
+        vz: Math.sin(phi) * Math.sin(theta) * speed,
+        color: FIREWORK_COLORS[i % FIREWORK_COLORS.length],
+        born: now,
+        life: 900 + Math.random() * 700,
+        size: 1.6 + Math.random() * 2,
+        gravity: 9,
       });
     }
   }


### PR DESCRIPTION
## 改了什么

整活功能④：**击杀烟花秀**。自己完成击杀的瞬间，在目标位置炸开一朵彩虹烟花；爆头时更大一圈。

- **视觉**：7 色彩虹粒子、球面均匀分布 + 向上偏置（先炸开再飘落），重力 9 带漂浮感，寿命 0.9-1.6s；爆头 `big=true`：90 粒 vs 56 粒、初速更高
- **与既有死亡特效叠加不冲突**：`spawnDeath`（青蓝灰的死亡碎片）照常播放，烟花在其上叠加庆祝层
- **零协议、零服务端改动**：复用 EvKill 事件里已经有的受害者快照位置

## 实现细节

- `client/src/particles.ts`：新增 `spawnFirework(pos, big = false)`，完全复用既有 `ParticleData` 管线与 InstancedMesh 粒子池（沿用 `MAX_PARTICLES` 上限与容量截断，烟花多了会挤占普通粒子配额但不崩）
- `client/src/main.ts`：EvKill 分支中 `victimState` 就绪后追加 4 行触发逻辑；`eventOrigin` 临时向量同步消费，无时序问题
- 自雷（`e.victim === net.yourId`）不放烟花——炸自己没什么好庆祝的

## 验证

- `npm run build` 通过（仅既有 chunk 体积告警）
- 与 #18（雷达活化等，也在 main.ts handleEvent 内改动）改动区域不同（EvKill 分支 vs 雷达/喊话分支），可干净合并且无符号冲突

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34