### PR TITLE
feat: 《天灾工厂》DLC · 雷暴/流星雨/电磁风暴轮换天灾

### DIFF
--- a/server/room.go
+++ b/server/room.go
@@ -17,6 +17,12 @@ type Room struct {
 	Pickups               []Pickup
 	Chickens              []Chicken
 	nextNadeId, nextIdSeq uint16
+	stormNextAt           time.Time
+	stormEndsAt           time.Time
+	stormNextStrikeAt     time.Time
+	stormStrikePos        Vec3
+	stormStrikesLeft      int
+	stormKind             uint8
 	tick                  uint32
 	pending               []Event
 	botAIs                map[uint16]*BotAI

--- a/server/sim.go
+++ b/server/sim.go
@@ -285,6 +285,7 @@ func (r *Room) Step(now time.Time) {
 	}
 	r.StepPickups(now)
 	r.StepChickens(now)
+	r.stepStorm(now)
 	r.recordHistory()
 }
 
@@ -394,6 +395,10 @@ func (r *Room) CheckSanity(p *PlayerState) {
 
 func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick uint32, shotSeq uint16, now time.Time) bool {
 	if !p.Alive || p.Reloading || now.Before(p.NextFire) || !finite(yaw) || !finite(pitch) {
+		return false
+	}
+	// 电磁风暴：枪械间歇性失灵（不耗弹，哑火）。
+	if r.empJam(now) {
 		return false
 	}
 	if p.IsBot && r.AnyBlackDream(now) {

--- a/server/storm.go
+++ b/server/storm.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// 《天灾工厂》DLC：轮换天灾系统。每 120 秒随机降临一场天灾（3 秒预警 +
+// 14 秒持续）：雷暴（脚下落雷 AoE）、流星雨（大半径轰击）、电磁风暴
+//（枪械间歇性失灵）。伤害全部走既有 Damage/EvExplosion 管线，零协议改动。
+
+const (
+	stormFirst        = 120 * time.Second
+	stormGap          = 120 * time.Second
+	stormWarnDuration = 3 * time.Second
+	stormDuration     = 14 * time.Second
+	stormThunderR     = 3.5
+	stormThunderDmg   = 60.0
+	stormMeteorR      = 4.5
+	stormMeteorDmg    = 70.0
+)
+
+const (
+	StormNone uint8 = iota
+	StormThunder
+	StormMeteor
+	StormEMP
+)
+
+// empJamChance 用 var 方便测试注入 100%。
+var empJamChance = 0.35
+
+// Room 侧字段见 room.go：stormNextAt / stormKind / stormEndsAt /
+// stormNextStrikeAt / stormStrikesLeft / stormStrikePos。
+
+func (r *Room) stepStorm(now time.Time) {
+	if r.stormKind == StormNone {
+		if r.stormNextAt.IsZero() {
+			r.stormNextAt = now.Add(stormFirst)
+			return
+		}
+		if !now.Before(r.stormNextAt) {
+			kinds := []uint8{StormThunder, StormMeteor, StormEMP}
+			r.stormKind = kinds[rand.IntN(len(kinds))]
+			r.stormEndsAt = now.Add(stormWarnDuration + stormDuration)
+			r.stormNextStrikeAt = now.Add(stormWarnDuration)
+			r.stormStrikesLeft = map[uint8]int{StormThunder: 6, StormMeteor: 3, StormEMP: 0}[r.stormKind]
+			r.stormAnnounce(map[uint8]string{
+				StormThunder: "⚠ 天灾预警：雷暴即将来临，小心脚下的落雷！",
+				StormMeteor:  "⚠ 天灾预警：流星雨来袭，抬头没有用，跑起来！",
+				StormEMP:     "⚠ 天灾预警：电磁风暴将至，枪械将间歇性失灵！",
+			}[r.stormKind])
+		}
+		return
+	}
+	if now.After(r.stormEndsAt) {
+		kind := r.stormKind
+		r.stormKind = StormNone
+		r.stormNextAt = now.Add(stormGap)
+		if r.hasStormAudience() {
+			r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报", Message: map[uint8]string{
+				StormThunder: "⚡ 雷暴过去了，别放松，下一场天灾在路上。",
+				StormMeteor:  "☄ 流星雨结束了，捡一捡地上有没有陨铁。",
+				StormEMP:     "📡 电磁风暴消散，枪械恢复准头。",
+			}[kind]})
+		}
+		return
+	}
+	if now.Before(r.stormNextStrikeAt) || r.stormStrikesLeft <= 0 {
+		return
+	}
+	switch r.stormKind {
+	case StormThunder:
+		r.stormStrikeAt(now, r.randomPlayerVicinity(), stormThunderR, stormThunderDmg, "⚡ 轰隆——！")
+		r.stormNextStrikeAt = now.Add(2200 * time.Millisecond)
+	case StormMeteor:
+		r.stormStrikeAt(now, r.randomPlayerVicinity(), stormMeteorR, stormMeteorDmg, "☄ 流星坠落！")
+		r.stormNextStrikeAt = now.Add(3500 * time.Millisecond)
+	}
+	r.stormStrikesLeft--
+}
+
+// randomPlayerVicinity：随机存活玩家周边 ±12m 的落点。
+func (r *Room) randomPlayerVicinity() Vec3 {
+	live := make([]*PlayerState, 0, 4)
+	for _, pl := range r.Players {
+		if pl.Alive {
+			live = append(live, &pl.PlayerState)
+		}
+	}
+	if len(live) == 0 {
+		return Vec3{}
+	}
+	anchor := live[rand.IntN(len(live))]
+	return Vec3{anchor.Pos.X + rand.Float64()*24 - 12, 0, anchor.Pos.Z + rand.Float64()*24 - 12}
+}
+
+// stormStrikeAt：在指定落点砸一击，AoE 伤害走 Damage（自雷语义）。
+// 落点写进 stormStrikePos，测试可确定性断言。
+func (r *Room) stormStrikeAt(now time.Time, pos Vec3, radius, dmg float64, shout string) {
+	r.stormStrikePos = pos
+	r.Emit(Event{Type: EvExplosion, Origin: pos})
+	for _, pl := range r.Players {
+		v := &pl.PlayerState
+		if !v.Alive {
+			continue
+		}
+		dx, dz := v.Pos.X-pos.X, v.Pos.Z-pos.Z
+		d := dx*dx + dz*dz
+		if d > radius*radius {
+			continue
+		}
+		dist := math.Sqrt(d)
+		r.Damage(v, v, dmg*(1-dist/radius), false, WeaponHE, now)
+	}
+	if r.hasStormAudience() {
+		r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报", Message: shout})
+	}
+}
+
+// empJam：电磁风暴持续期内枪械按概率失灵（TryFire 顶部调用）。
+func (r *Room) empJam(now time.Time) bool {
+	return r.stormKind == StormEMP &&
+		now.Before(r.stormEndsAt) &&
+		r.stormEndsAt.Sub(now) < stormDuration && // 预警期不 jam
+		rand.Float64() < empJamChance
+}
+
+func (r *Room) stormAnnounce(msg string) {
+	if r.hasStormAudience() {
+		r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报", Message: msg})
+	}
+}
+
+func (r *Room) hasStormAudience() bool {
+	for _, pl := range r.Players {
+		if !pl.IsBot {
+			return true
+		}
+	}
+	return false
+}
+
+

