### PR TITLE
feat: 《据点战争》DLC · A/B/C 三据点占领积分赛

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -987,6 +987,7 @@ function enterPractice() {
     world = new WorldView(scene, map);
     world.clouds.visible = hud.quality !== 'low';
     hud.setMap(map);
+    buildZoneBeacons(map, world);
   }
   const map = bundledMap as MapData;
   let spawn: [number, number, number] = map.spawns?.[0] ?? [0, 0, 0];
@@ -1167,6 +1168,7 @@ net.onWelcome = (id, _revision) => {
     world = new WorldView(scene, map);
     world.clouds.visible = hud.quality !== 'low';
     hud.setMap(map);
+    buildZoneBeacons(map, world);
     for (const [pickupId, pickup] of pickupStates) world.setPickup(pickupId, pickup.kind, ...pickup.origin);
   }
   names.set(id, myName);
@@ -1276,6 +1278,29 @@ net.onRoster = (list) => {
 net.onEvents = (events) => {
   for (const e of events) handleEvent(e);
 };
+
+// ============ 《据点战争》DLC：A/B/C 据点信标 ============
+// 与服务端 zone.go 同位的三个据点；被墙体占用的中心自动跳过。
+const ZONE_CENTERS: [number, number, number][] = [[-96, -96, 0x3de1ff], [0, 160, 0xff4dd2], [96, 96, 0xffd54a]];
+const zoneBeaconBuilt = new Set<MapData>();
+function buildZoneBeacons(map: MapData, worldView: WorldView) {
+  if (zoneBeaconBuilt.has(map)) return;
+  zoneBeaconBuilt.add(map);
+  for (const [x, z, color] of ZONE_CENTERS) {
+    if (!canOccupy(worldView.boxes, new THREE.Vector3(x, 0.1, z), PHYS.standingHeight)) continue;
+    const pole = new THREE.Mesh(
+      new THREE.BoxGeometry(1, 8, 1),
+      new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.8 }),
+    );
+    pole.position.set(x, 4, z);
+    const cap = new THREE.Mesh(
+      new THREE.BoxGeometry(2, 0.8, 2),
+      new THREE.MeshBasicMaterial({ color }),
+    );
+    cap.position.set(x, 8.2, z);
+    scene.add(pole, cap);
+  }
+}
 
 function handleEvent(e: GameEvent) {
   if (e.type === 17) {

--- a/server/room.go
+++ b/server/room.go
@@ -16,6 +16,8 @@ type Room struct {
 	Grenades              []*Grenade
 	Pickups               []Pickup
 	Chickens              []Chicken
+	zoneOwners            [3]uint16
+	zoneHoldTicks         [3]int
 	nextNadeId, nextIdSeq uint16
 	tick                  uint32
 	pending               []Event

--- a/server/sim.go
+++ b/server/sim.go
@@ -285,6 +285,7 @@ func (r *Room) Step(now time.Time) {
 	}
 	r.StepPickups(now)
 	r.StepChickens(now)
+	r.stepZones()
 	r.recordHistory()
 }
 

--- a/server/zone.go
+++ b/server/zone.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+// 《据点战争》DLC：A/B/C 三据点占领积分赛。
+// 单独一人在据点内持续站立即开始「巩固」；巩固满 10 秒获得一次
+// 大招点奖励并播报；多人同处则进入争夺冻结。零协议改动。
+
+const (
+	zoneRadius        = 7.0                // 据点半径（水平）
+	zoneHoldTicks     = 10 * TickRate      // 巩固一轮所需 tick（10 秒）
+	zoneRewardHP      = 25                 // 每轮巩固奖励回血
+	zoneRewardUlt     = 1                  // 每轮巩固奖励大招点
+	zoneCenterBlocked = -1.0               // 中心被墙占用的死区标记
+)
+
+// 地图无关的三个据点位（CanOccupy 判定为墙时该据点自动休眠）。
+var zoneCenters = [3]Vec3{
+	{X: -96, Z: -96},
+	{X: 0, Z: 160},
+	{X: 96, Z: 96},
+}
+
+var zoneNames = [3]string{"A", "B", "C"}
+
+// stepZones：每 tick 扫描三个据点的占员情况（3×N，开销可忽略）。
+func (r *Room) stepZones() {
+	for zi := range zoneCenters {
+		center := zoneCenters[zi]
+		if !r.World.CanOccupy(Vec3{X: center.X, Y: 0.1, Z: center.Z}, StandingHeight) {
+			continue // 中心被墙体占用：据点休眠
+		}
+		occupant := (*PlayerState)(nil)
+		contested := false
+		for _, pl := range r.Players {
+			p := &pl.PlayerState
+			if !p.Alive || !p.OnGround {
+				continue
+			}
+			dx, dz := p.Pos.X-center.X, p.Pos.Z-center.Z
+			if dx*dx+dz*dz > zoneRadius*zoneRadius {
+				continue
+			}
+			if occupant == nil {
+				occupant = p
+			} else {
+				contested = true
+			}
+		}
+		if contested || occupant == nil {
+			continue // 争夺中/无人：冻结不倒退
+		}
+		if r.zoneOwners[zi] != occupant.Id {
+			// 换人占领：重置巩固进度并播报首占。
+			r.zoneOwners[zi] = occupant.Id
+			r.zoneHoldTicks[zi] = 0
+			if r.hasZoneAudience() {
+				r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+					Message: fmt.Sprintf("🏛 %s 点已被 %s 占领，站稳 10 秒领取奖励！", zoneNames[zi], occupant.Name)})
+			}
+			continue
+		}
+		r.zoneHoldTicks[zi]++
+		if r.zoneHoldTicks[zi] >= zoneHoldTicks {
+			r.zoneHoldTicks[zi] = 0
+			if occupant.Ultimate == 0 {
+				occupant.UltimatePoints = uint8(min(UltimateRequirement, int(occupant.UltimatePoints)+zoneRewardUlt))
+			}
+			occupant.HP = uint8(min(MaxHP, int(occupant.HP)+zoneRewardHP))
+			if r.hasZoneAudience() {
+				r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+					Message: fmt.Sprintf("🏛 %s 巩固了 %s 点（+%d 大招点 +%d HP）", occupant.Name, zoneNames[zi], zoneRewardUlt, zoneRewardHP)})
+			}
+		}
+	}
+}
+
+func (r *Room) hasZoneAudience() bool {
+	for _, pl := range r.Players {
+		if !pl.IsBot {
+			return true
+		}
+	}
+	return false
+}
+
+// 供测试：把一名玩家放到据点内。
+func zoneDistance(p Vec3, zi int) float64 {
+	return math.Hypot(p.X-zoneCenters[zi].X, p.Z-zoneCenters[zi].Z)
+}

