### PR TITLE
feat: 月球跳 · 重力-30% 起跳+25%，全服蹦得更高（预测两端同步）

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -141,8 +141,9 @@ export const PHYS = {
   groundAccel: 44,
   stopAccel: 60,
   airAccel: 9.5,
-  gravity: -22.0,
-  jumpVel: 8.4,
+  // 月球跳：与服务端 sim.go 的 Gravity/JumpVel 保持逐位一致（预测不回弹）
+  gravity: -15.0,
+  jumpVel: 10.5,
   crouchSpeed: 0.6,
   eyeHeight: 1.7,
   crouchEye: 1.12,

--- a/server/moon_jump_test.go
+++ b/server/moon_jump_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// 月球跳：按服务端 Move 的离散积分模拟一次满额起跳，验证跳跃高度
+// 与新解析解 ≈3.7m 吻合（旧参数重力 -22、起跳 8.4 只有 1.6m）。
+// 注意：客户端预测常数（client/src/constants.ts 的 PHYS.gravity/jumpVel）
+// 与服务端 Gravity/JumpVel 必须逐位一致，改动时两端同步。
+func TestMoonJumpApex(t *testing.T) {
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}}, nil)
+	p := &Player{Room: r, joined: true}
+	p.PlayerState = PlayerState{Id: 10, Name: "moon", Primary: 3, Secondary: 0, ActiveSlot: 1}
+	p.ApplyLoadout(3, 0)
+	p.HP = MaxHP
+	p.Alive = true
+	p.OnGround = true
+	p.Pos = Vec3{0, 0, 0}
+	p.CmdKeys = KeyJump
+	r.Players = append(r.Players, p)
+
+	now := time.Now()
+	apex := 0.0
+	for range 240 { // 4 秒足够完成一次起跳-落地
+		r.Move(&p.PlayerState, now)
+		now = now.Add(time.Second / TickRate)
+		if p.Pos.Y > apex {
+			apex = p.Pos.Y
+		}
+	}
+	// 解析解 v²/2g = 10.5²/30 ≈ 3.675；离散积分误差在容差内。
+	want := JumpVel * JumpVel / (2 * math.Abs(Gravity))
+	if apex < want-0.25 || apex > want+0.25 {
+		t.Fatalf("月球跳顶点 = %.3f, 期望 %.3f ±0.25", apex, want)
+	}
+	if apex < 3.0 {
+		t.Fatalf("月球跳顶点 %.3f 应显著高于旧参数的 1.6m", apex)
+	}
+	if p.OnGround && p.Pos.Y > 0.01 {
+		t.Fatalf("跳跃结束后应回到地面, 实际 y = %.3f", p.Pos.Y)
+	}
+}

--- a/server/proto_test.go
+++ b/server/proto_test.go
@@ -112,7 +112,8 @@ func TestWebSocketHeartbeatToleratesThrottledBrowserTimers(t *testing.T) {
 }
 
 func TestBalanceValues(t *testing.T) {
-	if RespawnDelayS != 3*time.Second || WalkSpeed != 6.4 || GroundAccel != 44 || StopAccel != 60 || AirAccel != 9.5 || JumpVel != 8.4 || MaxRewindTicks != 8 {
+	// 月球跳（Gravity=-15 / JumpVel=10.5）是有意的平衡变更，见 sim.go 常数注释。
+	if RespawnDelayS != 3*time.Second || WalkSpeed != 6.4 || GroundAccel != 44 || StopAccel != 60 || AirAccel != 9.5 || JumpVel != 10.5 || MaxRewindTicks != 8 {
 		t.Fatalf("unexpected movement balance")
 	}
 	wantDamage := []float64{23, 44, 22, 33, 29, 103, 34, 24, 27, 29, 27, 72, 17}

--- a/server/sim.go
+++ b/server/sim.go
@@ -65,8 +65,10 @@ const (
 	StopAccel                   = 60.0
 	AirAccel                    = 9.5
 	CrouchSpeed                 = .6
-	Gravity                     = -22.0
-	JumpVel                     = 8.4
+	// 月球跳：重力 -30%、起跳 +25%，跳跃高度 1.6m → ≈3.7m。
+	// 客户端预测常数（client/src/constants.ts 的 PHYS.gravity/jumpVel）必须同步修改。
+	Gravity                     = -15.0
+	JumpVel                     = 10.5
 	MaxRewindTicks              = 8
 	MaxHP                       = 100
 	SpawnProtectS               = 2 * time.Second


### PR DESCRIPTION
## 改了什么

整活功能⑦：**月球跳**。全服进入低重力状态——重力 -30%、起跳速度 +25%，跳跃高度从 1.6m 飙到 ≈3.7m，人人都是月球漫步者，手雷抛物线一起变飘。

- **服务端** `server/sim.go`：`Gravity -22.0 → -15.0`，`JumpVel 8.4 → 10.5`
- **客户端** `client/src/constants.ts`：`PHYS.gravity/jumpVel` **逐位同步**——本地预测公式与服务端 `Move()` 完全一致（跳起判定、重力积分同一公式），零回弹
- 附带效果（两端一致，非副作用）：手雷飞行轨迹变飘（服务端 `StepGrenades` 与客户端预览线共用同一常数）

## 设计取舍（第一性原则）

- **预测一致性是硬约束**：`LocalPlayer.update` 的 `vel.y = jumpVel` / `vel.y += gravity*dt` 与服务端 `Move()` 逐行对应，所以必须双端同改、逐位一致——两端注释都标注了这个耦合
- **不会飞出地图**：跳跃顶点 ≈3.7m，`MaxFlightHeight`(45m) 与地图边界检查不变；蹲跳、飞行模式逻辑不受影响
- **平衡锁定测试同步更新**：`TestBalanceValues` 的职责是防止*意外*漂移，本次为有意变更，锁定值更新为 10.5 并注释来源

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过（含更新后的平衡锁定测试）
- 新增 `server/moon_jump_test.go`：以服务端 `Move()` 的离散积分模拟满额起跳 4 秒，顶点 = 3.675m ±0.25（解析解 v²/2g），显著高于旧参数 1.6m，且最终落回地面
- `npm run build` 通过

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34