--- a/server/storm_test.go
+++ b/server/storm_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newStormRoom(t *testing.T) *Room {
+	store, err := NewStore(t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewRoom(1, &World{Size: [2]float64{96, 96}}, store)
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{0, 0, 0}
+	r.Players = append(r.Players, human)
+	return r
+}
+
+func TestStormWarningAndLightningStrike(t *testing.T) {
+	r := newStormRoom(t)
+	now := time.Now()
+	r.pending = nil
+
+	r.stepStorm(now) // 排期
+	if len(r.pending) != 0 || r.stormKind != StormNone {
+		t.Fatal("排期阶段不应有事件或天灾")
+	}
+
+	// 到点：预警播报 + 进入预警期（不立即造成伤害）。
+	r.stormNextAt = now
+	before := len(r.pending)
+	r.stepStorm(now)
+	if r.stormKind == StormNone {
+		t.Fatal("到点应降临一场天灾")
+	}
+	warned := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvChat && strings.Contains(e.Message, "天灾预警") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatal("应有天灾预警播报")
+	}
+	hpBefore := r.Players[0].PlayerState.HP
+	r.stepStorm(now.Add(time.Second))
+	if r.Players[0].PlayerState.HP != hpBefore {
+		t.Fatal("预警期内不应有伤害")
+	}
+
+	// 强制雷暴并校验落点伤害：玩家站在落点中心 → 吃满额雷击。
+	forced := r.stormKind != StormThunder
+	r.stormKind = StormThunder
+	r.stormStrikesLeft = 1
+	r.stormNextStrikeAt = now.Add(stormWarnDuration)
+	strikeTime := now.Add(stormWarnDuration)
+	before = len(r.pending)
+	r.stepStorm(strikeTime)
+	if forced && len(r.pending) == before {
+		t.Fatal("雷击应产生事件")
+	}
+	pos := r.stormStrikePos
+	r.Players[0].PlayerState.Pos = pos // 站到落点中心再结算? 落点已结算——改为校验事件
+	blast := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvExplosion {
+			blast = true
+		}
+	}
+	if !blast {
+		t.Fatal("雷击应发出 EvExplosion")
+	}
+}
+
+// 落点伤害：玩家恰好站在 stormStrikePos 时吃满额伤害（可致死走自雷语义）。
+func TestLightningDamagesPlayersInRadius(t *testing.T) {
+	r := newStormRoom(t)
+	now := time.Now()
+	human := &r.Players[0].PlayerState
+	human.HP = 30 // 满额 60 应致死
+
+	r.stormKind = StormThunder
+	r.stormEndsAt = now.Add(time.Minute)
+	r.stormNextStrikeAt = now
+	r.stormStrikesLeft = 5
+	// 直接调用 strike：落点即玩家脚下。
+	before := len(r.pending)
+	r.stormStrikeAt(now, human.Pos, stormThunderR, stormThunderDmg, "⚡ 轰隆——！")
+	if human.Alive {
+		t.Fatal("站桩吃满额雷击应致死")
+	}
+	death := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvKill && e.Killer == 10 && e.Victim == 10 {
+			death = true // 自雷语义：Killer=Victim
+		}
+	}
+	if !death {
+		t.Fatal("致死应有 EvKill（自雷）")
+	}
+	// 半径外玩家毫发无伤。
+	bystander := newTestBot(11, r)
+	bystander.Pos = Vec3{40, 0, 40}
+	r.Players = append(r.Players, bystander)
+	human.HP = MaxHP
+	human.Alive = true
+	before = len(r.pending)
+	r.stormStrikeAt(now.Add(time.Second), human.Pos, stormThunderR, stormThunderDmg, "⚡ 轰隆——！")
+	if bystander.PlayerState.HP != MaxHP {
+		t.Fatal("半径外不应受伤")
+	}
+	_ = before
+}
+
+// 电磁风暴：预警期不 jam，持续期按概率哑火（100% 注入时必哑火且不耗弹）。
+func TestEMPJamsFiringWithoutAmmoCost(t *testing.T) {
+	old := empJamChance
+	empJamChance = 1
+	defer func() { empJamChance = old }()
+
+	r := newStormRoom(t)
+	now := time.Now()
+	shooter := &r.Players[0].PlayerState
+	shooter.Pos = Vec3{0, 0, 0}
+	r.stormKind = StormEMP
+	r.stormEndsAt = now.Add(stormWarnDuration + stormDuration)
+	r.stormNextStrikeAt = now
+
+	// 预警期（还剩 > stormDuration）不 jam。
+	magBefore := shooter.Mags[0]
+	fired := r.TryFire(shooter, 0, 0, 0, 0, 1, now)
+	if !fired {
+		t.Fatal("预警期不应 jam")
+	}
+	if shooter.Mags[0] != magBefore-1 {
+		t.Fatal("预警期开火应正常耗弹")
+	}
+
+	// 持续期：必哑火且不耗弹。
+	r.stormEndsAt = now.Add(stormDuration)
+	magBefore = shooter.Mags[0]
+	fired = r.TryFire(shooter, 0, 0, 0, 0, 2, now.Add(time.Second))
+	if fired {
+		t.Fatal("100% jam 概率下开火应失败")
+	}
+	if shooter.Mags[0] != magBefore {
+		t.Fatal("哑火不应耗弹")
+	}
+}


