### PR TITLE
feat: 鸡圈噩梦称号 · 炸鸡 10/25/50 只授予全房称号播报

### DIFF
--- a/server/chicken_title_test.go
+++ b/server/chicken_title_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newChickenTitleRoom() *Room {
+	r := NewRoom(1, &World{Size: [2]float64{64, 64}, Spawns: [][3]float64{{0, 0, 0}}}, nil)
+	r.initChickens()
+	human := newTestHuman(10, r)
+	r.Players = append(r.Players, human)
+	shooter := newTestBot(11, r)
+	shooter.Pos = Vec3{5, 0, 5}
+	r.Players = append(r.Players, shooter)
+	return r
+}
+
+// 炸鸡里程碑：10/25/50 各播一次称号，其余次数静默。
+func TestChickenKillTitlesAtMilestones(t *testing.T) {
+	r := newChickenTitleRoom()
+	shooter := r.Players[1]
+	r.Chickens[0].Alive = true
+	r.Chickens[0].Pos = Vec3{5, 0, 5}
+	r.Chickens[0].Home = Vec3{5, 0, 5}
+
+	milestones := map[int]string{10: "鸡圈噩梦", 25: "炸鸡大王", 50: "禽类保护协会"}
+	titles := 0
+	for i := 1; i <= 50; i++ {
+		r.Chickens[0].Alive = true // 每次复活同一只鸡供射杀
+		before := len(r.pending)
+		// 从鸡盒（高度 0~0.62m）内水平穿过的射线，wallDist/playerDist 放行为最近命中。
+		hit := r.chickenShot(&shooter.PlayerState, Vec3{5, 0.3, 8}, Vec3{0, 0, -1}, 1e9, 1e9, 3, time.Now())
+		if !hit {
+			t.Fatalf("第 %d 次应命中小鸡", i)
+		}
+		if shooter.PlayerState.ChickenKills != uint8(i) {
+			t.Fatalf("炸鸡计数 = %d, 期望 %d", shooter.PlayerState.ChickenKills, i)
+		}
+		chat := 0
+		want, isMilestone := milestones[i]
+		for _, e := range r.pending[before:] {
+			if e.Type != EvChat {
+				continue
+			}
+			if !isMilestone {
+				t.Fatalf("第 %d 次炸鸡不应有称号播报, 实际 %q", i, e.Message)
+			}
+			if !strings.Contains(e.Message, want) || !strings.Contains(e.Message, shooter.Name) {
+				t.Fatalf("第 %d 次炸鸡的称号播报异常: %q", i, e.Message)
+			}
+			chat++
+		}
+		if isMilestone {
+			if chat != 1 {
+				t.Fatalf("第 %d 次应恰好 1 条称号播报, 实际 %d", i, chat)
+			}
+			titles++
+		}
+	}
+	if titles != 3 {
+		t.Fatalf("50 次炸鸡应触发 3 个称号, 实际 %d", titles)
+	}
+}

--- a/server/sim.go
+++ b/server/sim.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"math/rand/v2"
@@ -140,6 +141,7 @@ type PlayerState struct {
 	LastShotAt                                                     time.Time
 	NextChatAt                                                     time.Time
 	ShotCounter                                                    uint8
+	ChickenKills                                                   uint8
 	inputWindowStart                                               time.Time
 	inputCount                                                     int
 }
@@ -1342,8 +1344,33 @@ func (r *Room) chickenShot(p *PlayerState, origin, dir Vec3, wallDist, playerDis
 	if p.HP < MaxHP {
 		p.HP = uint8(min(MaxHP, int(p.HP)+25))
 	}
+	r.chickenKillTitle(p)
 	r.Emit(Event{Type: EvChickenDeath, Killer: p.Id, Victim: best.Id, Origin: best.Pos, Weapon: weapon})
 	return true
+}
+
+// 鸡圈噩梦称号：炸鸡累计到里程碑时全房播报一次（服务端私有计数，零协议改动）。
+var chickenKillTitles = map[uint8]string{
+	10: "🍗 %s 已斩获 10 只小鸡，荣获「鸡圈噩梦」称号！",
+	25: "🏆 %s 炸鸡数达到 25，正式加冕「炸鸡大王」！小鸡们发来抗议信",
+	50: "🚨 %s 的第 50 只小鸡倒下了！禽类保护协会已介入调查",
+}
+
+func (r *Room) chickenKillTitle(p *PlayerState) {
+	if p.ChickenKills == 255 {
+		return
+	}
+	p.ChickenKills++
+	title, ok := chickenKillTitles[p.ChickenKills]
+	if !ok {
+		return
+	}
+	for _, pl := range r.Players {
+		if !pl.IsBot {
+			r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报", Message: fmt.Sprintf(title, p.Name)})
+			return
+		}
+	}
 }
 
 func (r *Room) ThrowGrenade(p *PlayerState, yaw, pitch float64, now time.Time) {


### PR DESCRIPTION
## 改了什么

整活功能⑮：**鸡圈噩梦称号**。炸鸡不再是简单的 +25 回血——累计炸鸡数达到里程碑，全房授予称号：

- **10 只**：「🍗 X 已斩获 10 只小鸡，荣获『鸡圈噩梦』称号！」
- **25 只**：「🏆 X 炸鸡数达到 25，正式加冕「炸鸡大王」！小鸡们发来抗议信」
- **50 只**：「🚨 X 的第 50 只小鸡倒下了！禽类保护协会已介入调查」

- 每个里程碑恰好播报一次；有真人在线才发；与回血奖励完全正交
- **零协议改动**：`ChickenKills` 是服务端私有计数，快照不携带

## 实现细节

- `server/sim.go`：`PlayerState` 新增 `ChickenKills uint8`；`chickenShot` 命中尾部挂 `chickenKillTitle()`（称号表驱动，255 封顶防溢出）
- 与 #20（鸡雨，StepChickens 头部+init）/ #27（围观，StepChickens 尾部）改动区域互不重叠，可独立合并

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/chicken_title_test.go`：构造穿过鸡盒的确定性射线，连炸 50 次——计数逐次推进、三个里程碑各恰好 1 条含名字与称号关键词的播报、其余 47 次完全静默

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34