### PR TITLE
feat: 《鸡鸡帝国》DLC · 金鸡王 Boss + 皇家护卫队 + 超级补给

### DIFF
--- a/server/chicken_empire_test.go
+++ b/server/chicken_empire_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newEmpireRoom() *Room {
+	r := NewRoom(1, &World{Size: [2]float64{128, 128}, Spawns: [][3]float64{{0, 0, 0}, {20, 0, 20}}}, nil)
+	r.initChickens()
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{40, 0, 40}
+	r.Players = append(r.Players, human)
+	return r
+}
+
+// 拥立：到点后某只存活小鸡成为王（600 血），有播报，护卫就位。
+func TestKingPromotionAndGuards(t *testing.T) {
+	r := newEmpireRoom()
+	now := time.Now()
+	r.pending = nil // 丢弃 initChickens 的出生事件，只看本次调用增量
+	r.stepChickenKing(now) // 排期
+	if len(r.pending) != 0 {
+		t.Fatal("排期阶段不应有事件")
+	}
+
+	r.nextKingAt = now
+	before := len(r.pending)
+	r.stepChickenKing(now)
+	king := r.kingChicken()
+	if king == nil {
+		t.Fatal("到点应拥立金鸡王")
+	}
+	if king.KingHP != kingHP {
+		t.Fatalf("王血量 = %d, 期望 %d", king.KingHP, kingHP)
+	}
+	announced := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvChat && strings.Contains(e.Message, "金鸡王") {
+			announced = true
+		}
+	}
+	if !announced {
+		t.Fatal("拥立应有播报")
+	}
+
+	// 护卫：最近的 kingGuardCount 只小鸡把家安到王脚下并朝王走。
+	r.stepChickenKing(now)
+	guards := 0
+	for i := range r.Chickens {
+		c := &r.Chickens[i]
+		if c == king || !c.Alive {
+			continue
+		}
+		if c.Home == king.Pos {
+			guards++
+			if c.Dir.X == 0 && c.Dir.Z == 0 {
+				t.Fatalf("护卫应朝王移动, 鸡 %d 方向为零", c.Id)
+			}
+		}
+	}
+	if guards != kingGuardCount {
+		t.Fatalf("护卫数 = %d, 期望 %d", guards, kingGuardCount)
+	}
+}
+
+// 王要多枪才能杀：中间命中发 EvHit 且不死；最后一枪驾崩掉超级补给。
+func TestKingTakesMultipleShotsAndDropsLoot(t *testing.T) {
+	r := newEmpireRoom()
+	now := time.Now()
+	r.nextKingAt = now
+	r.stepChickenKing(now)
+	king := r.kingChicken()
+	king.Pos = Vec3{5, 0, 5}
+	king.Home = king.Pos
+
+	shooter := &r.Players[0].PlayerState // AK-47（33 伤害一发）
+	shooter.HP = 30
+	shooter.Armor = 0
+	shotsToKill := 0
+	dmgPerShot := uint8(Weapons[3].Dmg)
+
+	for round := 1; ; round++ {
+		before := len(r.pending)
+		r.Chickens[0].Alive = true
+		// 对王所在位置直接判定命中（绕过 raycast，命中逻辑自 chickenShot 起）。
+		// 直接调用 chickenShot 的命中段：把王作为 best 的路径难以独立构造，
+		// 这里用射线真实打：从王盒内穿过的射线。
+		hit := r.chickenShot(shooter, Vec3{5, 0.3, 8}, Vec3{0, 0, -1}, 1e9, 1e9, 3, now)
+		if !hit {
+			t.Fatalf("第 %d 枪应命中王", round)
+		}
+		shotsToKill = round
+		if !king.Alive {
+			// 驾崩：应有 EvChickenDeath + 奖励播报
+			death, reward := false, false
+			for _, e := range r.pending[before:] {
+				if e.Type == EvChickenDeath {
+					death = true
+				}
+				if e.Type == EvChat && strings.Contains(e.Message, "超级补给") {
+					reward = true
+				}
+			}
+			if !death || !reward {
+				t.Fatalf("王驾崩应有死亡事件+奖励播报, death=%v reward=%v", death, reward)
+			}
+			break
+		}
+		// 未死：应有 EvHit 反馈、无死亡事件、血量递减。
+		hits, deaths := 0, 0
+		for _, e := range r.pending[before:] {
+			if e.Type == EvHit && e.Victim == king.Id {
+				hits++
+				if e.Dmg != dmgPerShot {
+					t.Fatalf("EvHit 伤害 = %d, 期望 %d", e.Dmg, dmgPerShot)
+				}
+			}
+			if e.Type == EvChickenDeath {
+				deaths++
+			}
+		}
+		if hits != 1 || deaths != 0 {
+			t.Fatalf("第 %d 枪后: EvHit=%d EvDeath=%d, 期望 1/0", round, hits, deaths)
+		}
+		if round > 40 {
+			t.Fatal("王血量异常，未能被击杀")
+		}
+	}
+	want := (kingHP + uint16(dmgPerShot) - 1) / uint16(dmgPerShot)
+	if uint16(shotsToKill) != want {
+		t.Fatalf("击杀王需 %d 枪, 期望 %d", shotsToKill, want)
+	}
+	// 超级补给：满血满甲。
+	if shooter.HP != MaxHP || shooter.Armor != 100 {
+		t.Fatalf("补给后 HP=%d Armor=%d, 期望 %d/100", shooter.HP, shooter.Armor, MaxHP)
+	}
+	// 王位已清空，轮回排期已推进。
+	if r.kingChicken() != nil {
+		t.Fatal("王驾崩后不应再有在位王")
+	}
+	if !r.nextKingAt.After(now) {
+		t.Fatal("驾崩后应推进下一位王的排期")
+	}
+}
+
+// 王驾崩后按普通小鸡重生，且王位状态清零。
+func TestKingRespawnsAsCommoner(t *testing.T) {
+	r := newEmpireRoom()
+	now := time.Now()
+	r.nextKingAt = now
+	r.stepChickenKing(now)
+	king := r.kingChicken()
+	king.KingHP = 1
+	r.chickenShot(&r.Players[0].PlayerState, Vec3{king.Pos.X, 0.3, king.Pos.Z + 3}, Vec3{0, 0, -1}, 1e9, 1e9, 3, now)
+	if king.King {
+		t.Fatal("驾崩后 King 标志应清除")
+	}
+	// 到重生时间复活。
+	later := now.Add(30 * time.Second)
+	r.StepChickens(later)
+	if !king.Alive || king.King || king.KingHP != 0 {
+		t.Fatalf("复活后应为平民小鸡: Alive=%v King=%v HP=%d", king.Alive, king.King, king.KingHP)
+	}
+}