### PR DESCRIPTION
# 《天灾工厂》DLC ⛈️

超大型 DLC：**轮换天灾系统**——战场不再是安全屋，每 120 秒随机降临一场天灾，3 秒预警 + 14 秒持续，全员活下去。零协议改动。

## 三种天灾

| 天灾 | 机制 |
|---|---|
| ⚡ **雷暴** | 14 秒内 6 次落雷，落点在随机玩家 ±12m 内游走，每击半径 3.5m、中心满额 60 伤害（可致死，自雷语义） |
| ☄ **流星雨** | 3 次大范围轰击，半径 4.5m、中心 70 伤害 |
| 📡 **电磁风暴** | 无伤害但枪械 35% 概率哑火（**不耗弹**，纯吓唬人），预警期不生效 |

- 落雷/流星走 `EvExplosion` 既有爆炸视觉 + `Damage` 既有伤害管线（自雷语义：Killer=Victim，死亡播报自动成立）
- 预警与战况走 EvChat 播报（「⚠ 天灾预警」「⚡ 轰隆——！」）
- 概率参数 `empJamChance` 用 var，测试可注入 100%

## 实现

- `server/storm.go`（新文件）：月相式状态机（排期 → 预警 → 持续 → 间歇）；`stormStrikeAt` 落点结算（落点写入 `stormStrikePos` 供测试断言）；`empJam` 在 `TryFire` 顶部接入（哑火早于耗弹）
- `server/room.go`：Room 新增 6 个 storm 字段（独立命名，与其他 DLC 无符号冲突）

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/storm_test.go` 3 测试：预警播报与预警期零伤害、落点 AoE 半径内外伤害与致死（自雷 EvKill）、EMP 预警期正常开火 / 持续期必哑火不耗弹

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34