### PR TITLE
feat: 战场 DJ 电台 · 全房每 15 杀整活播报一次

### DIFF
--- a/server/battle_dj_test.go
+++ b/server/battle_dj_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func mkKills(n int) []Event {
+	evts := make([]Event, 0, n)
+	for i := 0; i < n; i++ {
+		evts = append(evts, Event{Type: EvKill, Killer: 10, Victim: uint16(20 + i)})
+	}
+	return evts
+}
+
+func TestDJBroadcastsEveryFifteenKills(t *testing.T) {
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}}, nil)
+	human := newTestHuman(10, r)
+	r.Players = append(r.Players, human)
+
+	// 14 杀：不播。
+	r.djOnEvents(mkKills(14))
+	if len(r.pending) != 0 {
+		t.Fatal("未满 15 杀不应播报")
+	}
+	// 第 15 杀：恰好 1 条 DJ 播报，计数归零。
+	r.djOnEvents(mkKills(1))
+	if len(r.pending) != 1 {
+		t.Fatalf("第 15 杀应恰好 1 条播报, 实际 %d", len(r.pending))
+	}
+	e := r.pending[0]
+	if e.Type != EvChat || e.Name != "战场DJ" {
+		t.Fatalf("播报应为战场DJ EvChat, 实际 type=%d name=%q", e.Type, e.Name)
+	}
+	if !strings.Contains(e.Message, "🎵") {
+		t.Fatalf("播报应来自电台文案, 实际 %q", e.Message)
+	}
+	r.pending = nil
+
+	// 计数回绕后再来一轮。
+	r.djOnEvents(mkKills(15))
+	if len(r.pending) != 1 {
+		t.Fatalf("回绕后第 15 杀应再次播报, 实际 %d", len(r.pending))
+	}
+}
+
+func TestDJSkipsSelfKillsAndEmptyRooms(t *testing.T) {
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}}, nil)
+
+	// 自雷不计入击杀数。
+	selfKills := make([]Event, 0, 20)
+	for i := 0; i < 20; i++ {
+		selfKills = append(selfKills, Event{Type: EvKill, Killer: 10, Victim: 10})
+	}
+	r.djOnEvents(selfKills)
+	if r.djKillCount != 0 {
+		t.Fatalf("自雷不应累计 DJ 计数, 实际 %d", r.djKillCount)
+	}
+
+	// 无人在线：计数照常累计回绕但不播报。
+	human := newTestHuman(10, r)
+	human.IsBot = true // 伪造无真人场景
+	r.Players = append(r.Players, human)
+	r.djOnEvents(mkKills(15))
+	if len(r.pending) != 0 {
+		t.Fatal("无真人不应播报")
+	}
+	if r.djKillCount != 0 {
+		t.Fatal("满 15 杀后计数应回绕")
+	}
+}

--- a/server/room.go
+++ b/server/room.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"math/rand/v2"
 	"sync"
 	"time"
 )
@@ -24,6 +25,7 @@ type Room struct {
 	teamAttempts          map[uint16]*teamAttempt
 	outboundBuf           []outbound
 	quantizedBuf          []quantState
+	djKillCount           uint32
 }
 
 // teamAttempt tracks the consecutive crouch taps of one human for illegal teaming.
@@ -119,6 +121,7 @@ func (r *Room) Run() {
 		r.Step(now)
 		evts := r.pending
 		r.pending = nil
+		r.djOnEvents(evts)
 		needSnap := r.tick%2 == 0
 		var outs []outbound
 		if needSnap || len(evts) > 0 {
@@ -187,6 +190,41 @@ func (r *Room) Run() {
 		recordTick(took)
 		if took > time.Second/TickRate {
 			log.Printf("room %d: slow tick %v", r.Id, took)
+		}
+	}
+}
+
+// 战场 DJ：全房每凑满 15 次击杀（不含自雷），电台整活播报一次。
+const djEveryKills = 15
+
+var djLines = []string{
+	"🎵 下面这首歌送给刚才所有倒地起飞的朋友——《其实都是枪法问题》",
+	"🎵 有观众点播《蹲坑的人最长寿》，送给全场老六",
+	"🎵 刚才的爆炸声是气氛组拉的，请各位继续营业",
+	"🎵 插播寻鸡启事：战场小鸡失踪多只，见到请立即……照看",
+	"🎵 温馨提示：躺平不可耻，可耻的是躺了还被补枪",
+	"🎵 感谢各位老六的倾情演出，冰可乐请到出生点自取",
+}
+
+func (r *Room) djOnEvents(evts []Event) {
+	kills := 0
+	for _, e := range evts {
+		if e.Type == EvKill && e.Killer != e.Victim {
+			kills++
+		}
+	}
+	if kills == 0 {
+		return
+	}
+	r.djKillCount += uint32(kills)
+	if r.djKillCount < djEveryKills {
+		return
+	}
+	r.djKillCount %= djEveryKills
+	for _, p := range r.Players {
+		if !p.IsBot {
+			r.Emit(Event{Type: EvChat, Player: 0, Name: "战场DJ", Message: djLines[rand.IntN(len(djLines))]})
+			break
 		}
 	}
 }


### PR DESCRIPTION
## 改了什么

整活功能⑪：**战场 DJ 电台**。全房每凑满 15 次击杀（不含自雷），「战场DJ」上线从 6 条电台文案里随机播一条：

- 「🎵 下面这首歌送给刚才所有倒地起飞的朋友——《其实都是枪法问题》」
- 「🎵 有观众点播《蹲坑的人最长寿》，送给全场老六」
- 「🎵 插播寻鸡启事：战场小鸡失踪多只，见到请立即……照看」
- 「🎵 温馨提示：躺平不可耻，可耻的是躺了还被补枪」
- 「🎵 刚才的爆炸声是气氛组拉的，请各位继续营业」
- 「🎵 感谢各位老六的倾情演出，冰可乐请到出生点自取」

## 实现细节

- **位置**：`Run()` 事件排空（`evts := r.pending; r.pending = nil`）之后调 `djOnEvents(evts)`——数的是本 tick 刚发生的事，播报追加进 `r.pending` 随下一 tick 批次发出，时序干净
- **计数**：`djKillCount` 累加回绕（`%= 15`），自雷不计；真人在线才发（无真人静默回绕）
- **零协议改动**：复用 EvChat 全房广播；与 #19/#20/#27 的 EvChat 使用互不干扰
- Room 结构体新增 `djKillCount`（尾部插入，与 #20/#27 的字段位置错开，可独立合并）

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/battle_dj_test.go`：14 杀不播、第 15 杀恰好 1 条（type/名/文案断言）、回绕后续播、自雷不计入、无真人静默回绕

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34