### PR TITLE
feat: 雾袭 · 随机浓雾 18 秒，听声辨位的浪漫

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -17,6 +17,33 @@ const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x78939d);
 scene.fog = new THREE.Fog(0x8ea5a8, 52, 265);
 
+// 雾袭：每隔 75-120 秒随机来一场 18 秒的浓雾（能见度 265m → 60m），
+// 指数平滑过渡进出。只动雾距（near/far），雾色归灯光系统管，互不干扰。
+const FOG_NORMAL_NEAR = 52, FOG_NORMAL_FAR = 265;
+const FOG_ATTACK_NEAR = 8, FOG_ATTACK_FAR = 60;
+const FOG_ATTACK_DURATION = 18000;
+let fogAttackUntil = 0;
+let nextFogAttackAt = 0;
+
+function updateFogAttack(t: number, dt: number) {
+  const fog = scene.fog as THREE.Fog;
+  if (nextFogAttackAt === 0) {
+    nextFogAttackAt = t + 60000 + Math.random() * 60000;
+    return;
+  }
+  const attacking = t < fogAttackUntil;
+  if (!attacking && t >= nextFogAttackAt) {
+    fogAttackUntil = t + FOG_ATTACK_DURATION;
+    nextFogAttackAt = t + FOG_ATTACK_DURATION + 57000 + Math.random() * 45000;
+    hud.addChatMessage('战场气象台', '🌫 雾袭来了！能见度骤降，注意听声辨位', false);
+  }
+  const targetNear = attacking ? FOG_ATTACK_NEAR : FOG_NORMAL_NEAR;
+  const targetFar = attacking ? FOG_ATTACK_FAR : FOG_NORMAL_FAR;
+  const k = 1 - Math.exp(-dt * 2.5);
+  fog.near += (targetNear - fog.near) * k;
+  fog.far += (targetFar - fog.far) * k;
+}
+
 const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.05, 450);
 camera.rotation.order = 'YXZ';
 camera.layers.enable(0);
@@ -1604,6 +1631,7 @@ function frame(t: number) {
   requestAnimationFrame(frame);
   const dt = Math.min(0.05, (t - prev) / 1000);
   prev = t;
+  updateFogAttack(t, dt);
   if (document.hidden) return;
 
   if (joined && alive) {


### PR DESCRIPTION
## 改了什么

整活功能⑬：**雾袭**。每隔 75-120 秒，战场随机被一场 18 秒的浓雾吞没——能见度从 265m 骤降到 60m，伴随本地气象播报「🌫 雾袭来了！注意听声辨位」，然后平滑散去。

- **平滑过渡**：进出均按 `1-e^{-2.5dt}` 指数插值，无跳变
- **与灯光正交**：只动雾距 `near/far`，雾的颜色归灯光系统（与蹦迪 PR #26 改的是不同字段，两者合并互不干扰）
- **氛围 but 公平**：纯客户端视觉，服务端命中判定不受影响；听脚步声反而是老玩家的浪漫
- **后台标签页**：更新放在 `document.hidden` 早退之前，切走再切回状态一致，每帧开销可忽略

## 实现细节

- `client/src/main.ts`：新增 `updateFogAttack(t, dt)` 状态机（未排期→排期→雾袭→恢复循环），挂点在 `frame()` 的 dt 计算之后；播报走 `hud.addChatMessage` 本地聊天栏（名字「战场气象台」）
- 插入锚点与蹦迪 PR（#26，`renderer.render` 前）不同，可独立合并

## 验证

- `tsc --noEmit && vite build` 通过（仅既有 chunk 体积告警）
- 状态机走查：首次调用只排期；到点置 `fogAttackUntil` 并播报一次；持续期内重复进入不重播报；结束后向常规雾距恢复

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34