### PR TITLE
feat: bot 弹幕 · 存活 bot 每隔一阵说骚话（带 AI 徽章）

### DIFF
--- a/server/bot.go
+++ b/server/bot.go
@@ -9,6 +9,28 @@ import (
 // Expanded 12 Bot roster across all sectors of the map
 const maxBotSkill = 2
 
+// bot 弹幕：每隔一阵随机存活 bot 以自己身份说句骚话（EvChat 全房可见）。
+var botChatMinGap = 45 * time.Second
+var botChatMaxGap = 90 * time.Second
+
+var botTrashTalk = []string{
+	"有人闻到炸鸡味吗？可能是我刚才开的枪",
+	"我不是针对谁，我是说在座的各位都是……哎呀谁打我",
+	"蹲是战术，不是害怕！",
+	"谁又扔雷？说好的绅士决斗呢？",
+	"刚才那波是我的锅，下一波还是我的锅",
+	"小鸡是无辜的，请把子弹留给我",
+	"系统提示：本 bot 已连续作战 72 小时，需要抱抱",
+	"你不要过来呀！",
+	"实测：蹲下真的不会变强，别问我怎么知道的",
+	"这把赢了请全场喝可乐，输了就当无事发生",
+	"狙击手在哪？出来！我数到三……三！",
+	"队友别慌，我这就白给支援！",
+	"我枪法很稳的，就是子弹有点歪",
+	"听说今天有人连败六场躺平了，节哀",
+	"都别抢，最后一只小鸡是我的！",
+}
+
 var botPrimaries = []uint8{3, 4, 2, 8, 9, 10, 12, 11}
 var botSecondaries = []uint8{0, 7, 1}
 
@@ -462,6 +484,39 @@ func (r *Room) StepBots(now time.Time) {
 		}
 
 		p.CmdKeys = moveKeys
+	}
+	r.stepBotChat(now)
+}
+
+// stepBotChat 驱动 bot 弹幕：到点随机选一名存活 bot 说一句骚话。
+func (r *Room) stepBotChat(now time.Time) {
+	if r.nextBotChatAt.IsZero() {
+		r.nextBotChatAt = now.Add(botChatMinGap + time.Duration(rand.IntN(int((botChatMaxGap-botChatMinGap)/time.Second)))*time.Second)
+		return
+	}
+	if !now.Before(r.nextBotChatAt) {
+		r.nextBotChatAt = now.Add(botChatMinGap + time.Duration(rand.IntN(int((botChatMaxGap-botChatMinGap)/time.Second)))*time.Second)
+		hasHuman := false
+		for _, p := range r.Players {
+			if !p.IsBot {
+				hasHuman = true
+				break
+			}
+		}
+		if !hasHuman {
+			return // 没有真人观众，bot 闭麦
+		}
+		talkers := make([]*Player, 0, 4)
+		for _, pl := range r.Players {
+			if pl.IsBot && pl.Alive {
+				talkers = append(talkers, pl)
+			}
+		}
+		if len(talkers) == 0 {
+			return
+		}
+		sp := talkers[rand.IntN(len(talkers))]
+		r.Emit(Event{Type: EvChat, Player: sp.Id, Name: sp.Name, Message: botTrashTalk[rand.IntN(len(botTrashTalk))]})
 	}
 }
 

--- a/server/bot_trash_talk_test.go
+++ b/server/bot_trash_talk_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBotTrashTalkFromAliveBot(t *testing.T) {
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}}, nil)
+	human := newTestHuman(10, r)
+	talker := newTestBot(11, r)
+	corpse := newTestBot(12, r)
+	corpse.Alive = false // 阵亡 bot 没有发言权
+	r.Players = append(r.Players, human, talker, corpse)
+
+	now := time.Now()
+	// 首次调用只排期。
+	r.stepBotChat(now)
+	if len(r.pending) != 0 {
+		t.Fatal("排期阶段不应有弹幕")
+	}
+	// 到点：播报者必须是存活 bot，且用其身份（Player=Id）发言。
+	r.nextBotChatAt = now
+	before := len(r.pending)
+	r.stepBotChat(now)
+	if len(r.pending) != 1 {
+		t.Fatalf("应有一条弹幕, 实际 %d", len(r.pending))
+	}
+	e := r.pending[before]
+	if e.Type != EvChat || e.Player != 11 || e.Name != talker.Name {
+		t.Fatalf("弹幕应以存活 bot 身份发出, 实际 type=%d player=%d", e.Type, e.Player)
+	}
+	if strings.TrimSpace(e.Message) == "" {
+		t.Fatal("弹幕内容不应为空")
+	}
+	// 间隔已推进。
+	if !r.nextBotChatAt.After(now) {
+		t.Fatal("播报后应推进下一次排期")
+	}
+}
+
+func TestBotTrashTalkSilentWithoutHumans(t *testing.T) {
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}}, nil)
+	b := newTestBot(11, r)
+	r.Players = append(r.Players, b)
+	r.nextBotChatAt = time.Now()
+	before := len(r.pending)
+	r.stepBotChat(time.Now())
+	if len(r.pending) != before {
+		t.Fatal("无真人观众 bot 应闭麦")
+	}
+	if r.nextBotChatAt.IsZero() || r.nextBotChatAt.Before(time.Now().Add(botChatMinGap-time.Second)) {
+		t.Fatal("闭麦后仍应推进排期")
+	}
+}

--- a/server/room.go
+++ b/server/room.go
@@ -20,6 +20,7 @@ type Room struct {
 	tick                  uint32
 	pending               []Event
 	botAIs                map[uint16]*BotAI
+	nextBotChatAt         time.Time
 	history               map[uint16]*poseHistory
 	teamAttempts          map[uint16]*teamAttempt
 	outboundBuf           []outbound


### PR DESCRIPTION
## 改了什么

整活功能⑫：**bot 弹幕**。每隔 45-90 秒，随机一名存活 bot 以**自己的身份**（自己的 ID + 名字 + AI 徽章）在全场聊天里说一句骚话——战场从此有了活人感。

- 15 条骚话池节选：
  - 「有人闻到炸鸡味吗？可能是我刚才开的枪」
  - 「蹲是战术，不是害怕！」
  - 「系统提示：本 bot 已连续作战 72 小时，需要抱抱」
  - 「队友别慌，我这就白给支援！」
  - 「都别抢，最后一只小鸡是我的！」
- **身份真实**：`EvChat.Player = bot.ID`，客户端聊天渲染、真人/AI 徽章、记分板联动全部按既有逻辑工作
- **分寸感**：仅存活 bot 发言（阵亡闭嘴）；无真人观众全场闭麦（静默推进排期）；频率全局 45-90 秒一条，不刷屏

## 实现细节

- `server/bot.go`：`StepBots()` **循环外**尾部挂 `stepBotChat()`（与 #23 嘲讽、#28 躺平的循环内插入点错开，可独立合并）；间隔用 `var` 便于测试注入
- `server/room.go`：Room 新增 `nextBotChatAt`（挂在 botAIs 行后，与其他 PR 的字段插入位置错开）
- 零协议改动（EvChat 本就支持任意玩家身份）

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/bot_trash_talk_test.go`：首调只排期零事件、到点发言者必须是存活 bot 且 ID/名字正确、间隔推进、无真人闭麦且排期照常

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34