### PR TITLE
feat: 蹦迪灯光秀 · 全场景灯光色相循环（光敏友好，无频闪）

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -38,6 +38,19 @@ scene.add(camera);
 const fillLight = new THREE.DirectionalLight(0x789fb0, 0.5);
 fillLight.position.set(-70, 50, 70);
 scene.add(fillLight);
+
+// 蹦迪灯光秀：全场景灯光色相缓慢循环（24s 一轮），亮度/强度恒定——
+// 只转色相不闪频，光敏玩家友好。纯客户端装饰，不影响任何玩法数据。
+const DISCO_PERIOD_MS = 24000;
+function applyDiscoLights(t: number) {
+  const hue = (t % DISCO_PERIOD_MS) / DISCO_PERIOD_MS;
+  sun.color.setHSL(hue, 0.55, 0.62);
+  hemiLight.color.setHSL((hue + 0.5) % 1, 0.4, 0.75);
+  hemiLight.groundColor.setHSL((hue + 0.25) % 1, 0.45, 0.35);
+  fillLight.color.setHSL((hue + 0.33) % 1, 0.5, 0.6);
+  (scene.background as THREE.Color).setHSL(hue, 0.35, 0.5);
+  (scene.fog as THREE.Fog).color.setHSL(hue, 0.35, 0.62);
+}
 const hud = new Hud();
 const audio = new AudioEngine();
 window.addEventListener('pointerdown', () => audio.init(), { once: true, capture: true });
@@ -1767,6 +1780,7 @@ function frame(t: number) {
     particles.update(dt, t, world);
     world?.animate(t);
     weapons.syncFrom(camera);
+    applyDiscoLights(t);
     renderer.render(scene, camera);
     if (alive) weapons.renderOverlay(renderer, scene);
     if (t - lastLabels >= 1000 / 30) {


### PR DESCRIPTION
## 改了什么

整活功能⑧：**蹦迪灯光秀**。全场景灯光色相持续循环——太阳、补光、半球光天地色、天空背景、雾，六处按错开相位 24 秒一轮缓慢变色，战场自带舞美。

- **光敏友好**：只转色相（HSL 的 H），亮度与光强恒定，无任何明暗脉冲/频闪
- **相位错开**：主光 / 补光(+0.33) / 半球天(+0.5) / 地面(+0.25) 各走各的色环，颜色有层次不糊成一色
- **零玩法影响**：不触碰玩家皮肤材质、HUD、命中数据、协议

## 实现细节

- `client/src/main.ts`：新增 `applyDiscoLights(t)`，在 `frame()` 渲染前调用；每帧 6 次 `setHSL`，开销可忽略
- `scene.fog` 的 TS 可空类型用显式收窄处理（初始化在同文件底部无法被推导）

## 验证

- `tsc --noEmit && vite build` 通过（仅既有 chunk 体积告警）
- 观感说明：色相循环周期 24s，肉眼为缓慢彩虹流转而非闪烁

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34