### PR TITLE
feat: bot 全员梗化 · 老六蹲王/白给战神/菜就多练参战

### DIFF
--- a/server/bot.go
+++ b/server/bot.go
@@ -16,19 +16,21 @@ func botSkill(id uint16) int {
 	return int(id) % (maxBotSkill + 1)
 }
 
+// 整活名单：bot 全员梗化登场。名字带 [BOT] 前缀仅为旧客户端兼容兜底
+// （真人/AI 权威判定走快照状态字节 bit128），长度须与 maxBotCount 容量一致。
 var BotNames = []string{
-	"[BOT] Phoenix",
-	"[BOT] Hunter",
-	"[BOT] Viper",
-	"[BOT] Ghost",
-	"[BOT] Maverick",
-	"[BOT] Raven",
-	"[BOT] Striker",
-	"[BOT] Valkyrie",
-	"[BOT] Apex",
-	"[BOT] Shadow",
-	"[BOT] Frost",
-	"[BOT] Titan",
+	"[BOT] 老六蹲王",
+	"[BOT] 干拉哥",
+	"[BOT] 狙击之神（水）",
+	"[BOT] 鸡圈守护者",
+	"[BOT] 一枪不中",
+	"[BOT] 平底锅侠",
+	"[BOT] 扔雷小能手",
+	"[BOT] 白给战神",
+	"[BOT] 战场氛围组",
+	"[BOT] 疾跑送头侠",
+	"[BOT] 蹲坑艺术家",
+	"[BOT] 菜就多练",
 }
 
 type BotAI struct {


### PR DESCRIPTION
## 改了什么

整活功能⑥：**bot 全员梗化**。12 名 bot 从英文代号换成战场活人感中文名单——击杀播报从「[BOT] Viper 击杀了 you」变成「[BOT] 白给战神 击杀了 you」，痛苦都变得有趣了。

- 新名单：老六蹲王 / 干拉哥 / 狙击之神（水）/ 鸡圈守护者 / 一枪不中 / 平底锅侠 / 扔雷小能手 / 白给战神 / 战场氛围组 / 疾跑送头侠 / 蹲坑艺术家 / 菜就多练
- 记分板、头顶名牌、击杀播报、聊天徽章全部自动生效，无需客户端改动

## 兼容性说明

- `[BOT]` 前缀保留：权威的真人/AI 判定走快照状态字节 bit128（#16 引入），前缀仅作旧客户端显示兜底
- 名单长度不变（12 = `maxBotCount` 容量上限来源）
- 名字经 `safeNameBytes`（≤64 字节）编码，最长「[BOT] 狙击之神（水）」22 字节，远在限内
- bot 不写战绩库（`Store.Accumulate` 仅真人），无数据兼容问题

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 纯数据改动：diff 仅名单字符串，无逻辑变化

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34