### PR TITLE
feat: bot 击杀嘲讽 · 得手后原地转圈庆祝（40% 概率）

### DIFF
--- a/server/bot.go
+++ b/server/bot.go
@@ -53,7 +53,18 @@ type BotAI struct {
 	GlanceUntil  time.Time
 	GlanceYaw    float64
 	LastHurtAt   time.Time
+	// 击杀嘲讽：TauntUntil 之前原地转圈庆祝，TauntSpin 为旋转方向（±1）。
+	TauntUntil time.Time
+	TauntSpin  float64
 }
+
+// 嘲讽是可调的整活参数；chance 用 var 方便测试里改成 100%。
+var botTauntChance = 0.4
+
+const (
+	botTauntDuration = 1500 * time.Millisecond
+	botTauntSpinRate = 0.42 // rad per tick，60tick/s ≈ 每秒 4 圈
+)
 
 func (r *Room) SetBotCount(count int) {
 	if count < 0 {
@@ -150,6 +161,15 @@ func (r *Room) StepBots(now time.Time) {
 			ai.Target = nil
 			ai.TargetDist = 0
 			ai.HearUntil = time.Time{}
+			continue
+		}
+
+		// 击杀嘲讽：原地转圈庆祝，期间不动、不开火、不索敌、不换弹。
+		if now.Before(ai.TauntUntil) {
+			p.CmdKeys = 0
+			p.Yaw += ai.TauntSpin * botTauntSpinRate
+			ai.Target = nil
+			ai.TargetDist = 0
 			continue
 		}
 
@@ -477,7 +497,21 @@ func yawToward(cur, want, rate float64) float64 {
 }
 
 func (r *Room) botKilled(victim, killer *PlayerState, now time.Time) {
-	if victim == nil || killer == nil || !victim.IsBot || victim.Id == killer.Id {
+	if victim == nil || killer == nil || victim.Id == killer.Id {
+		return
+	}
+	// 击杀嘲讽：bot 得手后概率原地转圈庆祝（无论 victim 是真人还是 bot）。
+	if killer.IsBot {
+		if kai := r.botAIs[killer.Id]; kai != nil && rand.Float64() < botTauntChance {
+			kai.TauntUntil = now.Add(botTauntDuration)
+			if rand.Float64() < 0.5 {
+				kai.TauntSpin = -1
+			} else {
+				kai.TauntSpin = 1
+			}
+		}
+	}
+	if !victim.IsBot {
 		return
 	}
 	ai := r.botAIs[victim.Id]

--- a/server/bot_taunt_test.go
+++ b/server/bot_taunt_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func newTauntRoom() *Room {
+	// 空地图：无墙体、无出生点，Raycast/CanOccupy 均为确定性空行为。
+	return NewRoom(1, &World{Size: [2]float64{64, 64}}, nil)
+}
+
+// Bot 得手（无论击杀真人还是 bot）都应概率触发嘲讽：TauntUntil 置为未来、方向为 ±1。
+func TestBotTauntTriggersOnKill(t *testing.T) {
+	old := botTauntChance
+	botTauntChance = 1
+	defer func() { botTauntChance = old }()
+
+	r := newTauntRoom()
+	killer := newTestBot(10, r)
+	r.Players = append(r.Players, killer)
+	r.botAIs[10] = &BotAI{}
+
+	now := time.Now()
+	// 击杀真人也嘲讽（victim 非 bot 不影响触发）。
+	r.botKilled(&PlayerState{Id: 77}, &killer.PlayerState, now)
+	ai := r.botAIs[10]
+	if !now.Before(ai.TauntUntil) {
+		t.Fatal("击杀后应进入嘲讽状态")
+	}
+	if ai.TauntUntil.Sub(now) != botTauntDuration {
+		t.Fatalf("嘲讽时长 = %v, 期望 %v", ai.TauntUntil.Sub(now), botTauntDuration)
+	}
+	if ai.TauntSpin != -1 && ai.TauntSpin != 1 {
+		t.Fatalf("嘲讽方向 = %v, 期望 ±1", ai.TauntSpin)
+	}
+
+	// 自雷不嘲讽。
+	ai.TauntUntil = time.Time{}
+	r.botKilled(&killer.PlayerState, &killer.PlayerState, now)
+	if !ai.TauntUntil.IsZero() {
+		t.Fatal("自雷不应触发嘲讽")
+	}
+
+	// 概率为 0 时不触发。
+	botTauntChance = 0
+	ai.TauntUntil = time.Time{}
+	r.botKilled(&PlayerState{Id: 77}, &killer.PlayerState, now)
+	if !ai.TauntUntil.IsZero() {
+		t.Fatal("概率 0 时不应触发嘲讽")
+	}
+}
+
+// 嘲讽期间 bot 应原地转圈：CmdKeys 为 0、yaw 按方向恒速旋转；结束后恢复常态移动。
+func TestBotTauntSpinsInPlace(t *testing.T) {
+	r := newTauntRoom()
+	killer := newTestBot(10, r)
+	killer.Pos = Vec3{5, 0, 5}
+	r.Players = append(r.Players, killer)
+	r.botAIs[10] = &BotAI{TargetPos: Vec3{-20, 0, -20}, NextGlanceAt: time.Now().Add(time.Hour), TauntUntil: time.Now().Add(time.Second), TauntSpin: 1}
+	killer.Yaw = 0
+
+	now := time.Now()
+	for range 10 {
+		r.StepBots(now)
+		now = now.Add(time.Second / TickRate)
+	}
+	if killer.CmdKeys != 0 {
+		t.Fatalf("嘲讽期间移动键应为 0, 实际 %d", killer.CmdKeys)
+	}
+	want := 10 * botTauntSpinRate
+	if killer.Yaw < want*0.99 || killer.Yaw > want*1.01 {
+		t.Fatalf("10 tick 后 yaw = %f, 期望 ≈ %f", killer.Yaw, want)
+	}
+
+	// 嘲讽结束后恢复常态：朝目标点移动。
+	r.botAIs[10].TauntUntil = now.Add(-time.Second)
+	r.StepBots(now)
+	if killer.CmdKeys&KeyForward == 0 {
+		t.Fatalf("嘲讽结束后应恢复移动, CmdKeys = %d", killer.CmdKeys)
+	}
+}


### PR DESCRIPTION
## 改了什么

整活功能⑤：**bot 击杀嘲讽**。bot 得手后有一定概率在原地来一段快乐转圈舞——你刚从屏幕上消失，凶手就在你的尸体旁转圈庆祝。

- **触发**：bot 完成击杀（ victim 是真人或 bot 均可）后 40% 概率触发，随机方向
- **表演**：原地转圈 1.5 秒，转速 0.42 rad/tick（60tick/s ≈ 每秒 4 圈），纯 yaw 旋转，位置不动
- **AI 冻结**：嘲讽期间不移动、不开火、不索敌、不换弹（与既有黑梦冻结块同一实现模式：置零 + continue），不会出现边转圈边开枪的鬼畜画面
- **安全边界**：自雷不庆祝；黑梦大招冻结优先级更高；复仇追杀/听声警觉等状态在嘲讽结束后照常生效
- **零协议改动、零 sim.go 改动**（触发点复用 `botKilled`，快照的 yaw 字段天然把旋转同步给所有客户端）

## 实现细节

- `server/bot.go`：
  - `BotAI` 新增 `TauntUntil` / `TauntSpin` 两个字段
  - `botKilled()` 顶部（`victim.IsBot` 判断之前）加触发逻辑——这是唯一需要动到击杀路径的地方，因此与 #19（连杀梗播报，在 sim.go Damage）完全无冲突
  - `StepBots()` 在黑梦冻结块之后插入嘲讽块
  - `botTauntChance` 用 `var`（0.4），测试可注入 100%/0%
- 转圈通过每 tick 直接修改 `p.Yaw` 实现，与其他 AI 的 `yawToward` 平滑转向天然互斥（嘲讽块 continue 跳过）

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/bot_taunt_test.go`：
  - 击杀真人触发、时长精确 1.5s、方向 ±1
  - 自雷不触发、概率 0 不触发
  - 嘲讽期间 10 tick：CmdKeys 恒为 0、yaw 恒速累计（误差 <1%）
  - 嘲讽结束后恢复常态：朝目标点移动（KeyForward 置位）

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34