--- a/server/room.go
+++ b/server/room.go
@@ -17,6 +17,7 @@ type Room struct {
 	Pickups               []Pickup
 	Chickens              []Chicken
 	nextNadeId, nextIdSeq uint16
+	nextKingAt            time.Time
 	tick                  uint32
 	pending               []Event
 	botAIs                map[uint16]*BotAI

--- a/server/sim.go
+++ b/server/sim.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"math/rand/v2"
@@ -1191,6 +1192,14 @@ const (
 	chickenWanderR   = 9.0                        // roam radius around home spawn
 	chickenHitHeight = 0.62                       // AABB height for bullet tests
 	chickenHeartbeat = 5 * time.Second            // max age of an idle chicken's last broadcast
+
+	// 《鸡鸡帝国》DLC：金鸡王混入鸡群，护卫队暴露位置，击杀掉超级补给。
+	kingFirstAt      = 3 * time.Minute   // 开局到首位金鸡王
+	kingRespawnMin   = 4 * time.Minute   // 王驾崩后到下一位的最短间隔
+	kingRespawnMax   = 6 * time.Minute   // 最长间隔
+	kingRetry        = 30 * time.Second  // 无鸡可立王时重试
+	kingHP           = 600               // 王的血量（多枪才能击杀）
+	kingGuardCount   = 2                 // 皇家护卫队规模
 )
 
 // Battlefield chickens are the classic CS-style easter egg: harmless voxel
@@ -1201,6 +1210,8 @@ type Chicken struct {
 	Pos                Vec3
 	Dir                Vec3 // horizontal heading; zero means idling in place
 	Alive              bool
+	King               bool   // 金鸡王：多枪才能击杀，击杀掉超级补给
+	KingHP             uint16 // 王的血量（仅 King=true 时有效）
 	NextTurn           time.Time
 	RespawnAt          time.Time
 	lastEmitPos        Vec3
@@ -1224,6 +1235,8 @@ func (r *Room) respawnChicken(c *Chicken) {
 	c.Pos = c.Home
 	c.Dir = Vec3{}
 	c.Alive = true
+	c.King = false
+	c.KingHP = 0
 	c.NextTurn = time.Time{}
 	c.forceEmit = true
 	r.Emit(Event{Type: EvChickenSpawn, Player: c.Id, Origin: c.Pos})
@@ -1268,6 +1281,7 @@ func (r *Room) StepChickens(now time.Time) {
 	if len(r.Chickens) == 0 {
 		return
 	}
+	r.stepChickenKing(now)
 	for i := range r.Chickens {
 		c := &r.Chickens[i]
 		if !c.Alive {
@@ -1337,13 +1351,109 @@ func (r *Room) chickenShot(p *PlayerState, origin, dir Vec3, wallDist, playerDis
 	if best == nil {
 		return false
 	}
-	best.Alive = false
-	best.RespawnAt = now.Add(time.Duration(15+rand.IntN(10)) * time.Second)
-	if p.HP < MaxHP {
+	// 金鸡王：多枪才能击杀；命中即给打击反馈（EvHit，客户端有 hitmarker），
+	// 但只有王驾崩才发 EvChickenDeath。击杀奖励：满血 + 满甲 + 弹药大礼包。
+	if best.King {
+		dmg := Weapons[weapon].Dmg
+		dealt := uint16(math.Min(dmg, float64(best.KingHP)))
+		best.KingHP -= dealt
+		r.Emit(Event{Type: EvHit, Player: p.Id, Victim: best.Id, Dmg: uint8(math.Min(dmg, 255))})
+		if best.KingHP > 0 {
+			return true
+		}
+		best.King = false
+		p.HP = MaxHP
+		p.Armor = 100
+		p.grantStreakAmmo()
+		r.nextKingAt = now.Add(kingRespawnMin + time.Duration(rand.IntN(int((kingRespawnMax-kingRespawnMin)/time.Second)))*time.Second)
+		for _, pl := range r.Players {
+			if !pl.IsBot {
+				r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+					Message: fmt.Sprintf("👑 %s 击杀了金鸡王！超级补给到账：满血 + 满甲 + 弹药大礼包", p.Name)})
+				break
+			}
+		}
+	} else if p.HP < MaxHP {
 		p.HP = uint8(min(MaxHP, int(p.HP)+25))
 	}
+	best.Alive = false
+	best.RespawnAt = now.Add(time.Duration(15+rand.IntN(10)) * time.Second)
 	r.Emit(Event{Type: EvChickenDeath, Killer: p.Id, Victim: best.Id, Origin: best.Pos, Weapon: weapon})
 	return true
+}
+
+// kingChicken 返回在位的金鸡王（可能为 nil）。
+func (r *Room) kingChicken() *Chicken {
+	for i := range r.Chickens {
+		c := &r.Chickens[i]
+		if c.King && c.Alive {
+			return c
+		}
+	}
+	return nil
+}
+
+// stepChickenKing 驱动王的轮回：在位时护卫护送；空位到点则从存活小鸡中随机拥立。
+func (r *Room) stepChickenKing(now time.Time) {
+	if king := r.kingChicken(); king != nil {
+		r.escortGuards(king)
+		return
+	}
+	if r.nextKingAt.IsZero() {
+		r.nextKingAt = now.Add(kingFirstAt)
+		return
+	}
+	if !now.Before(r.nextKingAt) {
+		r.nextKingAt = now.Add(kingRespawnMin + time.Duration(rand.IntN(int((kingRespawnMax-kingRespawnMin)/time.Second)))*time.Second)
+		live := make([]*Chicken, 0, len(r.Chickens))
+		for i := range r.Chickens {
+			if r.Chickens[i].Alive {
+				live = append(live, &r.Chickens[i])
+			}
+		}
+		if len(live) == 0 {
+			return
+		}
+		king := live[rand.IntN(len(live))]
+		king.King = true
+		king.KingHP = kingHP
+		king.forceEmit = true
+		r.Emit(Event{Type: EvChickenSpawn, Player: king.Id, Origin: king.Pos, Dir: king.Dir})
+		for _, pl := range r.Players {
+			if !pl.IsBot {
+				r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+					Message: "👑 金鸡王混入了鸡群！护卫队会暴露它的位置——打爆它：满血 + 满甲 + 弹药大礼包"})
+				break
+			}
+		}
+	}
+}
+
+// escortGuards：离王最近的两只小鸡成为皇家护卫，贴身护送并暴露王的位置。
+func (r *Room) escortGuards(king *Chicken) {
+	first, second := (*Chicken)(nil), (*Chicken)(nil)
+	fd2, sd2 := math.MaxFloat64, math.MaxFloat64
+	for i := range r.Chickens {
+		c := &r.Chickens[i]
+		if !c.Alive || c == king {
+			continue
+		}
+		dx, dz := c.Pos.X-king.Pos.X, c.Pos.Z-king.Pos.Z
+		d2 := dx*dx + dz*dz
+		if d2 < fd2 {
+			second, sd2 = first, fd2
+			first, fd2 = c, d2
+		} else if d2 < sd2 {
+			second, sd2 = c, d2
+		}
+	}
+	for _, g := range []*Chicken{first, second} {
+		if g == nil {
+			continue
+		}
+		g.Home = king.Pos
+		g.Dir = norm(Vec3{king.Pos.X - g.Pos.X, 0, king.Pos.Z - g.Pos.Z})
+	}
 }
 
 func (r *Room) ThrowGrenade(p *PlayerState, yaw, pitch float64, now time.Time) {


### PR DESCRIPTION
# 《鸡鸡帝国》DLC 🐔👑

超大型 DLC 之一：战场小鸡从「CS 式彩蛋」升级为完整 Boss 玩法体系。零协议改动。

## 玩法

**金鸡王降临**：开局 3 分钟后，一位金鸡王从存活小鸡中随机拥立诞生：

- **600 血 Boss**：混在鸡群里，外形无法分辨——但它的**皇家护卫队**（最近的两只小鸡）会贴身护送，队形就是找王的视觉线索
- **多枪击杀**：每枪命中都有 EvHit 打击反馈（客户端 hitmarker + 音效直接生效），血量打空才发击杀事件——用纯服务端状态实现了 Boss 血条语义
- **超级补给**：击杀奖励满血 + 满甲 + 弹药大礼包（`grantStreakAmmo`），全房播报「👑 X 击杀了金鸡王！」
- **轮回**：王驾崩后 4-6 分钟随机拥立下一位；复活的小鸡自动贬为平民（`respawnChicken` 清王位状态）

## 为什么零协议也能做 Boss

- 血量是服务端私有状态（`Chicken.King/KingHP`），快照不携带
- 命中反馈复用 `EvHit`（`Victim` 填小鸡 ID；客户端 `states.get()` 查不到玩家会安全跳过拖尾粒子，hitmarker/音效正常）
- 位置同步走既有 `EvChickenSpawn` 移动事件流

## 实现

- `server/sim.go`：Chicken 新增 `King/KingHP`；`chickenShot` 王分支（命中反馈→未死提前返回→驾崩掉落）；`stepChickenKing/kingChicken/escortGuards`（护卫 = 距离最近两只，O(n) 两遍扫描）
- `server/room.go`：Room 新增 `nextKingAt`
- 与 #20/#27/#33 等鸡系 PR 的插入锚点全部错开

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/chicken_empire_test.go`（3 个测试）：
  - 拥立：到点立王、血量 600、播报、护卫就位且朝向正确
  - Boss 战：AK（33 伤害）19 枪击杀曲线精确断言、每枪 EvHit 伤害、中途无死亡事件、驾崩时死亡事件 + 奖励播报 + 满血满甲数值
  - 轮回：驾崩后王位清零、重生为平民小鸡

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34