### PR TITLE
feat: 战场荣誉榜 · 每 5 分钟一期击杀王/打工皇帝战报

### DIFF
--- a/server/honor_board_test.go
+++ b/server/honor_board_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHonorBoardReportsKings(t *testing.T) {
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}}, nil)
+	human := newTestHuman(10, r)
+	ace := newTestBot(11, r)
+	fodder := newTestBot(12, r)
+	ace.Kills, fodder.Deaths = 12, 9
+	r.Players = append(r.Players, human, ace, fodder)
+
+	now := time.Now()
+	// 首次调用只排期。
+	r.reportHonor(now)
+	if len(r.pending) != 0 {
+		t.Fatal("排期阶段不应有播报")
+	}
+	// 到点：一期完整荣誉榜。
+	r.nextHonorReportAt = now
+	before := len(r.pending)
+	r.reportHonor(now)
+	if len(r.pending) != 1 {
+		t.Fatalf("应有一条荣誉榜, 实际 %d", len(r.pending))
+	}
+	e := r.pending[before]
+	if e.Type != EvChat || e.Name != "战场播报" {
+		t.Fatalf("荣誉榜应为战场播报 EvChat, 实际 type=%d name=%q", e.Type, e.Name)
+	}
+	if !strings.Contains(e.Message, "击杀王") || !strings.Contains(e.Message, "12") {
+		t.Fatalf("荣誉榜应含击杀王与杀数, 实际 %q", e.Message)
+	}
+	if !strings.Contains(e.Message, "打工皇帝") || !strings.Contains(e.Message, "9") {
+		t.Fatalf("荣誉榜应含打工皇帝与阵亡数, 实际 %q", e.Message)
+	}
+	if !r.nextHonorReportAt.After(now) {
+		t.Fatal("播报后应推进下一期排期")
+	}
+}
+
+func TestHonorBoardSkipsEmptyAndNoShows(t *testing.T) {
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}}, nil)
+	now := time.Now()
+	r.nextHonorReportAt = now
+	r.reportHonor(now) // 空房间：直接返回不 panic
+	if len(r.pending) != 0 {
+		t.Fatal("空房间不应播报")
+	}
+
+	// 全员零杀零阵亡：凑不出榜单，不播。
+	b := newTestBot(11, r)
+	human := newTestHuman(10, r)
+	r.Players = append(r.Players, human, b)
+	r.reportHonor(now)
+	if len(r.pending) != 0 {
+		t.Fatal("无数据不应播报")
+	}
+
+	// 纯 bot 局：有数据也不播。
+	ace := newTestBot(12, r)
+	ace.Kills = 5
+	r.Players = append(r.Players, ace)
+	r.reportHonor(now)
+	if len(r.pending) != 0 {
+		t.Fatal("无真人不应播报")
+	}
+}

--- a/server/room.go
+++ b/server/room.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -12,6 +13,7 @@ type Room struct {
 	Store                 *Store
 	mu                    sync.Mutex
 	running, closed       bool
+	nextHonorReportAt     time.Time
 	Players               []*Player
 	Grenades              []*Grenade
 	Pickups               []Pickup
@@ -112,6 +114,7 @@ func (r *Room) Run() {
 			r.mu.Unlock()
 			return
 		}
+		r.reportHonor(now)
 		for _, p := range r.Players {
 			p.applyQueuedInput()
 		}
@@ -189,6 +192,50 @@ func (r *Room) Run() {
 			log.Printf("room %d: slow tick %v", r.Id, took)
 		}
 	}
+}
+
+// 战场荣誉榜：每 5 分钟一期，播报击杀王与阵亡之王（有真人才发）。
+const honorReportInterval = 5 * time.Minute
+
+func (r *Room) reportHonor(now time.Time) {
+	if len(r.Players) == 0 {
+		return
+	}
+	if r.nextHonorReportAt.IsZero() {
+		r.nextHonorReportAt = now.Add(honorReportInterval)
+		return
+	}
+	if now.Before(r.nextHonorReportAt) {
+		return
+	}
+	r.nextHonorReportAt = now.Add(honorReportInterval)
+	hasHuman := false
+	topKills, topDeaths := r.Players[0], r.Players[0]
+	for _, p := range r.Players {
+		if !p.IsBot {
+			hasHuman = true
+		}
+		if p.Kills > topKills.Kills {
+			topKills = p
+		}
+		if p.Deaths > topDeaths.Deaths {
+			topDeaths = p
+		}
+	}
+	if !hasHuman {
+		return
+	}
+	msg := "🏅 荣誉榜"
+	if topKills.Kills > 0 {
+		msg += fmt.Sprintf("｜击杀王：%s（%d 杀）", topKills.Name, topKills.Kills)
+	}
+	if topDeaths.Deaths > 0 {
+		msg += fmt.Sprintf("｜打工皇帝：%s（%d 阵亡）", topDeaths.Name, topDeaths.Deaths)
+	}
+	if msg == "🏅 荣誉榜" {
+		return
+	}
+	r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报", Message: msg})
 }
 
 func (r *Room) eventsFor(target *Player, evts []Event) []Event {


### PR DESCRIPTION
## 改了什么

整活功能⑭：**战场荣誉榜**。每 5 分钟一期定时战报，服务端扫描全房数据现场颁奖：

> 🏅 荣誉榜｜击杀王：[BOT] 干拉哥（12 杀）｜打工皇帝：[BOT] 菜就多练（9 阵亡）

- **双榜**：击杀王（Kills 最高）+ 打工皇帝（Deaths 最高），带具体数字
- **克制原则**：无人在线不播；全房零杀零阵亡凑不出榜单不播；空房防御直接返回
- **零协议改动**：复用 EvChat 通道（Name=战场播报）

## 实现细节

- `server/room.go`：Room 新增 `nextHonorReportAt`（插在 `running, closed` 行后，与 #11/#12/#20/#27 的字段插入位置全部错开）；`reportHonor()` 状态机（首调排期→到点扫描→组稿播报→推进下一期）
- Run 钩子插在 `applyQueuedInput` 之前（#11 DJ 的锚点在事件排空之后，两者独立可合并）
- 单次扫描 O(玩家数)，60 tick/s 下空转成本为两次比较

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/honor_board_test.go`：
  - 排期阶段零事件；到点后单条播报、击杀王/打工皇帝姓名与数值断言、排期推进
  - 三类静默：空房间（防御不 panic）、全房零数据、纯 bot 局

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34