### PR TITLE
feat: 《赏金猎人》DLC · 连杀悬赏 + 收割奖励（纯服务端经济）

### DIFF
--- a/server/bounty.go
+++ b/server/bounty.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// 《赏金猎人》DLC：连杀 5 人的玩家自动挂上悬赏，击杀者领取奖励。
+// 纯服务端经济系统：EvChat 播报 + 既有回血/大招点结算，零协议改动。
+
+const (
+	bountyStreak       = 5   // 连杀多少场挂悬赏
+	bountyAmount       = 100 // 悬赏金额（战报口径）
+	bountyRewardHP     = 50  // 领赏回血
+	bountyRewardUltPts = 2   // 领赏大招点
+)
+
+// bountySet：连杀达到阈值时给攻击者挂上悬赏（在 Damage 击杀流程中调用）。
+func (r *Room) bountySet(p *PlayerState) {
+	if p.Streak != bountyStreak {
+		return
+	}
+	if r.bountyOf == nil {
+		r.bountyOf = make(map[uint16]uint16)
+	}
+	if r.bountyOf[p.Id] > 0 {
+		return
+	}
+	r.bountyOf[p.Id] = bountyAmount
+	if r.hasBountyAudience() {
+		r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+			Message: fmt.Sprintf("💰 %s 连杀 %d 人，人头价值 %d 悬赏——拿他！", p.Name, p.Streak, bountyAmount)})
+	}
+}
+
+// bountyClaim：悬赏目标被击杀时结算奖励（在 Damage 击杀流程中调用）。
+// 奖励 = 回血 + 大招点（大招点仅真人；bot 也能领回血与播报 credit）。
+func (r *Room) bountyClaim(attacker, victim *PlayerState, now time.Time) {
+	amount := r.bountyOf[victim.Id]
+	if amount == 0 || attacker.Id == victim.Id {
+		return
+	}
+	delete(r.bountyOf, victim.Id)
+	attacker.HP = uint8(min(MaxHP, int(attacker.HP)+bountyRewardHP))
+	if !attacker.IsBot && attacker.Ultimate == 0 {
+		attacker.UltimatePoints = uint8(min(UltimateRequirement, int(attacker.UltimatePoints)+bountyRewardUltPts))
+	}
+	if r.hasBountyAudience() {
+		r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
+			Message: fmt.Sprintf("💰 %s 收割了 %s 的 %d 悬赏！奖励：+%d HP +2 大招点", attacker.Name, victim.Name, amount, bountyRewardHP)})
+	}
+}
+
+func (r *Room) hasBountyAudience() bool {
+	for _, pl := range r.Players {
+		if !pl.IsBot {
+			return true
+		}
+	}
+	return false
+}

