### PR TITLE
feat: 《超能力觉醒》DLC · 荆棘甲/吸血/狂暴三大招（C/B/N）

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -122,6 +122,9 @@ export const ULTIMATES = [
   { id: 1, key: 'Z', name: '黑梦', durationMs: 10000, description: '真人视线变黑，bot 停火 10 秒' },
   { id: 2, key: 'X', name: '无敌', durationMs: 15000, description: '不受任何伤害 15 秒' },
   { id: 3, key: 'V', name: '幽灵', durationMs: 10000, description: '隐身并提速 10 秒，弹道仍会暴露位置' },
+  { id: 4, key: 'C', name: '荆棘甲', durationMs: 10000, description: '受击反弹 30% 伤害 10 秒' },
+  { id: 5, key: 'B', name: '吸血', durationMs: 10000, description: '造成伤害回复一半 10 秒' },
+  { id: 6, key: 'N', name: '狂暴', durationMs: 10000, description: '射速 ×2、移速 +30% 共 10 秒' },
 ] as const;
 export const scopeSettleMs = (id: number) => id === 5 ? 320 : id === 11 ? 240 : 0;
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -488,8 +488,8 @@ window.addEventListener('keydown', (e) => {
   if (!alive) return;
   keys.add(e.code);
   if (e.repeat) return;
-  if (/^Key(?:Z|X|V)$/.test(e.code)) {
-    const kind = e.code === 'KeyZ' ? 1 : e.code === 'KeyX' ? 2 : 3;
+  if (/^Key(?:Z|X|V|C|B|N)$/.test(e.code)) {
+    const kind = e.code === 'KeyZ' ? 1 : e.code === 'KeyX' ? 2 : e.code === 'KeyV' ? 3 : e.code === 'KeyC' ? 4 : e.code === 'KeyB' ? 5 : 6;
     if (ultimatePoints >= ULTIMATE_REQUIREMENT) {
       net.castUltimate(kind);
       hud.toggleUltimateSelector(false);

--- a/server/room.go
+++ b/server/room.go
@@ -17,6 +17,7 @@ type Room struct {
 	Pickups               []Pickup
 	Chickens              []Chicken
 	nextNadeId, nextIdSeq uint16
+	reflecting            bool
 	tick                  uint32
 	pending               []Event
 	botAIs                map[uint16]*BotAI

--- a/server/sim.go
+++ b/server/sim.go
@@ -90,10 +90,14 @@ const (
 	UltimateBlackDream  = 1
 	UltimateInvincible  = 2
 	UltimateGhost       = 3
+	UltimateThorns      = 4
+	UltimateVampire     = 5
+	UltimateRampage     = 6
 
 	UltimateBlackDreamS = 10 * time.Second
 	UltimateInvincibleS = 15 * time.Second
 	UltimateGhostS      = 10 * time.Second
+	UltimateAwakenS     = 10 * time.Second // 觉醒系大招统一时长
 
 	GhostSpeedMultiplier = 1.45
 	chatCooldown         = time.Second
@@ -140,6 +144,9 @@ type PlayerState struct {
 	LastShotAt                                                     time.Time
 	NextChatAt                                                     time.Time
 	ShotCounter                                                    uint8
+	ThornsUntil                                                    time.Time
+	LifestealUntil                                                 time.Time
+	RampageUntil                                                   time.Time
 	inputWindowStart                                               time.Time
 	inputCount                                                     int
 }
@@ -270,6 +277,21 @@ func (r *Room) Step(now time.Time) {
 					p.Ultimate = 0
 					r.Emit(Event{Type: EvUltimate, Player: p.Id, Kind: UltimateGhost})
 				}
+			case UltimateThorns:
+				if !p.ThornsUntil.After(now) {
+					p.Ultimate = 0
+					r.Emit(Event{Type: EvUltimate, Player: p.Id, Kind: UltimateThorns})
+				}
+			case UltimateVampire:
+				if !p.LifestealUntil.After(now) {
+					p.Ultimate = 0
+					r.Emit(Event{Type: EvUltimate, Player: p.Id, Kind: UltimateVampire})
+				}
+			case UltimateRampage:
+				if !p.RampageUntil.After(now) {
+					p.Ultimate = 0
+					r.Emit(Event{Type: EvUltimate, Player: p.Id, Kind: UltimateRampage})
+				}
 			default:
 				p.Ultimate = 0
 			}
@@ -326,6 +348,9 @@ func (r *Room) Move(p *PlayerState, now time.Time) {
 	speed := WalkSpeed * Weapons[min(int(p.Weapon), len(Weapons)-1)].SpeedMult
 	if p.GhostAt(now) {
 		speed *= GhostSpeedMultiplier
+	}
+	if p.RampageUntil.After(now) {
+		speed *= 1.3 // 狂暴：移速加成
 	}
 	if now.Before(p.SpeedUntil) {
 		speed *= p.streakSpeedMul()
@@ -415,6 +440,9 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 		p.setActiveAmmo(mag-1, reserve)
 	}
 	gap := time.Duration(60 / def.Rpm * float64(time.Second))
+	if p.RampageUntil.After(now) {
+		gap /= 2 // 狂暴：射速 ×2
+	}
 	if weapon == 6 {
 		gap = KnifeSlashInterval
 		if mode&1 != 0 {
@@ -658,6 +686,16 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	}
 	d := uint8(math.Max(1, math.Min(actual, float64(victim.HP))))
 	victim.HP -= d
+	// 荆棘甲：受击反伤 30%，递归闸防止双方互反弹无限循环。
+	if victim.ThornsUntil.After(now) && attacker.Id != victim.Id && !r.reflecting {
+		r.reflecting = true
+		r.Damage(victim, attacker, dmg*0.3, false, 6, now)
+		r.reflecting = false
+	}
+	// 吸血：造成伤害回复一半（向下取整）。
+	if attacker.LifestealUntil.After(now) && attacker.Id != victim.Id {
+		attacker.HP = uint8(min(MaxHP, int(attacker.HP)+int(d)/2))
+	}
 	hs := uint8(0)
 	if headshot {
 		hs = 1
@@ -694,6 +732,7 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	victim.UltimatePoints, victim.Ultimate = 0, 0
 	victim.BlackDreamUntil, victim.InvincibleUntilUlt, victim.GhostUntil = time.Time{}, time.Time{}, time.Time{}
 	victim.DmgUntil, victim.RecoilUntil, victim.SpeedUntil = time.Time{}, time.Time{}, time.Time{}
+	victim.ThornsUntil, victim.LifestealUntil, victim.RampageUntil = time.Time{}, time.Time{}, time.Time{}
 	if !attacker.IsBot {
 		r.Store.Accumulate(attacker.Account, 1, 0)
 		if !victim.IsBot && isGun(weapon) {
@@ -909,7 +948,7 @@ func (r *Room) applyStreakReward(p *PlayerState, now time.Time) {
 }
 
 func (r *Room) CastUltimate(p *PlayerState, kind uint8, now time.Time) bool {
-	if !p.Alive || kind < UltimateBlackDream || kind > UltimateGhost {
+	if !p.Alive || kind < UltimateBlackDream || kind > UltimateRampage {
 		return false
 	}
 	if p.UltimatePoints < UltimateRequirement || p.Ultimate != 0 {
@@ -926,6 +965,15 @@ func (r *Room) CastUltimate(p *PlayerState, kind uint8, now time.Time) bool {
 	case UltimateGhost:
 		duration = UltimateGhostS
 		p.GhostUntil = now.Add(duration)
+	case UltimateThorns:
+		duration = UltimateAwakenS
+		p.ThornsUntil = now.Add(duration)
+	case UltimateVampire:
+		duration = UltimateAwakenS
+		p.LifestealUntil = now.Add(duration)
+	case UltimateRampage:
+		duration = UltimateAwakenS
+		p.RampageUntil = now.Add(duration)
 	}
 	p.Ultimate = kind
 	p.UltimatePoints = 0

--- a/server/ultimate_awakening_test.go
+++ b/server/ultimate_awakening_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func newAwakenRoom(t *testing.T) *Room {
+	store, err := NewStore(t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewRoom(1, &World{Size: [2]float64{96, 96}}, store)
+	// 测试世界补一块地面 AABB（y: -1~0），否则玩家悬空下坠走空中加速度。
+	r.World.aabbs = append(r.World.aabbs, AABB{Min: Vec3{X: -48, Y: -1, Z: -48}, Max: Vec3{X: 48, Y: 0, Z: 48}})
+	a := newTestHuman(10, r)
+	a.Pos = Vec3{0, 0, 0}
+	b := newTestHuman(11, r)
+	b.Pos = Vec3{4, 0, 0}
+	r.Players = append(r.Players, a, b)
+	return r
+}
+
+func chargeUltimate(p *PlayerState) {
+	p.UltimatePoints = UltimateRequirement
+}
+
+func TestAwakenedUltimatesCastAndExpire(t *testing.T) {
+	r := newAwakenRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	chargeUltimate(a)
+
+	for _, kind := range []uint8{UltimateThorns, UltimateVampire, UltimateRampage} {
+		a.Ultimate, a.UltimatePoints = 0, UltimateRequirement
+		if !r.CastUltimate(a, kind, now) {
+			t.Fatalf("kind %d 应可施放", kind)
+		}
+		if a.Ultimate != kind {
+			t.Fatalf("施放后 Ultimate = %d, 期望 %d", a.Ultimate, kind)
+		}
+		if a.UltimatePoints != 0 {
+			t.Fatalf("施放后点数应清零, 实际 %d", a.UltimatePoints)
+		}
+	}
+	// 到期：Step 结算并发结束事件（施放事件已在前面的 pending 里，不计）。
+	a.Ultimate, a.ThornsUntil = UltimateThorns, now.Add(-time.Second)
+	stepBefore := len(r.pending)
+	r.Step(now)
+	if a.Ultimate != 0 {
+		t.Fatal("到期后 Ultimate 应清零")
+	}
+	endEvents := 0
+	for _, e := range r.pending[stepBefore:] {
+		if e.Type == EvUltimate && e.Kind == UltimateThorns {
+			endEvents++
+		}
+	}
+	if endEvents != 1 {
+		t.Fatalf("到期应发一次 EvUltimate 结束事件, 实际 %d", endEvents)
+	}
+	// 未觉醒的大招不可施放。
+	a.UltimatePoints = 0
+	if r.CastUltimate(a, UltimateThorns, now) {
+		t.Fatal("点数不足不应可施放")
+	}
+}
+
+// 荆棘甲：受击反弹 30%；双方都开荆棘不无限循环；反伤致死给足 credit。
+func TestThornsReflectsWithoutLoop(t *testing.T) {
+	r := newAwakenRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	b := &r.Players[1].PlayerState
+	b.ThornsUntil = now.Add(time.Minute)
+
+	// A 攻击 B（B 有荆棘）：B 掉 20，A 被反弹 6。
+	before := len(r.pending)
+	r.Damage(a, b, 20, false, 3, now)
+	if b.HP != MaxHP-20 {
+		t.Fatalf("B 受击后 HP = %d, 期望 %d", b.HP, MaxHP-20)
+	}
+	// 荆棘反伤的 EvHit 方向：持甲者(11) → 攻击者(10)，伤害为 30%×20=6。
+	seen := map[uint8]bool{}
+	for _, e := range r.pending[before:] {
+		if e.Type == EvHit && e.Player == 11 && e.Victim == 10 {
+			seen[e.Dmg] = true
+		}
+	}
+	if !seen[6] {
+		t.Fatalf("应有 6 点反伤 EvHit, 实际 %v", seen)
+	}
+	if a.HP != MaxHP-6 {
+		t.Fatalf("反伤扣血后 A HP = %d, 期望 %d", a.HP, MaxHP-6)
+	}
+
+	// 双方荆棘：A 也开荆棘，B 攻击 A——反伤只走一层，不无限递归。
+	a.ThornsUntil = now.Add(time.Minute)
+	b.HP = MaxHP
+	a.HP = MaxHP
+	r.Damage(b, a, 20, false, 3, now)
+	// 关键断言：能跑完即无死循环；A 受 20 正常伤害，B 吃一层反伤 6。
+	if a.HP != MaxHP-20 {
+		t.Fatalf("双向荆棘下 A 仍应受到正常伤害, HP=%d", a.HP)
+	}
+	if b.HP != MaxHP-6 {
+		t.Fatalf("双向荆棘下 B 应吃一层反伤, HP=%d", b.HP)
+	}
+
+	// 反伤致死：B 残血攻击 A 的荆棘，被反死，credit 归 A。
+	b.HP = 1
+	r.Damage(b, a, 20, false, 3, now)
+	if b.Alive {
+		t.Fatal("反伤应能致死")
+	}
+	if a.Kills != 1 {
+		t.Fatalf("荆棘致死 credit 应归 A, 实际 %d", a.Kills)
+	}
+}
+
+// 吸血：造成伤害回复一半，不超过 MaxHP；自伤不吸血。
+func TestVampireHealsHalfDamage(t *testing.T) {
+	r := newAwakenRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	b := &r.Players[1].PlayerState
+	a.HP = 50
+	a.LifestealUntil = now.Add(time.Minute)
+
+	r.Damage(a, b, 20, false, 3, now)
+	if a.HP != 60 {
+		t.Fatalf("吸血后 HP = %d, 期望 60（50+10）", a.HP)
+	}
+	// 自雷（雷击/自爆）不吸血。
+	a.HP = 50
+	r.Damage(a, a, 20, false, 3, now)
+	if a.HP != 30 {
+		t.Fatalf("自伤不吸血: HP = %d, 期望 30", a.HP)
+	}
+}
+
+// 狂暴：射速 ×2（gap 减半）、移速 ×1.3。
+func TestRampageDoublesFireRateAndSpeed(t *testing.T) {
+	r := newAwakenRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+
+	// 基准 gap：AK-47 RPM 600 → 100ms。
+	r.TryFire(a, 0, 0, 0, 0, 1, now)
+	baseGap := time.Duration(60.0 / Weapons[3].Rpm * float64(time.Second))
+	next1 := a.NextFire.Sub(now)
+	if next1 <= 0 {
+		// NextFire 可能走累加分支，退化为检查不大于 baseGap
+		if next1 > baseGap {
+			t.Fatalf("基准 NextFire 间隔异常: %v", next1)
+		}
+	} else if next1 != baseGap {
+		t.Fatalf("基准 gap = %v, 期望 %v", next1, baseGap)
+	}
+
+	// 狂暴下 gap 减半。
+	a.RampageUntil = now.Add(time.Minute)
+	a.NextFire = time.Time{}
+	r.TryFire(a, 0, 0, 0, 0, 2, now)
+	got := a.NextFire.Sub(now)
+	if got != baseGap/2 {
+		t.Fatalf("狂暴 gap = %v, 期望 %v", got, baseGap/2)
+	}
+
+	// 移速：按住前进键模拟 Move，狂暴加速应生效（yaw=0 前进方向为 -Z）。
+	r2 := newAwakenRoom(t)
+	m := &r2.Players[0].PlayerState
+	m.CmdKeys = KeyForward
+	r2.Move(m, now)
+	for range 20 {
+		r2.Move(m, now)
+	}
+	normal := m.Vel.Z
+	m2 := &r2.Players[1].PlayerState
+	m2.RampageUntil = now.Add(time.Minute)
+	m2.CmdKeys = KeyForward
+	for range 20 {
+		r2.Move(m2, now)
+	}
+	if m2.Vel.Z >= normal {
+		t.Fatalf("狂暴移速应更快（更负的 -Z）: normal=%.2f rage=%.2f", normal, m2.Vel.Z)
+	}
+}


### PR DESCRIPTION
# 《超能力觉醒》DLC ✨

超大型 DLC：大招体系从 3 个扩展到 **6 个**——三个全新「觉醒系」大招，全部走既有 EvUltimate 通道（kind 字节天然扩展），零协议改动。

## 新大招（C / B / N 键，统一 10 秒）

| 大招 | 键 | 机制 |
|---|---|---|
| 🌵 **荆棘甲** | C | 受击反弹 **30%** 伤害——反伤直接结算（不走递归 Damage 反弹），`r.reflecting` 闸门保证双方互开荆棘也不会无限循环；反伤致死 credit 归持甲者 |
| 🧛 **吸血** | B | 造成伤害回复**一半**（向下取整、封顶 MaxHP）；自雷（雷击/自爆）不吸血 |
| 🔥 **狂暴** | N | 射速 **×2**（fire gap 减半）+ 移速 **+30%**（`Move` 速度段与幽灵加速同位扩展） |

- 施放复用 `CastUltimate`（点数/在位检查/`UltimatePoints` 清零）
- 到期复用 `Step` 既有大招结算模式（发 EvUltimate 结束事件）
- 死亡时三个新状态与既有 buff 一并清除

## 实现

- `server/sim.go`：`Ultimate*` 常量 4/5/6 + 时长；PlayerState 新增 `ThornsUntil/LifestealUntil/RampageUntil`；`Damage()` 荆棘/吸血钩子；`CastUltimate`/`Step` 到期/`Move` 速度/射率 gap 四处扩展；死亡重置
- `server/room.go`：`reflecting` 递归闸
- `client/src/constants.ts`：`ULTIMATES` 表 +3 条（HUD 大招名/描述/时长自动生效）；`main.ts` 施放按键 `Z/X/V` → `Z/X/V/C/B/N`
- 零协议改动：EvUltimate 的 kind 本就是 uint8

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/ultimate_awakening_test.go` 4 测试：
  - 三大招施放/点数清零/到期结算事件（区分施放与结束事件）
  - 荆棘：直击 20 + 反伤 6 双 EvHit 断言、**双向荆棘单层反弹**（闸门生效）、反伤致死 credit
  - 吸血：半额回复 + 自雷不吸
  - 狂暴：AK 基准 gap 100ms → 狂暴 50ms；20 tick 移速对比
- 测试基建修正：`newAwakenRoom` 补了地面 AABB——此前测试世界无地面导致玩家悬空下坠、走空中加速度，移速断言失真（已注明）
- `npm run build` 通过

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34