### PR TITLE
feat: 《虫洞》DLC · 纠缠传送门（双端同构选址，零协议改动）

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -988,6 +988,7 @@ function enterPractice() {
     world.clouds.visible = hud.quality !== 'low';
     hud.setMap(map);
   }
+  disposeWormholes(); // 练习模式没有服务端模拟，虫洞只是摆设，直接不显示
   const map = bundledMap as MapData;
   let spawn: [number, number, number] = map.spawns?.[0] ?? [0, 0, 0];
   if (world && map.spawns) {
@@ -1136,6 +1137,7 @@ hud.onExit = () => {
   if (document.fullscreenElement) void document.exitFullscreen();
   net.disconnect();
   hud.exitMatch();
+  disposeWormholes();
   for (const id of [...remotes.ids()]) remotes.remove(id);
   removeDummies();
   particles.clearBulletHoles();
@@ -1169,6 +1171,7 @@ net.onWelcome = (id, _revision) => {
     hud.setMap(map);
     for (const [pickupId, pickup] of pickupStates) world.setPickup(pickupId, pickup.kind, ...pickup.origin);
   }
+  buildWormholes();
   names.set(id, myName);
 };
 
@@ -1599,12 +1602,137 @@ remotes.onShot = (s, position, burstShots) => {
 
 remotes.onStep = (position) => playSpatial('step', position.x, position.z, 0.16, 26, 0.92);
 
+// ---------- 《虫洞》DLC：纠缠传送门（选址与 server/wormhole.go 逐位同构） ----------
+const WORMHOLE_VISUAL = {
+  ringRadius: 1.7,
+  swirlRadius: 1.56,
+  centerY: 1.75,
+  colors: [0x4dd8ff, 0xff5fd0],
+  swirlColors: ['#8feaff', '#ffa6ec'],
+};
+
+let wormholeGroup: THREE.Group | null = null;
+const wormholeSwirls: THREE.Mesh[] = [];
+
+// wormholeAnchors 与服务端 wormholePair 同一算法：出生点里挑相距最远、
+// 都能站满人（canOccupy）的一对。遍历顺序只依赖地图 JSON 的出生点数组，
+// 双端读同一份 map.json，选址结果天然一致，无需协议同步。
+function wormholeAnchors(map: MapData): [THREE.Vector3, THREE.Vector3] | null {
+  const spawns = map.spawns ?? [];
+  if (!world || spawns.length < 2) return null;
+  let best = -1;
+  let a: THREE.Vector3 | null = null;
+  let b: THREE.Vector3 | null = null;
+  for (let i = 0; i < spawns.length; i++) {
+    const pi = new THREE.Vector3(spawns[i][0], spawns[i][1], spawns[i][2]);
+    if (!canOccupy(world.boxes, pi, PHYS.standingHeight)) continue;
+    for (let j = i + 1; j < spawns.length; j++) {
+      const pj = new THREE.Vector3(spawns[j][0], spawns[j][1], spawns[j][2]);
+      const dx = pi.x - pj.x;
+      const dz = pi.z - pj.z;
+      const d = dx * dx + dz * dz;
+      if (d > best && canOccupy(world.boxes, pj, PHYS.standingHeight)) {
+        best = d;
+        a = pi.clone();
+        b = pj.clone();
+      }
+    }
+  }
+  return best > 0 && a && b ? [a, b] : null;
+}
+
+function wormholeSwirlTexture(color: string): THREE.CanvasTexture {
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = 256;
+  const g = canvas.getContext('2d')!;
+  g.translate(128, 128);
+  g.lineCap = 'round';
+  for (let arm = 0; arm < 3; arm++) {
+    g.beginPath();
+    for (let t = 0; t <= 1.0001; t += 0.02) {
+      const ang = arm * (Math.PI * 2 / 3) + t * Math.PI * 3;
+      const r = 10 + t * 112;
+      const x = Math.cos(ang) * r;
+      const y = Math.sin(ang) * r;
+      if (t === 0) g.moveTo(x, y);
+      else g.lineTo(x, y);
+    }
+    g.strokeStyle = color;
+    g.globalAlpha = 0.5;
+    g.lineWidth = 11;
+    g.stroke();
+  }
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+function disposeWormholes() {
+  if (!wormholeGroup) return;
+  scene.remove(wormholeGroup);
+  wormholeGroup.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    mesh.geometry.dispose();
+    const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    for (const mat of mats) {
+      if (mat instanceof THREE.MeshBasicMaterial) mat.map?.dispose();
+      mat.dispose();
+    }
+  });
+  wormholeGroup = null;
+  wormholeSwirls.length = 0;
+}
+
+// buildWormholes 在真实对局里构建两扇纠缠门：竖立光环 + 旋转星涡 +
+// 贴地定位环，环面法线指向对门（即穿行方向）。练习模式/离开对局时整体拆除。
+function buildWormholes() {
+  disposeWormholes();
+  if (!world) return;
+  const anchors = wormholeAnchors(bundledMap as MapData);
+  if (!anchors) return;
+  wormholeGroup = new THREE.Group();
+  for (let k = 0; k < 2; k++) {
+    const pos = anchors[k];
+    const other = anchors[1 - k];
+    const portal = new THREE.Group();
+    portal.position.set(pos.x, pos.y + WORMHOLE_VISUAL.centerY, pos.z);
+    portal.lookAt(other.x, pos.y + WORMHOLE_VISUAL.centerY, other.z);
+    const ring = new THREE.Mesh(
+      new THREE.TorusGeometry(WORMHOLE_VISUAL.ringRadius, 0.14, 12, 48),
+      new THREE.MeshBasicMaterial({ color: WORMHOLE_VISUAL.colors[k] }),
+    );
+    const swirl = new THREE.Mesh(
+      new THREE.CircleGeometry(WORMHOLE_VISUAL.swirlRadius, 40),
+      new THREE.MeshBasicMaterial({ map: wormholeSwirlTexture(WORMHOLE_VISUAL.swirlColors[k]), transparent: true, side: THREE.DoubleSide, depthWrite: false, opacity: 0.85 }),
+    );
+    const base = new THREE.Mesh(
+      new THREE.TorusGeometry(2.05, 0.05, 8, 48),
+      new THREE.MeshBasicMaterial({ color: WORMHOLE_VISUAL.colors[k], transparent: true, opacity: 0.45 }),
+    );
+    base.rotation.x = Math.PI / 2;
+    base.position.y = -WORMHOLE_VISUAL.centerY + 0.03;
+    portal.add(ring, swirl, base);
+    wormholeGroup.add(portal);
+    wormholeSwirls.push(swirl);
+  }
+  scene.add(wormholeGroup);
+}
+
+function updateWormholes(dt: number) {
+  if (!wormholeGroup) return;
+  for (let i = 0; i < wormholeSwirls.length; i++) {
+    wormholeSwirls[i].rotation.z += (i === 0 ? 1 : -1) * dt * 1.7;
+  }
+}
+
 let prev = performance.now(), lastLabels = 0;
 function frame(t: number) {
   requestAnimationFrame(frame);
   const dt = Math.min(0.05, (t - prev) / 1000);
   prev = t;
   if (document.hidden) return;
+  updateWormholes(dt);
 
   if (joined && alive) {
     local.speedMultiplier = (t < speedBoostUntil ? SPEED_BOOST_MULTIPLIER : 1) * (ultimateKind === 3 && t < ultimateUntil ? 1.45 : 1);

--- a/server/room.go
+++ b/server/room.go
@@ -7,23 +7,26 @@ import (
 )
 
 type Room struct {
-	Id                    int
-	World                 *World
-	Store                 *Store
-	mu                    sync.Mutex
-	running, closed       bool
-	Players               []*Player
-	Grenades              []*Grenade
-	Pickups               []Pickup
-	Chickens              []Chicken
-	nextNadeId, nextIdSeq uint16
-	tick                  uint32
-	pending               []Event
-	botAIs                map[uint16]*BotAI
-	history               map[uint16]*poseHistory
-	teamAttempts          map[uint16]*teamAttempt
-	outboundBuf           []outbound
-	quantizedBuf          []quantState
+	Id                            int
+	World                         *World
+	Store                         *Store
+	mu                            sync.Mutex
+	running, closed               bool
+	Players                       []*Player
+	Grenades                      []*Grenade
+	Pickups                       []Pickup
+	Chickens                      []Chicken
+	Wormholes                     [2]Vec3
+	wormholeOK, wormholeAnnounced bool
+	wormholeCooldowns             map[uint16]time.Time
+	nextNadeId, nextIdSeq         uint16
+	tick                          uint32
+	pending                       []Event
+	botAIs                        map[uint16]*BotAI
+	history                       map[uint16]*poseHistory
+	teamAttempts                  map[uint16]*teamAttempt
+	outboundBuf                   []outbound
+	quantizedBuf                  []quantState
 }
 
 // teamAttempt tracks the consecutive crouch taps of one human for illegal teaming.
@@ -39,6 +42,7 @@ func NewRoom(id int, w *World, s *Store) *Room {
 	r := &Room{Id: id, World: w, Store: s, nextIdSeq: 1, botAIs: make(map[uint16]*BotAI), history: make(map[uint16]*poseHistory), teamAttempts: make(map[uint16]*teamAttempt)}
 	r.initPickups()
 	r.initChickens()
+	r.initWormholes()
 	return r
 }
 
@@ -61,6 +65,7 @@ func (r *Room) Remove(p *Player) {
 	}
 	delete(r.botAIs, p.Id)
 	delete(r.history, p.Id)
+	delete(r.wormholeCooldowns, p.Id)
 	for _, other := range r.Players {
 		delete(other.netCache, p.Id)
 		delete(other.netFullAt, p.Id)
@@ -71,6 +76,7 @@ func (r *Room) Remove(p *Player) {
 		r.history = make(map[uint16]*poseHistory)
 		r.Grenades, r.Pickups, r.pending = nil, nil, nil
 		r.Chickens = nil
+		r.wormholeCooldowns = nil
 		return
 	}
 	r.Emit(Event{Type: EvPlayerLeave, Player: p.Id})

--- a/server/sim.go
+++ b/server/sim.go
@@ -285,6 +285,7 @@ func (r *Room) Step(now time.Time) {
 	}
 	r.StepPickups(now)
 	r.StepChickens(now)
+	r.StepWormholes(now)
 	r.recordHistory()
 }
 

--- a/server/wormhole.go
+++ b/server/wormhole.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"math"
+	"time"
+)
+
+// 《虫洞》DLC：纠缠传送门玩法。
+// 战场两端各出现一扇光环虫洞，走进任何一扇，瞬间从另一扇穿出。
+// 零协议改动：传送本身只改服务端私有坐标（快照自然携带），
+// 特效复用 EvExplosion 爆炸粒子，播报复用 EvChat。
+
+const (
+	wormholeRadius   = 1.5             // 触发半径（水平距离）
+	wormholeHeight   = 2.0             // 触发纵向窗口（允许跳跃穿越）
+	wormholeExitDist = 2.6             // 出口沿穿行方向距门体的落点（保证落在触发圈外，防原地打转）
+	wormholeCooldown = 3 * time.Second // 每人冷却，防止两门间乒乓
+)
+
+// wormholePair 从出生点里挑相距最远、且能完整站立的两处作为纠缠门锚点。
+// 纯几何 + 严格大于，遍历顺序只依赖地图 JSON 的出生点数组——
+// 客户端 main.ts 的 wormholeAnchors 按同一算法逐位复刻，两侧选址天然一致。
+func wormholePair(w *World) (a, b Vec3, ok bool) {
+	best := -1.0
+	for i := range w.Spawns {
+		si := w.Spawns[i]
+		pi := Vec3{si[0], si[1], si[2]}
+		if !w.CanOccupy(pi, StandingHeight) {
+			continue
+		}
+		for j := i + 1; j < len(w.Spawns); j++ {
+			sj := w.Spawns[j]
+			pj := Vec3{sj[0], sj[1], sj[2]}
+			dx, dz := pi.X-pj.X, pi.Z-pj.Z
+			if d := dx*dx + dz*dz; d > best && w.CanOccupy(pj, StandingHeight) {
+				best = d
+				a, b = pi, pj
+			}
+		}
+	}
+	return a, b, best > 0
+}
+
+func (r *Room) initWormholes() {
+	a, b, ok := wormholePair(r.World)
+	if !ok {
+		return
+	}
+	r.Wormholes = [2]Vec3{a, b}
+	r.wormholeOK = true
+	r.wormholeCooldowns = make(map[uint16]time.Time)
+}
+
+// StepWormholes 每 tick 扫描存活玩家：站进任一扇门且冷却已过、
+// 且不在出生保护期（出生点常与门体重合，保护期就是天然的下车通道）即传送。
+// 首名玩家到场后全房播报一次玩法。
+func (r *Room) StepWormholes(now time.Time) {
+	if !r.wormholeOK {
+		return
+	}
+	if !r.wormholeAnnounced {
+		if len(r.Players) == 0 {
+			return
+		}
+		r.wormholeAnnounced = true
+		r.Emit(Event{Type: EvChat, Name: "🌀 时空乱流", Message: "一对纠缠虫洞已在战场两端张开——走进光环，瞬间从世界的另一头穿出！"})
+	}
+	for _, pl := range r.Players {
+		p := &pl.PlayerState
+		if !p.Alive || now.Before(p.InvincibleUntil) {
+			continue
+		}
+		if until, ok := r.wormholeCooldowns[p.Id]; ok && now.Before(until) {
+			continue
+		}
+		enter := -1
+		for k, wh := range r.Wormholes {
+			dx, dz := p.Pos.X-wh.X, p.Pos.Z-wh.Z
+			if dx*dx+dz*dz <= wormholeRadius*wormholeRadius && math.Abs(p.Pos.Y-wh.Y) <= wormholeHeight {
+				enter = k
+				break
+			}
+		}
+		if enter < 0 {
+			continue
+		}
+		exit := r.wormholeExit(enter)
+		r.Emit(Event{Type: EvExplosion, Origin: p.Pos})
+		p.Pos = exit
+		r.Emit(Event{Type: EvExplosion, Origin: exit})
+		r.wormholeCooldowns[p.Id] = now.Add(wormholeCooldown)
+	}
+}
+
+// wormholeExit 计算从 enter 号门穿出后的落点：沿两门连线方向穿出门体
+// wormholeExitDist 米（虫洞的隧道语义：从哪边进，就顺着穿出去）；
+// 落点被墙挡住则退回对门锚点，最后收敛在世界边界内。
+func (r *Room) wormholeExit(enter int) Vec3 {
+	enterPos, exitPos := r.Wormholes[enter], r.Wormholes[1-enter]
+	dx, dz := exitPos.X-enterPos.X, exitPos.Z-enterPos.Z
+	dist := math.Hypot(dx, dz)
+	out := exitPos
+	if dist > 0.001 {
+		out.X += dx / dist * wormholeExitDist
+		out.Z += dz / dist * wormholeExitDist
+	}
+	if !r.World.CanOccupy(out, StandingHeight) {
+		out = exitPos
+	}
+	halfX, halfZ := r.World.Size[0]/2-PlayerHalf, r.World.Size[1]/2-PlayerHalf
+	out.X = math.Max(-halfX, math.Min(halfX, out.X))
+	out.Z = math.Max(-halfZ, math.Min(halfZ, out.Z))
+	out.Y = exitPos.Y
+	return out
+}

--- a/server/wormhole_test.go
+++ b/server/wormhole_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// newWormholeTestRoom 构造带地板的空旷世界：地板只是让 Step 里的 Move
+// 有落点可站（空地图会让玩家无限下坠），出生点判定不受影响
+// （玩家盒 y∈[feet, feet+2.1] 与地板 y∈[-1,0] 不相交）。
+func newWormholeTestRoom(spawns [][3]float64) *Room {
+	w := &World{Size: [2]float64{128, 128}, Spawns: spawns}
+	w.aabbs = append(w.aabbs, AABB{Min: Vec3{-64, -1, -64}, Max: Vec3{64, 0, 64}})
+	return NewRoom(1, w, nil)
+}
+
+func wormholeEvents(r *Room, evType uint8) []Event {
+	var out []Event
+	for _, e := range r.pending {
+		if e.Type == evType {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func vecClose(a, b Vec3, tol float64) bool {
+	dx, dy, dz := a.X-b.X, a.Y-b.Y, a.Z-b.Z
+	return dx*dx+dy*dy+dz*dz <= tol*tol
+}
+
+func TestWormholePairPicksFarthestWalkableSpawns(t *testing.T) {
+	w := &World{Size: [2]float64{128, 128}, Spawns: [][3]float64{
+		{0, 0, 0}, {50, 0, 0}, {0, 0, 50}, {-50, 0, -50},
+	}}
+	a, b, ok := wormholePair(w)
+	if !ok {
+		t.Fatalf("应当选出一对有效锚点")
+	}
+	// 最大间距对：{50,0,0}↔{-50,0,-50}（d=12500，唯一最大值）
+	if a.X != 50 || a.Z != 0 || b.X != -50 || b.Z != -50 {
+		t.Fatalf("应选中相距最远的一对，got a=%v b=%v", a, b)
+	}
+	a2, b2, ok2 := wormholePair(w)
+	if !ok2 || a2 != a || b2 != b {
+		t.Fatalf("选址必须逐位确定，got a=%v b=%v vs a2=%v b2=%v", a, b, a2, b2)
+	}
+
+	// 被墙体堵死的出生点不参与选址
+	w.aabbs = append(w.aabbs, AABB{Min: Vec3{-50.4, 0, -50.4}, Max: Vec3{-49.6, 2.2, -49.6}})
+	a3, b3, ok3 := wormholePair(w)
+	if !ok3 || a3 != (Vec3{50, 0, 0}) || b3 != (Vec3{0, 0, 50}) {
+		t.Fatalf("堵死 {-50,-50} 后应改选 {50,0}↔{0,50} 对，got a=%v b=%v", a3, b3)
+	}
+}
+
+func TestWormholeDisabledWithoutDistinctSpawns(t *testing.T) {
+	// 两个出生点水平重合 → 无有效间距对，功能静默关闭
+	r := newWormholeTestRoom([][3]float64{{10, 0, 10}, {10, 0, 10}})
+	if r.wormholeOK {
+		t.Fatalf("重合出生点不应启用虫洞")
+	}
+	// 空世界不 panic
+	r2 := NewRoom(2, &World{Size: [2]float64{64, 64}}, nil)
+	if r2.wormholeOK {
+		t.Fatalf("无出生点不应启用虫洞")
+	}
+}
+
+func TestWormholeTeleportCooldownAndAnnounce(t *testing.T) {
+	r := newWormholeTestRoom([][3]float64{{0, 0, 0}, {50, 0, 0}})
+	if !r.wormholeOK {
+		t.Fatalf("虫洞应当启用")
+	}
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{0.5, 0, 0.3} // A 门圈内
+	r.Players = append(r.Players, human)
+	r.pending = nil // 丢弃 NewRoom 的小鸡出生事件，只看本测试产生的事件
+
+	base := time.Now()
+	r.Step(base)
+
+	// 全房播报恰好一次
+	if chats := wormholeEvents(r, EvChat); len(chats) != 1 {
+		t.Fatalf("首名玩家到场应播报一次玩法，got %d", len(chats))
+	}
+
+	// 传送到 B 门出口：沿 A→B 方向穿出门体 2.6m
+	p := &human.PlayerState
+	if p.Pos.X < 52.59 || p.Pos.X > 52.61 || p.Pos.Z != 0 || p.Pos.Y != 0 {
+		t.Fatalf("应传送到 B 门出口 (52.6,0,0)，got %v", p.Pos)
+	}
+	blasts := wormholeEvents(r, EvExplosion)
+	if len(blasts) != 2 || !vecClose(blasts[0].Origin, Vec3{0.5, 0, 0.3}, 0.01) || !vecClose(blasts[1].Origin, Vec3{52.6, 0, 0}, 0.001) {
+		t.Fatalf("应入口/出口各一发传送特效，got %v", blasts)
+	}
+
+	// 冷却期内站回 B 门圈不再触发
+	r.pending = nil
+	p.Pos = Vec3{52.5, 0, 0.2}
+	r.Step(base.Add(time.Second))
+	if p.Pos.X != 52.5 || p.Pos.Z != 0.2 {
+		t.Fatalf("冷却期内不应再次传送，got %v", p.Pos)
+	}
+
+	// 冷却过后从 B 门圈传回 A 门出口
+	r.pending = nil
+	p.Pos = Vec3{50.4, 0, 0.2}
+	r.Step(base.Add(4 * time.Second))
+	if p.Pos.X > -2.59 || p.Pos.X < -2.61 || p.Pos.Z != 0 {
+		t.Fatalf("冷却后应传回 A 门出口 (-2.6,0,0)，got %v", p.Pos)
+	}
+	// 全程播报仍只有一次
+	if chats := wormholeEvents(r, EvChat); len(chats) != 0 {
+		t.Fatalf("玩法播报只应发生一次")
+	}
+}
+
+func TestWormholeSkipsProtectedAndAirborne(t *testing.T) {
+	r := newWormholeTestRoom([][3]float64{{0, 0, 0}, {50, 0, 0}})
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{0.2, 0, 0.2}
+	r.Players = append(r.Players, human)
+	r.pending = nil
+	base := time.Now()
+
+	// 出生保护期内不传送（出生点常与门体重合，保护期就是下车通道）
+	human.InvincibleUntil = base.Add(2 * time.Second)
+	r.Step(base)
+	if p := &human.PlayerState; p.Pos.X != 0.2 || p.Pos.Z != 0.2 {
+		t.Fatalf("出生保护期内不应传送，got %v", p.Pos)
+	}
+
+	// 纵向窗口外（高处掠过）不传送
+	human.InvincibleUntil = time.Time{}
+	human.Pos = Vec3{0.2, 5, 0.2}
+	human.OnGround = false
+	r.Step(base)
+	if p := &human.PlayerState; p.Pos.X != 0.2 || p.Pos.Z != 0.2 || p.Pos.Y <= wormholeHeight {
+		t.Fatalf("纵向窗口外不应传送，got %v", p.Pos)
+	}
+	if len(wormholeEvents(r, EvExplosion)) != 0 {
+		t.Fatalf("未触发传送不应有特效事件")
+	}
+}
+
+func TestWormholeExitFallsBackWhenBlocked(t *testing.T) {
+	r := newWormholeTestRoom([][3]float64{{0, 0, 0}, {50, 0, 0}})
+	// 堵死 B 门出口落点 (52.6,0,0)
+	r.World.aabbs = append(r.World.aabbs, AABB{Min: Vec3{52.2, 0, -0.6}, Max: Vec3{53.2, 2.2, 0.6}})
+	human := newTestHuman(10, r)
+	human.Pos = Vec3{0.3, 0, 0.2}
+	r.Players = append(r.Players, human)
+	r.pending = nil
+
+	r.Step(time.Now())
+	if p := &human.PlayerState; p.Pos != (Vec3{50, 0, 0}) {
+		t.Fatalf("出口被堵应退回 B 门锚点 (50,0,0)，got %v", p.Pos)
+	}
+}
+
+// TestWormholeRealMapPair 用仓库真实地图做交叉校验：选址必须成功、
+// 两门必须拉开足够距离、锚点必须可站立。客户端 main.ts 的 wormholeAnchors
+// 与本算法逐位同构，双方只依赖同一份 map.json 的出生点数组。
+func TestWormholeRealMapPair(t *testing.T) {
+	w, err := LoadWorld("../map.json")
+	if err != nil {
+		t.Skipf("仓库地图不可用，跳过：%v", err)
+	}
+	a, b, ok := wormholePair(w)
+	if !ok {
+		t.Fatalf("真实地图应能选出一对虫洞锚点")
+	}
+	dx, dz := a.X-b.X, a.Z-b.Z
+	if d := math.Hypot(dx, dz); d < 60 {
+		t.Fatalf("两门间距 %.1fm，应至少 60m 才有传送的戏剧性", d)
+	}
+	for _, p := range []Vec3{a, b} {
+		if !w.CanOccupy(p, StandingHeight) {
+			t.Fatalf("锚点 %v 必须可站立", p)
+		}
+	}
+	t.Logf("虫洞锚点：A(%.1f, %.1f, %.1f) ↔ B(%.1f, %.1f, %.1f)，间距 %.1fm",
+		a.X, a.Y, a.Z, b.X, b.Y, b.Z, math.Hypot(dx, dz))
+}


### PR DESCRIPTION
# 《虫洞》DLC 🌀

超大型 DLC 之空间传送篇：**纠缠传送门**——战场两端各张开一扇光环虫洞，走进任何一扇，瞬间从世界的另一头穿出。纯服务端传送 + 双端同构选址，零协议改动。

## 玩法

- **成对出现**：从地图出生点里选**相距最远且可站立**的两处作为纠缠门锚点（主地图实测：屋顶门 A ↔ 远角地面门 B，间距 **151.8m**）
- **穿越**：站进任一扇光环（水平 1.5m、纵向 2m 窗口，允许跳跃穿越）→ 瞬移到对门出口，入口/出口各一发爆炸粒子 + 音效作传送特效
- **隧道语义**：出口沿两门连线方向穿出门体 2.6m——从哪边进就顺着穿出去，且天然落在触发圈外防原地打转；出口被墙挡住则退回对门锚点
- **防滥用**：出生保护期内不传送（出生点常与门体重合，保护期就是天然的下车通道）；每人 3 秒冷却防两门间乒乓；玩家退出房间清理冷却状态
- **零协议改动**：传送只写服务端私有坐标（快照自然携带，客户端 reconcile 对 >2m 误差直接吸附）；播报复用 EvChat（首名玩家到场时全房播报一次玩法）

## 实现

- `server/wormhole.go`（新文件）：`wormholePair` O(n²) 一次初始化选锚点（严格大于保证确定性）、`StepWormholes` 每 tick 扫描、`wormholeExit` 落点计算
- `server/room.go`：`Wormholes` 字段 + `wormholeCooldowns`；`NewRoom` 调 `initWormholes`；`Remove` 清理冷却
- `server/sim.go`：`Room.Step` 增加 `StepWormholes` 独立一行（与 #36/#41 等钩子行错开，可干净合并）
- 客户端 `main.ts`：**`wormholeAnchors` 与服务端 `wormholePair` 逐位同构**——同一份 map.json、同一 canOccupy 语义（严格比较、同排除水体）、同一遍历顺序，选址天然一致，无需协议同步；青/洋红双色门体（环面法线指向对门即穿行方向）+ Canvas 螺旋星涡反向旋转 + 贴地定位环；真实对局构建、练习模式/离开对局拆除并逐一 dispose

## 验证

- `go vet` / `go test -count=1 ./...` 全部通过
- 新增 `server/wormhole_test.go` **6 测试**：最远可站立对选址 + 逐位确定性、堵死出生点重选、重合/缺失出生点静默关闭、传送 + 冷却 + 玩法播报恰一次、出生保护与纵向窗口外不触发、出口被堵回退锚点、**真实地图交叉校验**（选址成功、间距 ≥60m、锚点可站立）
- `npm run build` 通过
- v10 协议冒烟与 main 基线（f240c2c）逐项一致（`botBitSet` 失败为主分支既有问题，见 #37）

## 声明

代码由 AI（GLM，ZCode Agent）编写并测试，符合本仓库「禁止人类写代码提交 PR」的实验规则 🙂 GitHub ID: liyu34