### PR TITLE
feat: 鸡群围观 · 随机真人当选偶像，全体小鸡涌向你

### DIFF
--- a/server/chicken_mob_test.go
+++ b/server/chicken_mob_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newMobRoom() *Room {
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}, Spawns: [][3]float64{{0, 0, 0}, {10, 0, 10}}}, nil)
+	r.initChickens()
+	human := newTestHuman(10, r)
+	human.Name = "偶像哥"
+	human.Pos = Vec3{20, 0, 20}
+	human.Alive = true
+	r.Players = append(r.Players, human)
+	return r
+}
+
+func TestChickenMobChasesIdol(t *testing.T) {
+	r := newMobRoom()
+	now := time.Now()
+	r.pending = nil // 丢弃 initChickens 的出生事件，只看本次调用增量
+	// 排期阶段不动。
+	r.stepChickenMob(now)
+	if len(r.pending) != 0 {
+		t.Fatal("排期阶段不应有事件")
+	}
+	// 到点开场：偶像选定 + 播报。
+	r.nextChickenMobAt = now
+	before := len(r.pending)
+	r.stepChickenMob(now)
+	if r.chickenMobTarget != 10 {
+		t.Fatalf("偶像应为唯一真人 10, 实际 %d", r.chickenMobTarget)
+	}
+	announced := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvChat && strings.Contains(e.Message, "偶像哥") {
+			announced = true
+		}
+	}
+	if !announced {
+		t.Fatal("开场应有含偶像名的播报")
+	}
+	// 围观中：小鸡把家安到偶像脚下并朝他走。
+	r.stepChickenMob(now.Add(time.Second))
+	c := &r.Chickens[0]
+	if c.Home.X != 20 || c.Home.Z != 20 {
+		t.Fatalf("围观中小鸡的家应迁到偶像脚下, 实际 %v", c.Home)
+	}
+	if c.Dir.X == 0 && c.Dir.Z == 0 {
+		t.Fatal("远距离围观中小鸡应朝偶像方向移动")
+	}
+	// 偶像阵亡 → 就地解散：定居 + 清态 + 播报。
+	human := r.Players[0]
+	human.Alive = false
+	before = len(r.pending)
+	r.stepChickenMob(now.Add(2 * time.Second))
+	if !r.chickenMobUntil.IsZero() || r.chickenMobTarget != 0 {
+		t.Fatal("偶像阵亡后围观状态应清空")
+	}
+	if c.Home != c.Pos {
+		t.Fatalf("解散后小鸡应就地定居, Home=%v Pos=%v", c.Home, c.Pos)
+	}
+	dissolved := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvChat && strings.Contains(e.Message, "解散") {
+			dissolved = true
+		}
+	}
+	if !dissolved {
+		t.Fatal("解散应有播报")
+	}
+}
+
+func TestChickenMobSkipsWithoutHumans(t *testing.T) {
+	r := newMobRoom()
+	r.Players = nil // 纯 bot/无人局
+	now := time.Now()
+	r.nextChickenMobAt = now
+	before := len(r.pending)
+	r.stepChickenMob(now)
+	if !r.chickenMobUntil.IsZero() {
+		t.Fatal("无真人不应开场")
+	}
+	if len(r.pending) != before {
+		t.Fatal("无真人不应播报")
+	}
+	if !r.nextChickenMobAt.After(now) {
+		t.Fatal("无真人应改期重试")
+	}
+}

--- a/server/room.go
+++ b/server/room.go
@@ -22,6 +22,9 @@ type Room struct {
 	botAIs                map[uint16]*BotAI
 	history               map[uint16]*poseHistory
 	teamAttempts          map[uint16]*teamAttempt
+	chickenMobTarget      uint16
+	chickenMobUntil       time.Time
+	nextChickenMobAt      time.Time
 	outboundBuf           []outbound
 	quantizedBuf          []quantState
 }

--- a/server/sim.go
+++ b/server/sim.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"math/rand/v2"
@@ -1191,6 +1192,13 @@ const (
 	chickenWanderR   = 9.0                        // roam radius around home spawn
 	chickenHitHeight = 0.62                       // AABB height for bullet tests
 	chickenHeartbeat = 5 * time.Second            // max age of an idle chicken's last broadcast
+
+	// 鸡群围观：随机选一名存活真人当「偶像」，全体小鸡涌向他围观一阵。
+	chickenMobFirst    = 150 * time.Second // 开局到第一场围观
+	chickenMobDuration = 12 * time.Second  // 每场围观时长
+	chickenMobMinGap   = 180 * time.Second // 两场围观最小间隔
+	chickenMobMaxGap   = 300 * time.Second // 两场围观最大间隔
+	chickenMobRetry    = 30 * time.Second  // 无真人可围观时重试
 )
 
 // Battlefield chickens are the classic CS-style easter egg: harmless voxel
@@ -1318,6 +1326,98 @@ func (r *Room) StepChickens(now time.Time) {
 			c.lastEmitPos, c.lastEmitAt = c.Pos, now
 		}
 	}