--- a/server/bounty_test.go
+++ b/server/bounty_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newBountyRoom(t *testing.T) *Room {
+	store, err := NewStore(t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewRoom(1, &World{Size: [2]float64{96, 96}}, store)
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{0, 0, 0}
+	target := newTestHuman(11, r)
+	target.Pos = Vec3{4, 0, 0}
+	r.Players = append(r.Players, human, target)
+	return r
+}
+
+func killOnce(r *Room, attacker, victim *Player, now time.Time) {
+	victim.HP = 1
+	r.Damage(&attacker.PlayerState, &victim.PlayerState, 1, false, 3, now)
+	victim.Alive = true // 复活以继续下一轮
+	victim.HP = MaxHP
+}
+
+// 连杀 5 人挂悬赏：第 4 杀无、第 5 杀有（播报 + map 记录）。
+func TestBountySetAtStreakFive(t *testing.T) {
+	r := newBountyRoom(t)
+	human := &r.Players[0].PlayerState
+	now := time.Now()
+
+	for i := 1; i <= 5; i++ {
+		before := len(r.pending)
+		killOnce(r, r.Players[0], r.Players[1], now)
+		bounty := r.bountyOf[10]
+		announced := false
+		for _, e := range r.pending[before:] {
+			if e.Type == EvChat && strings.Contains(e.Message, "悬赏") {
+				announced = true
+			}
+		}
+		if i < 5 {
+			if bounty != 0 || announced {
+				t.Fatalf("第 %d 杀不应挂悬赏", i)
+			}
+		} else if bounty != bountyAmount || !announced {
+			t.Fatalf("第 5 杀应挂 100 悬赏并播报, bounty=%d announced=%v", bounty, announced)
+		}
+	}
+	if human.Streak != 5 {
+		t.Fatalf("连杀数 = %d, 期望 5", human.Streak)
+	}
+}
+
+// 领赏：击杀有悬赏者 → 回血 + 大招点 + 播报 + 悬赏清除；自雷不领。
+func TestBountyClaimRewards(t *testing.T) {
+	r := newBountyRoom(t)
+	now := time.Now()
+	human := &r.Players[0].PlayerState
+	target := &r.Players[1].PlayerState
+	human.HP = 40
+	r.bountyOf = map[uint16]uint16{11: bountyAmount}
+
+	before := len(r.pending)
+	r.Damage(human, target, MaxHP, false, 3, now) // 击杀有悬赏者
+	claimed := false
+	for _, e := range r.pending[before:] {
+		if e.Type == EvChat && strings.Contains(e.Message, "收割了") {
+			claimed = true
+		}
+	}
+	if !claimed {
+		t.Fatal("领赏应有播报")
+	}
+	if human.HP != 40+bountyRewardHP {
+		t.Fatalf("领赏回血 = %d, 期望 %d", human.HP, 40+bountyRewardHP)
+	}
+	// 3 = 击杀本身的 1 点 + 悬赏奖励 2 点。
+	if human.UltimatePoints != 1+bountyRewardUltPts {
+		t.Fatalf("领赏大招点 = %d, 期望 %d", human.UltimatePoints, 1+bountyRewardUltPts)
+	}
+	if r.bountyOf[11] != 0 {
+		t.Fatal("领赏后悬赏应清除")
+	}
+
+	// 自雷不领赏。
+	r.bountyOf[10] = bountyAmount
+	human.HP = 1
+	r.Damage(human, human, 999, false, WeaponHE, now)
+	if r.bountyOf[10] != bountyAmount {
+		t.Fatal("自雷不应触发领赏清除")
+	}
+}
+
+// 退出房间带走悬赏（防 map 泄漏与死人领赏）。
+func TestBountyCleanupOnRemove(t *testing.T) {
+	r := newBountyRoom(t)
+	p := r.Players[0]
+	r.bountyOf = map[uint16]uint16{10: bountyAmount}
+	r.Remove(p)
+	if _, ok := r.bountyOf[10]; ok {
+		t.Fatal("退出房间应清除悬赏记录")
+	}
+}

--- a/server/room.go
+++ b/server/room.go
@@ -16,6 +16,7 @@ type Room struct {
 	Grenades              []*Grenade
 	Pickups               []Pickup
 	Chickens              []Chicken
+	bountyOf              map[uint16]uint16
 	nextNadeId, nextIdSeq uint16
 	tick                  uint32
 	pending               []Event
@@ -43,6 +44,9 @@ func NewRoom(id int, w *World, s *Store) *Room {
 }
 
 func (r *Room) Remove(p *Player) {
+	if r.bountyOf != nil {
+		delete(r.bountyOf, p.PlayerState.Id) // 退出房间带走悬赏
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// Clear bond: if this player had a bond mate, break the bond

--- a/server/sim.go
+++ b/server/sim.go
@@ -689,7 +689,9 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 			attacker.Streak++
 		}
 		r.applyStreakReward(attacker, now)
+		r.bountySet(attacker)
 	}
+	r.bountyClaim(attacker, victim, now)
 	victim.Streak = 0
 	victim.UltimatePoints, victim.Ultimate = 0, 0
 	victim.BlackDreamUntil, victim.InvincibleUntilUlt, victim.GhostUntil = time.Time{}, time.Time{}, time.Time{}


### PR DESCRIPTION
# 《赏金猎人》DLC 💰

超大型 DLC 之社交经济篇：**连杀悬赏系统**——连杀 5 人的玩家自动挂上人头悬赏，全房广播通缉，收割者领取重赏。纯服务端经济系统，零协议改动。

## 玩法

- **挂赏**：连杀达到 5 场 → 人头价值 100 悬赏，全房播报「💰 X 连杀 5 人，人头价值 100 悬赏——拿他！」
- **领赏**：击杀有悬赏者 → **+50 HP +2 大招点**（叠加在击杀本身的 +1 大招点上）+ 收割播报「💰 Y 收割了 X 的 100 悬赏！」
- **生命周期**：悬赏随死亡清除（连杀断）；玩家退出房间时 `Remove` 一并清理（防 map 泄漏与幽灵领赏）
- **边界**：自雷不挂赏不领赏；bot 连杀同样挂赏（人人都是猎物），领赏大招点仅真人（与既有大招点规则一致），回血谁都能领

## 实现

- `server/bounty.go`（新文件）：`bountySet` / `bountyClaim` / 懒初始化的 `bountyOf map[uint16]uint16`
- `server/sim.go`：`Damage` 挂钩两处——set 在 `applyStreakReward` 之后（streak 已自增）、claim 在 `victim.Streak` 清零之前
- `server/room.go`：`bountyOf` map + `Remove` 退出清理
- 零协议改动：全部通过 EvChat 播报 + 既有结算字段

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/bounty_test.go` 3 测试：
  - 第 1-4 杀无悬赏、第 5 杀恰好挂赏 + 播报
  - 领赏：回血 +50、大招点 = 击杀 1 + 悬赏 2 = 3、悬赏清除、自雷不领
  - `Remove` 退出清理

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34