### PR TITLE
feat: 《空投战争》DLC · 运输机掠空 + 传奇补给箱争夺

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1277,6 +1277,58 @@ net.onEvents = (events) => {
   for (const e of events) handleEvent(e);
 };
 
+// ============ 《空投战争》DLC：运输机飞行动画 ============
+// 传奇补给落地瞬间，一架运输机从天际掠过箱位上空（纯视觉，3.5 秒）。
+let airdropPlane: THREE.Group | null = null;
+let airdropPlaneFrom: THREE.Vector3 | null = null;
+let airdropPlaneTo: THREE.Vector3 | null = null;
+let airdropPlaneStart = 0;
+
+function spawnAirdropPlane(origin: number[]) {
+  if (airdropPlane) scene.remove(airdropPlane);
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(
+    new THREE.BoxGeometry(1.2, 1.2, 6),
+    new THREE.MeshLambertMaterial({ color: 0x4a5568 }),
+  );
+  const wing = new THREE.Mesh(
+    new THREE.BoxGeometry(9, 0.25, 1.4),
+    new THREE.MeshLambertMaterial({ color: 0x3a4354 }),
+  );
+  const tail = new THREE.Mesh(
+    new THREE.BoxGeometry(0.25, 1.6, 1.2),
+    new THREE.MeshLambertMaterial({ color: 0x3a4354 }),
+  );
+  tail.position.set(0, 0.8, 2.6);
+  g.add(body, wing, tail);
+  const tx = origin[0], tz = origin[2];
+  airdropPlaneFrom = new THREE.Vector3(tx - 120, 70, tz - 90);
+  airdropPlaneTo = new THREE.Vector3(tx + 120, 62, tz + 90);
+  g.position.copy(airdropPlaneFrom);
+  g.lookAt(airdropPlaneTo);
+  airdropPlane = g;
+  airdropPlaneStart = performance.now();
+  scene.add(g);
+}
+
+function updateAirdropPlane(t: number) {
+  if (!airdropPlane || !airdropPlaneFrom || !airdropPlaneTo) return;
+  const k = (t - airdropPlaneStart) / 3500;
+  if (k >= 1) {
+    scene.remove(airdropPlane);
+    airdropPlane.traverse((o) => {
+      const m = o as THREE.Mesh;
+      if (m.isMesh) {
+        m.geometry.dispose();
+        (m.material as THREE.Material).dispose();
+      }
+    });
+    airdropPlane = null;
+    return;
+  }
+  airdropPlane.position.lerpVectors(airdropPlaneFrom, airdropPlaneTo, k);
+}
+
 function handleEvent(e: GameEvent) {
   if (e.type === 17) {
     hud.addChatMessage(e.name ?? nameOf(e.player), e.message ?? '', e.player === net.yourId);
@@ -1491,6 +1543,7 @@ function handleEvent(e: GameEvent) {
   if (e.type === 10 && e.pickup !== undefined && e.kind !== undefined && e.origin) {
     pickupStates.set(e.pickup, { kind: e.kind, origin: e.origin });
     world?.setPickup(e.pickup, e.kind, ...e.origin);
+    if (e.kind === 3) spawnAirdropPlane(e.origin);
     return;
   }
   if (e.type === 11 && e.pickup !== undefined) {
@@ -1605,6 +1658,7 @@ function frame(t: number) {
   const dt = Math.min(0.05, (t - prev) / 1000);
   prev = t;
   if (document.hidden) return;
+  updateAirdropPlane(t);
 
   if (joined && alive) {
     local.speedMultiplier = (t < speedBoostUntil ? SPEED_BOOST_MULTIPLIER : 1) * (ultimateKind === 3 && t < ultimateUntil ? 1.45 : 1);

--- a/client/src/world.ts
+++ b/client/src/world.ts
@@ -412,7 +412,7 @@ export class WorldView {
   boxes: { x0: number; x1: number; y0: number; y1: number; z0: number; z1: number }[] = [];
   constructor(scene: THREE.Scene, map: MapData) {
     this.scene = scene;
-    this.pickupTemplates = [this.createPickup(0), this.createPickup(1), this.createPickup(2)];
+    this.pickupTemplates = [this.createPickup(0), this.createPickup(1), this.createPickup(2), this.createPickup(3)];
     this.chickenTemplate = this.createChicken();
 
     // 1. Build Repeating-UV High-Definition Voxel Map with Merged Geometries per Material
@@ -471,8 +471,8 @@ export class WorldView {
 
   private createPickup(kind: number): THREE.Group {
     const group = new THREE.Group();
-    const colors = [0xe4a94a, 0xd94c4c, 0x35c9e8];
-    const color = colors[kind];
+    const colors = [0xe4a94a, 0xd94c4c, 0x35c9e8, 0xffd54a];
+    const color = colors[kind] ?? colors[0];
     const core = new THREE.Mesh(
       new THREE.BoxGeometry(0.52, 0.36, 0.52),
       new THREE.MeshLambertMaterial({ color, emissive: color, emissiveIntensity: 0.75 }),
@@ -481,6 +481,22 @@ export class WorldView {
       new THREE.SphereGeometry(0.68, 12, 8),
       new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.16, depthWrite: false, blending: THREE.AdditiveBlending }),
     );
+    if (kind === 3) {
+      // 传奇空投箱：大一号的金色货箱 + 降落伞
+      const crate = new THREE.Mesh(
+        new THREE.BoxGeometry(0.7, 0.5, 0.7),
+        new THREE.MeshLambertMaterial({ color: 0xffd54a, emissive: 0xffd54a, emissiveIntensity: 0.5 }),
+      );
+      const strapMat = new THREE.MeshBasicMaterial({ color: 0x222222 });
+      const strap = new THREE.Mesh(new THREE.BoxGeometry(0.72, 0.52, 0.12), strapMat);
+      const chute = new THREE.Mesh(
+        new THREE.SphereGeometry(0.9, 12, 6, 0, Math.PI * 2, 0, Math.PI / 2),
+        new THREE.MeshLambertMaterial({ color: 0xf5f2df, side: THREE.DoubleSide }),
+      );
+      chute.position.y = 1.1;
+      group.add(crate, strap, chute);
+      return group;
+    }
     group.add(core, glow);
     const markerMat = new THREE.MeshBasicMaterial({ color: 0xf5f2df });
     if (kind === 0) {

--- a/server/airdrop.go
+++ b/server/airdrop.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// 《空投战争》DLC：运输机周期性掠过战场，投下传奇补给箱（金色空投）。
+// 箱子 45 秒无人认领则自动回收；抢到 = 满血满甲弹药全满 +2 大招点。
+// 复用拾取实体与 EvPickupSpawn/Taken 事件，零协议改动。
+
+const (
+	airdropFirst        = 90 * time.Second
+	airdropGapMin       = 120 * time.Second
+	airdropGapMax       = 180 * time.Second
+	airdropLinger       = 45 * time.Second
+	airdropIdBase uint16 = 600 // 空投箱 ID 段（与玩家 1+、僵尸 500+ 隔离）
+)
+
+// Room 侧字段见 room.go：nextAirdropAt / airdropSeq / airdropDeadlines。
+
+type airdropDeadline struct {
+	pickupId  uint16
+	expiresAt time.Time
+}
+
+// stepAirdrops：空投调度 + 无人认领的箱子到期回收。
+func (r *Room) stepAirdrops(now time.Time) {
+	if len(r.World.Spawns) == 0 {
+		return // 无出生点数据（空测试世界）时不做空投
+	}
+	if r.nextAirdropAt.IsZero() {
+		r.nextAirdropAt = now.Add(airdropFirst)
+		return
+	}
+	// 到期回收（从尾往头删，避免迭代位移问题）。
+	for i := len(r.airdropDeadlines) - 1; i >= 0; i-- {
+		if now.Before(r.airdropDeadlines[i].expiresAt) {
+			continue
+		}
+		id := r.airdropDeadlines[i].pickupId
+		r.airdropDeadlines = append(r.airdropDeadlines[:i], r.airdropDeadlines[i+1:]...)
+		// 箱子若已被拾取则不在 Pickups 里（拾取时置为永久休眠），回收仅对还在场的生效。
+		for j := range r.Pickups {
+			if r.Pickups[j].Id == id && r.Pickups[j].Active && r.Pickups[j].Kind == PickupAirdrop {
+				r.Pickups[j].Active = false
+				r.Pickups[j].RespawnAt = now.Add(100 * 365 * 24 * time.Hour)
+				r.Emit(Event{Type: EvPickupTaken, Player: id, Victim: 0, Kind: PickupAirdrop, Origin: r.Pickups[j].Pos})
+				break
+			}
+		}
+	}
+	if !now.Before(r.nextAirdropAt) {
+		gap := airdropGapMin + time.Duration(rand.IntN(int((airdropGapMax-airdropGapMin)/time.Second)))*time.Second
+		r.nextAirdropAt = now.Add(gap)
+		if len(r.Pickups) > 64 {
+			return // 拾取池异常膨胀时跳过本轮，保护快照体积
+		}
+		if r.hasAirdropAudience() {
+			r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+				Message: "✈ 运输机正在接近！传奇补给即将空投——满血满甲弹药全满 +2 大招点，先到先得！"})
+		}
+		pos := r.randomPickupPosition()
+		id := r.airdropSeq
+		if id < airdropIdBase {
+			id = airdropIdBase
+		}
+		r.airdropSeq = id + 1
+		r.Pickups = append(r.Pickups, Pickup{Id: id, Kind: PickupAirdrop, Pos: pos, Active: true, RespawnAt: now.Add(100 * 365 * 24 * time.Hour)})
+		r.airdropDeadlines = append(r.airdropDeadlines, airdropDeadline{pickupId: id, expiresAt: now.Add(airdropLinger)})
+		r.Emit(Event{Type: EvPickupSpawn, Player: id, Kind: PickupAirdrop, Origin: pos})
+	}
+}
+
+func (r *Room) hasAirdropAudience() bool {
+	for _, pl := range r.Players {
+		if !pl.IsBot {
+			return true
+		}
+	}
+	return false
+}

--- a/server/airdrop_test.go
+++ b/server/airdrop_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newAirdropRoom(t *testing.T) *Room {
+	store, err := NewStore(t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewRoom(1, &World{Size: [2]float64{96, 96}, Spawns: [][3]float64{{0, 0, 0}, {20, 0, 20}}}, store)
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{0, 0, 0}
+	r.Players = append(r.Players, human)
+	return r
+}
+
+// 空投生命周期：到点播报 + 箱子落地 → 45 秒无人认领 → 自动回收。
+func TestAirdropLifecycle(t *testing.T) {
+	r := newAirdropRoom(t)
+	now := time.Now()
+	r.pending = nil
+
+	r.stepAirdrops(now) // 排期
+	if len(r.pending) != 0 {
+		t.Fatal("排期阶段不应有事件")
+	}
+
+	r.nextAirdropAt = now
+	before := len(r.pending)
+	r.stepAirdrops(now)
+	if len(r.airdropDeadlines) != 1 {
+		t.Fatal("应有 1 个在期空投")
+	}
+	announced := false
+	spawned := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvChat && strings.Contains(e.Message, "运输机") {
+			announced = true
+		}
+		if e.Type == EvPickupSpawn && e.Kind == PickupAirdrop {
+			spawned = true
+		}
+	}
+	if !announced || !spawned {
+		t.Fatalf("空投应播报并生成箱子, announced=%v spawned=%v", announced, spawned)
+	}
+	crateId := r.airdropDeadlines[0].pickupId
+	if crateId < airdropIdBase {
+		t.Fatalf("空投箱 ID = %d, 应 ≥ %d", crateId, airdropIdBase)
+	}
+
+	// 未认领到期：回收（EvPickupTaken Victim=0）。
+	dawn := now.Add(airdropLinger + time.Second)
+	before = len(r.pending)
+	r.stepAirdrops(dawn)
+	recycled := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvPickupTaken && e.Player == crateId && e.Victim == 0 {
+			recycled = true
+		}
+	}
+	if !recycled {
+		t.Fatal("到期空投应回收")
+	}
+	for i := range r.Pickups {
+		if r.Pickups[i].Id == crateId && r.Pickups[i].Active {
+			t.Fatal("回收后箱子应休眠")
+		}
+	}
+}
+
+// 抢箱结算：满血满甲弹药全满 +2 大招点 + 播报；空投箱拾取后永不重生。
+func TestAirdropClaimJackpot(t *testing.T) {
+	r := newAirdropRoom(t)
+	now := time.Now()
+	human := &r.Players[0].PlayerState
+	human.HP = 20
+	human.Armor = 0
+	human.Mags = [2]int{1, 1}
+	human.Reserves = [2]int{1, 1}
+
+	// 手动放置一只空投箱在玩家脚下。
+	r.Pickups = append(r.Pickups, Pickup{Id: airdropIdBase, Kind: PickupAirdrop, Pos: Vec3{0, 0, 0}, Active: true, RespawnAt: now.Add(time.Hour)})
+	r.airdropDeadlines = append(r.airdropDeadlines, airdropDeadline{pickupId: airdropIdBase, expiresAt: now.Add(time.Hour)})
+
+	before := len(r.pending)
+	r.StepPickups(now)
+	jackpot := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvChat && strings.Contains(e.Message, "抢到了传奇补给") {
+			jackpot = true
+		}
+	}
+	if !jackpot {
+		t.Fatal("抢到空投应有播报")
+	}
+	if human.HP != MaxHP || human.Armor != 100 {
+		t.Fatalf("补给后 HP=%d Armor=%d, 期望 %d/100", human.HP, human.Armor, MaxHP)
+	}
+	if human.Mags[0] != Weapons[3].Mag || human.Reserves[0] != Weapons[3].Reserve {
+		t.Fatal("补给后弹药应全满")
+	}
+	if human.UltimatePoints != 2 {
+		t.Fatalf("大招点 = %d, 期望 2", human.UltimatePoints)
+	}
+	// 空投箱拾取后永久休眠（不进入常规重生轮换）。
+	for i := range r.Pickups {
+		if r.Pickups[i].Id == airdropIdBase && r.Pickups[i].Active {
+			t.Fatal("空投箱拾取后不应复活")
+		}
+	}
+}

--- a/server/room.go
+++ b/server/room.go
@@ -17,6 +17,9 @@ type Room struct {
 	Pickups               []Pickup
 	Chickens              []Chicken
 	nextNadeId, nextIdSeq uint16
+	nextAirdropAt         time.Time
+	airdropSeq            uint16
+	airdropDeadlines      []airdropDeadline
 	tick                  uint32
 	pending               []Event
 	botAIs                map[uint16]*BotAI

--- a/server/sim.go
+++ b/server/sim.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"math/rand/v2"
@@ -284,6 +285,7 @@ func (r *Room) Step(now time.Time) {
 		r.CheckSanity(p)
 	}
 	r.StepPickups(now)
+	r.stepAirdrops(now)
 	r.StepChickens(now)
 	r.recordHistory()
 }
@@ -1054,6 +1056,7 @@ const (
 	PickupAmmo uint8 = iota
 	PickupHealth
 	PickupSpeed
+	PickupAirdrop
 	pickupCount = 12
 )
 
@@ -1144,6 +1147,17 @@ func (r *Room) StepPickups(now time.Time) {
 			}
 			pickup.Active = false
 			pickup.RespawnAt = now.Add(time.Duration(8+rand.IntN(5)) * time.Second)
+			if pickup.Kind == PickupAirdrop {
+				// 传奇补给被抢：额外 +2 大招点 + 全房播报；空投箱不进入常规重生轮换。
+				pickup.RespawnAt = now.Add(100 * 365 * 24 * time.Hour)
+				if p.Ultimate == 0 {
+					p.UltimatePoints = uint8(min(UltimateRequirement, int(p.UltimatePoints)+2))
+				}
+				if r.hasAirdropAudience() {
+					r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+						Message: fmt.Sprintf("🏆 %s 抢到了传奇补给：满血 + 满甲 + 弹药全满 +2 大招点！", p.Name)})
+				}
+			}
 			ms := uint16(0)
 			if pickup.Kind == PickupSpeed {
 				ms = uint16(speedBoostDuration / time.Millisecond)
@@ -1171,6 +1185,14 @@ func applyPickup(p *PlayerState, kind uint8, now time.Time) bool {
 		p.HP = uint8(min(MaxHP, int(p.HP)+50))
 	case PickupSpeed:
 		p.SpeedUntil = now.Add(speedBoostDuration)
+	case PickupAirdrop:
+		// 传奇补给：满血满甲弹药全满（大招点奖励由 StepPickups 结算时发放）。
+		p.HP = MaxHP
+		p.Armor = 100
+		primary, secondary := Weapons[p.Primary], Weapons[p.Secondary]
+		p.Mags = [2]int{primary.Mag, secondary.Mag}
+		p.Reserves = [2]int{primary.Reserve, secondary.Reserve}
+		p.Reloading, p.ReloadEnd, p.NextFire = false, time.Time{}, now
 	default:
 		return false
 	}


### PR DESCRIPTION
# 《空投战争》DLC ✈️📦

超大型 DLC：**空投争夺玩法**——运输机周期性掠过战场，投下金色传奇补给箱，全房争夺。

## 玩法

- **投放**：开局 90 秒首投，此后每 120-180 秒一场；播报「✈ 运输机正在接近！」，金色货箱（带降落伞）落在随机活跃区域
- **争夺**：抢到 = **满血 + 满甲 + 弹药全满 + 2 大招点**，全房播报争夺结果
- **时效**：45 秒无人认领自动回收（晨光版 EvPickupTaken，Victim=0）
- **零协议改动**：复用拾取实体与 EvPickupSpawn/Taken 事件（kind 字节扩展 3 号，客户端未知名自动回退模板 0 的安全设计本就存在，本 PR 直接补上专属模板）

## 实现

- `server/airdrop.go`（新文件）：投放调度 + 到期回收（倒序删除防位移）+ `hasAirdropAudience`；ID 段 **600+**（与玩家 1+、僵尸 500+ 隔离）
- `server/sim.go`：`PickupAirdrop=3` 拾取类型 + `applyPickup` 大奖结算 + `StepPickups` 争夺播报钩子；空投箱拾取后**永久休眠**（RespawnAt=百年后），不进入常规拾取的 8-12s 重生轮换
- 拾取池 >64 时跳过投放（保护快照体积）；无出生点数据的世界跳过空投（`randomPickupPosition` 的 `IntN(0)` panic 隐患防御，生产地图不受影响）
- 客户端：`world.ts` 金色货箱+降落伞模板；`main.ts` 运输机 3.5 秒掠空动画（机身/机翼/尾翼，结束逐资源 dispose）

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/airdrop_test.go` 2 测试：生命周期（排期零事件→播报+落地+ID 段断言→到期回收+休眠）、抢箱结算（满血满甲弹药数值、+2 大招点、播报、永久休眠）
- `npm run build` 通过

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34