+	r.stepChickenMob(now)
+}
+
+// stepChickenMob 驱动「鸡群围观」：到点随机选一名存活真人当偶像，
+// 全体小鸡把家安到偶像脚下并朝他走（借 wander 机制自然聚拢）；
+// 围观结束就地定居。无真人则改期重试。
+func (r *Room) stepChickenMob(now time.Time) {
+	if len(r.Chickens) == 0 {
+		return
+	}
+	if !r.chickenMobUntil.IsZero() {
+		if now.Before(r.chickenMobUntil) {
+			idol := r.findPlayer(r.chickenMobTarget)
+			if idol != nil && idol.Alive {
+				for i := range r.Chickens {
+					c := &r.Chickens[i]
+					if !c.Alive || now.Before(c.NextTurn) {
+						continue
+					}
+					dx, dz := idol.Pos.X-c.Pos.X, idol.Pos.Z-c.Pos.Z
+					c.Home = Vec3{idol.Pos.X, idol.Pos.Y, idol.Pos.Z}
+					if dx*dx+dz*dz > 0.01 {
+						c.Dir = norm(Vec3{dx, 0, dz})
+					} else {
+						c.Dir = Vec3{} // 已经贴脸：站定仰视
+					}
+					c.NextTurn = now.Add(500 * time.Millisecond)
+				}
+				return
+			}
+			// 偶像阵亡/退出：就地解散
+			r.endChickenMob(now)
+			return
+		}
+		r.endChickenMob(now)
+		return
+	}
+	if r.nextChickenMobAt.IsZero() {
+		r.nextChickenMobAt = now.Add(chickenMobFirst)
+		return
+	}
+	if !now.Before(r.nextChickenMobAt) {
+		idol := r.pickChickenMobIdol()
+		gap := chickenMobMinGap + time.Duration(rand.IntN(int((chickenMobMaxGap-chickenMobMinGap)/time.Second)))*time.Second
+		r.nextChickenMobAt = now.Add(gap)
+		if idol == nil {
+			r.nextChickenMobAt = now.Add(chickenMobRetry)
+			return
+		}
+		r.chickenMobTarget = idol.Id
+		r.chickenMobUntil = now.Add(chickenMobDuration)
+		if r.hasAnyHumanOnline() {
+			r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+				Message: fmt.Sprintf("🎤🐣 小鸡们找到了新偶像：%s！全体围观！", idol.Name)})
+		}
+	}
+}
+
+func (r *Room) endChickenMob(now time.Time) {
+	for i := range r.Chickens {
+		c := &r.Chickens[i]
+		if c.Alive {
+			c.Home = c.Pos // 就地定居
+		}
+	}
+	if r.hasAnyHumanOnline() {
+		r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报", Message: "小鸡围观结束，就地解散定居"})
+	}
+	r.chickenMobUntil = time.Time{}
+	r.chickenMobTarget = 0
+}
+
+func (r *Room) pickChickenMobIdol() *PlayerState {
+	humans := make([]*PlayerState, 0, 4)
+	for _, p := range r.Players {
+		if !p.IsBot && p.Alive {
+			humans = append(humans, &p.PlayerState)
+		}
+	}
+	if len(humans) == 0 {
+		return nil
+	}
+	return humans[rand.IntN(len(humans))]
+}
+
+func (r *Room) hasAnyHumanOnline() bool {
+	for _, p := range r.Players {
+		if !p.IsBot {
+			return true
+		}
+	}
+	return false
 }
 
 // chickenShot tests the pellet ray against every live chicken; the nearest hit


### PR DESCRIPTION
## 改了什么

整活功能⑨：**鸡群围观**。每隔几分钟，系统随机选出一名存活真人当「偶像」，全体小鸡放下嘴边的活儿，浩浩荡荡向他涌去围观 12 秒——你正趴在角落蹲人，回头发现身后跟着一整支鸡队。

- **节奏**：开局 150 秒首场，之后每 180-300 秒随机一场，每场 12 秒
- **聚拢机制**：小鸡把「家」迁到偶像脚下并朝他移动（复用 wander 的 9m 徘徊机制，自然围成一圈而不是重叠成一坨）；贴脸时站定仰视
- **散场**：围观结束小鸡就地定居（当前位置成为新家）；偶像阵亡/退出立即解散
- **播报**：开场「🎤🐣 小鸡们找到了新偶像：X！全体围观！」；无真人可围观时 30 秒后重试，纯 bot 局不播报
- **零协议改动**：位置同步走既有 EvChickenSpawn 移动事件流；与鸡雨（#20）无共享符号，可独立合并

## 实现细节

- `server/sim.go`：`StepChickens()` 尾部挂 `stepChickenMob()`（与 #20 的头部排期钩子分处不同 hunk，合并无冲突）；新增 `endChickenMob` / `pickChickenMobIdol` / `hasAnyHumanOnline`
- `server/room.go`：Room 新增 `chickenMobTarget` / `chickenMobUntil` / `nextChickenMobAt` 三字段（与 #20 新增字段分处结构体不同位置）
- 零向量安全：小鸡与偶像重合时 `Dir` 置零站定（`norm()` 本身对零向量也安全，双保险）

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/chicken_mob_test.go`：排期阶段零事件、开场选定唯一真人与播报、围观中小鸡迁家+朝向断言、偶像阵亡后解散定居+清态、无真人静默改期

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34