--- a/server/zone_test.go
+++ b/server/zone_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func newZoneRoom(t *testing.T) *Room {
+	store, err := NewStore(t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 中央据点 B(0,160) 在本测试世界无墙体；A/C 同理（空世界无阻挡）。
+	r := NewRoom(1, &World{Size: [2]float64{512, 512}}, store)
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{X: zoneCenters[0].X, Y: 0, Z: zoneCenters[0].Z}
+	human.OnGround = true
+	r.Players = append(r.Players, human)
+	return r
+}
+
+func TestZoneControlAccruesAndRewards(t *testing.T) {
+	r := newZoneRoom(t)
+	human := &r.Players[0].PlayerState
+	human.HP = 50
+	r.pending = nil
+
+	// 占领播报：第一 tick 即宣布首占。
+	r.stepZones()
+	firstCap := false
+	for _, e := range r.pending {
+		if e.Type == EvChat && strings.Contains(e.Message, "A 点已被") {
+			firstCap = true
+		}
+	}
+	if !firstCap {
+		t.Fatal("首占应有播报")
+	}
+
+	// 巩固 10 秒：奖励 + 巩固播报。
+	r.pending = nil
+	for range zoneHoldTicks {
+		r.stepZones()
+	}
+	rewarded := false
+	for _, e := range r.pending {
+		if e.Type == EvChat && strings.Contains(e.Message, "巩固了 A 点") {
+			rewarded = true
+		}
+	}
+	if !rewarded {
+		t.Fatal("巩固满 10 秒应有奖励播报")
+	}
+	if human.UltimatePoints != zoneRewardUlt {
+		t.Fatalf("大招点 = %d, 期望 %d", human.UltimatePoints, zoneRewardUlt)
+	}
+	if human.HP != 50+zoneRewardHP {
+		t.Fatalf("奖励回血 = %d, 期望 %d", human.HP, 50+zoneRewardHP)
+	}
+}
+
+func TestZoneContestFreezesProgress(t *testing.T) {
+	r := newZoneRoom(t)
+	// 第二名玩家进点：争夺冻结。
+	b := newTestHuman(11, r)
+	b.Pos = Vec3{X: zoneCenters[0].X + 1, Y: 0, Z: zoneCenters[0].Z}
+	b.OnGround = true
+	r.Players = append(r.Players, b)
+
+	for range zoneHoldTicks + 10 {
+		r.stepZones()
+	}
+	if r.zoneOwners[0] != 0 && r.zoneHoldTicks[0] != 0 {
+		// 争夺期间不应产生新的巩固进度
+	}
+	// 首占可能已在单人 tick 完成（b 加入前），但加人后进度必须冻结：
+	heldBefore := r.zoneHoldTicks[0]
+	for range 50 {
+		r.stepZones()
+	}
+	if r.zoneHoldTicks[0] != heldBefore {
+		t.Fatalf("争夺中进度应冻结: %d → %d", heldBefore, r.zoneHoldTicks[0])
+	}
+}
+
+func TestZoneDeadZoneSkipped(t *testing.T) {
+	// 中央被墙体占用的据点自动休眠（测试：中心放一个方块的世界）。
+	store, err := NewStore(t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := &World{Size: [2]float64{512, 512}, Spawns: [][3]float64{{0, 0, 0}}}
+	w.aabbs = append(w.aabbs, AABB{Min: Vec3{X: zoneCenters[1].X - 3, Y: 0, Z: zoneCenters[1].Z - 3}, Max: Vec3{X: zoneCenters[1].X + 3, Y: 8, Z: zoneCenters[1].Z + 3}})
+	r := NewRoom(1, w, store)
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{X: zoneCenters[1].X + 5, Y: 0, Z: zoneCenters[1].Z}
+	human.OnGround = true
+	r.Players = append(r.Players, human)
+
+	r.stepZones()
+	if r.zoneOwners[1] != 0 {
+		t.Fatal("被墙占用的据点应休眠（不可占领）")
+	}
+}


### PR DESCRIPTION
# 《据点战争》DLC 🏛️

超大型 DLC：**A/B/C 三据点占领积分赛**——地图上出现三座同位信标，单独一人站进据点开始「巩固」，10 秒一轮领取奖励，多人同处则进入争夺冻结。

## 规则

- **三据点**：A(-96,-96) 青 / B(0,160) 紫 / C(96,96) 金，半径 7m
- **巩固**：恰好一人站内时每 tick 累积进度，满 10 秒 → **+1 大招点 +25 HP** 并全房播报「🏛 X 巩固了 A 点」
- **首占播报**：换人占领时播报「A 点已被 X 占领，站稳 10 秒领取奖励！」
- **争夺冻结**：两人及以上同处 → 进度冻结（不倒退，鼓励拉人火并）
- **地图自适应**：中心被墙体占用的据点自动休眠（`CanOccupy` 判定），任何地图上都能跑
- **零协议改动**：奖励走 EvChat 播报 + 既有大招点/HP 结算

## 实现

- `server/zone.go`（新文件）：每 tick 3×N 扫描（开销可忽略），`zoneOwners[3]` / `zoneHoldTicks[3]` 状态
- `server/sim.go`：`Room.Step` 挂钩（锚点与 #36 血月的 `stepZombies` 相邻但独立成行，可干净合并）
- 客户端：`main.ts` 同位常量的三色信标（pole+cap），两张地图构建路径（welcome/practice）都接入，`MapData` 级去重

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/zone_test.go` 3 测试：首占播报 + 巩固奖励数值（大招点/回血）、争夺冻结断言、墙体死区休眠
- `npm run build` 通过

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34