### PR TITLE
feat: 《海克斯觉醒》DLC · 每条命 3 选 1 强化卡（协议 v11）

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ pixel-strike/
 - **羁绊可见**：缔结羁绊时明确播报「你已与谁羁绊」并在 HUD 常驻显示羁绊队友名牌；队友为你挡枪/报仇/心有灵犀时播报会说清是谁为谁；羁绊队友的世界标签为粉色 💕；队友退出会实时提示羁绊解除。
 - **Shift 冲刺**：地面移动中按住 Shift 提速 1.3 倍（蹲伏/飞行时无效，飞行中 Shift 仍是下降）；移动端新增「跑」按钮。
 - **AI 标识权威化**：服务端在快照状态字节（bit128）下发 bot 标识，头顶标签、击杀播报、记分板与聊天的「真人/AI」徽章全部以此为准，bot 与战场小鸡不再因名字未同步而被误标为「真人」。
+- **海克斯强化**：进房与每次阵亡时弹出 3 张强化卡 3 选 1（数字键或点选），效果仅本条命生效、死亡即失效、复活重新选择。当前卡池：疾行者（移速 +15%）、强袭（伤害 +15%）、狂热（射速 +25%）、稳定（散布 -30%）、铁壁（受伤 -20%）、利爪（造成伤害 15% 回血）、血牛（血量上限 100→140）、弹药扩容（备弹翻倍）、快手（换弹 -30%）；bot 不参与。
 
 ## 操作
 
@@ -69,6 +70,7 @@ pixel-strike/
 | `R` / `G` | 换弹 / HE |
 | `T` / `Enter` | 聊天（手机用顶栏 💬 按钮） |
 | `H` | 快捷喊话（手机用顶栏 ⚡ 按钮，数字键/点按发送） |
+| 海克斯面板开启时 `1` / `2` / `3` | 选择强化卡（点选卡片亦可；死亡倒计时期间同样可选） |
 | `Tab` / `Esc` | 战绩 / 设置 |
 | `Esc` → 中国人能飞 | 开关飞行模式，开启时全场广播「玩家名 能飞」 |
 | 飞行中 `Space` / `Shift` | 上升 / 下降（贴地后 `Shift` 不再下降） |
@@ -179,8 +181,9 @@ Compose 已限制服务端 512 MB、静态前端 128 MB，总上限 640 MB。
 
 所有多字节字段均为 Little-Endian。
 
-- 客户端：Join `01`、Input `02`、Fire `03`、Reload `04`、Grenade `06`、Switch `08`、Loadout `09`、RosterRequest `0A`、ToggleFlight `0B`、Ping `F0`。Join 与 Loadout 均携带主、副武器皮肤选择，服务端按解锁进度校验。
+- 客户端：Join `01`、Input `02`、Fire `03`、Reload `04`、Grenade `06`、Switch `08`、Loadout `09`、RosterRequest `0A`、ToggleFlight `0B`、Ultimate `0C`、Chat `0D`、HexPick `0E`（选择海克斯卡）、Ping `F0`。Join 与 Loadout 均携带主、副武器皮肤选择，服务端按解锁进度校验。
 - 服务端：Welcome `81`、Snapshot `82`、Events `83`、Pong `84`、Self `86`、Roster `87`、Reject `88`。
+- 事件：HexOffer（个人，仅发本人：3 张卡 id）/ HexPick（广播：卡 id + 名字）。
 - Snapshot：`tick(u32) + inputAck(u16) + count(u8)`，玩家记录由 `id(u16) + fieldMask(u16)` 开始；`0x8000` 表示完整关键帧，状态包含角色皮肤和当前枪械皮肤。状态字节 bit128 = AI bot（客户端「真人/AI」徽章的权威来源）。
 
-主要实现位置：`server/netstate.go`（带宽）、`server/sim.go`（权威玩法）、`server/room.go`（60 Hz 房间）、`client/src/net.ts`（协议）、`client/src/player.ts`（预测与实例化角色）、`tools/bots.mjs`（压测）。
+主要实现位置：`server/netstate.go`（带宽）、`server/sim.go`（权威玩法）、`server/room.go`（60 Hz 房间）、`server/hex.go`（海克斯强化卡）、`client/src/net.ts`（协议）、`client/src/player.ts`（预测与实例化角色）、`tools/bots.mjs`（压测）。

--- a/client/index.html
+++ b/client/index.html
@@ -889,6 +889,59 @@
       white-space: nowrap;
     }
 
+    /* 海克斯强化卡选择器 */
+    #hex-selector {
+      position: absolute;
+      left: 50%;
+      bottom: 160px;
+      z-index: 46;
+      display: none;
+      flex-direction: column;
+      gap: 6px;
+      transform: translateX(-50%);
+      border: 1px solid #8b5cf6;
+      background: linear-gradient(135deg, rgb(28 24 40 / .97), rgb(13 11 20 / .98));
+      padding: 10px 14px;
+      box-shadow: 0 0 36px rgb(139 92 246 / .45);
+      animation: selector-in .15s ease-out;
+    }
+    #hex-selector .selector-label { color: #c4b5fd; }
+    .hex-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 2px;
+      min-width: 96px;
+      padding: 8px 6px;
+      border: 1px solid var(--line);
+      background: var(--panel);
+      cursor: pointer;
+      transition: border-color .12s ease, background-color .12s ease;
+      font-family: inherit;
+    }
+    .hex-card:hover { border-color: #a78bfa; background: var(--panel-2); }
+    .hex-card kbd {
+      width: 28px;
+      height: 28px;
+      display: grid;
+      place-items: center;
+      border: 1px solid var(--line-strong);
+      background: var(--ink);
+      color: #c4b5fd;
+      font: 700 14px var(--font-mono);
+    }
+    .hex-card strong {
+      color: var(--paper);
+      font: 700 11px var(--font-ui);
+      white-space: nowrap;
+    }
+    .hex-card span {
+      color: var(--muted);
+      font: 9px var(--font-mono);
+      white-space: nowrap;
+    }
+    #hex-row #hex-name { color: #c4b5fd; }
+
     /* 黑梦全屏遮罩 */
     #black-dream {
       position: fixed;
@@ -2194,6 +2247,10 @@
         <div class="ult-option" data-kind="3"><kbd>V</kbd><strong>幽灵</strong><span>隐身提速 10s</span></div>
       </div>
     </div>
+    <div id="hex-selector" role="dialog" aria-label="选择海克斯强化">
+      <div class="selector-label">海克斯强化 · 数字键 1-3 选卡（本条命生效）</div>
+      <div class="selector-options" id="hex-cards"></div>
+    </div>
     <div id="black-dream" aria-hidden="true"></div>
     <div id="invincible-vignette" aria-hidden="true"></div>
     <div id="ghost-vignette" aria-hidden="true"></div>
@@ -2257,6 +2314,9 @@
       <div class="vital-row">
         <div class="vital-meta"><span><span style="color:#94a3b8;">🛡️</span> ARMOR</span><strong id="armor">100</strong></div>
         <div class="vital-bar-track"><div id="armor-bar-fill" class="vital-bar-fill armor-fill"></div></div>
+      </div>
+      <div class="vital-row" id="hex-row" style="display:none;">
+        <div class="vital-meta"><span><span style="color:#a78bfa;">🃏</span> HEX</span><strong id="hex-name">-</strong></div>
       </div>
     </div>
 

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 10;
+export const PROTOCOL_VERSION = 11;
 
 export const OP = {
   Join: 0x01,
@@ -12,6 +12,7 @@ export const OP = {
   ToggleFlight: 0x0b,
   Ultimate: 0x0c,
   Chat: 0x0d,
+  Hex: 0x0e,
   Welcome: 0x81,
   Snapshot: 0x82,
   Events: 0x83,
@@ -127,6 +128,32 @@ export const ULTIMATES = [
   { id: 6, key: 'N', name: '狂暴', durationMs: 10000, description: '射速 ×2、移速 +30% 共 10 秒' },
 ] as const;
 export const scopeSettleMs = (id: number) => id === 5 ? 320 : id === 11 ? 240 : 0;
+
+// 海克斯强化卡：每条命死亡后 3 选 1（id 与 server/hex.go 的 HexCards 对齐）。
+// 速度/散布/射速系数由本地镜像保证预测与服务端一致。
+export const HEX_CARDS = [
+  { id: 1, name: '疾行者', description: '移速 +15%' },
+  { id: 2, name: '强袭', description: '伤害 +15%' },
+  { id: 3, name: '狂热', description: '射速 +25%' },
+  { id: 4, name: '稳定', description: '散布 -30%' },
+  { id: 5, name: '铁壁', description: '受到伤害 -20%' },
+  { id: 6, name: '利爪', description: '造成伤害 15% 回复生命' },
+  { id: 7, name: '血牛', description: '血量上限 100→140，选卡立即 +40' },
+  { id: 8, name: '弹药扩容', description: '两把武器备弹翻倍' },
+  { id: 9, name: '快手', description: '换弹耗时 -30%' },
+] as const;
+export const hexCard = (id: number) => HEX_CARDS.find((c) => c.id === id);
+export const HEX_SPEED_MULT = 1.15;
+export const HEX_SPREAD_MULT = 0.70;
+export const HEX_FIRE_RATE_DIV = 1.25;
+export const HEX_RELOAD_MULT = 0.70;
+export const HEX_BLOOD_OX_MAX_HP = 140;
+// 卡牌 id（与 server/hex.go 对齐）：客户端预测需要镜像的几张
+export const HEX_SPRINT = 1;
+export const HEX_FRENZY = 3;
+export const HEX_STEADY = 4;
+export const HEX_BLOOD_OX = 7;
+export const HEX_QUICKEN = 9;
 
 // 快捷喊话预设：H 键 / 顶栏 ⚡ 打开，数字键或点按直接以聊天通道发送
 export const QUICK_CHAT_PHRASES = [

--- a/client/src/hud.ts
+++ b/client/src/hud.ts
@@ -1,4 +1,4 @@
-import { QUICK_CHAT_PHRASES, ULTIMATE_REQUIREMENT, ULTIMATES, WEAPONS, type MapData, type PlayerSnap, type RosterEntry } from './constants.js';
+import { hexCard, QUICK_CHAT_PHRASES, ULTIMATE_REQUIREMENT, ULTIMATES, WEAPONS, type MapData, type PlayerSnap, type RosterEntry } from './constants.js';
 import { CharacterPreview } from './preview.js';
 
 function el(id: string): HTMLElement {
@@ -94,7 +94,12 @@ export class Hud {
   onTouchLayoutEdit: (() => void) | null = null;
   onChatSubmit: ((text: string) => void) | null = null;
   onQuickChat: ((text: string) => void) | null = null;
+  onHexPick: ((card: number) => void) | null = null;
   quickChatOpen = false;
+  hexSelectorOpen = false;
+  // 当前展示的 3 张海克斯卡（供数字键 1-3 选中）
+  hexOffer: number[] = [];
+  private hexMaxHp = 100;
   private menu = el('menu');
   private scoreboard = el('scoreboard');
   private settings = el('settings-modal');
@@ -346,6 +351,54 @@ export class Hud {
     if (!selector) return;
     this.ultimateSelectorOpen = force ?? !this.ultimateSelectorOpen;
     selector.style.display = this.ultimateSelectorOpen ? 'flex' : 'none';
+  }
+
+  // ============ 海克斯强化卡 ============
+  showHexCards(cards: number[]) {
+    const wrap = el('hex-cards');
+    const selector = el('hex-selector');
+    if (!wrap || !selector) return;
+    this.hexOffer = cards;
+    wrap.innerHTML = '';
+    cards.forEach((card, i) => {
+      const def = hexCard(card);
+      if (!def) return;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'hex-card';
+      btn.innerHTML = `<kbd>${i + 1}</kbd><strong>${esc(def.name)}</strong><span>${esc(def.description)}</span>`;
+      btn.addEventListener('click', () => this.onHexPick?.(card));
+      wrap.appendChild(btn);
+    });
+    this.hexSelectorOpen = true;
+    selector.style.display = 'flex';
+  }
+
+  toggleHexSelector(force?: boolean) {
+    const selector = el('hex-selector');
+    if (!selector) return;
+    this.hexSelectorOpen = force ?? !this.hexSelectorOpen;
+    selector.style.display = this.hexSelectorOpen ? 'flex' : 'none';
+  }
+
+  isHexSelectorOpen(): boolean {
+    return this.hexSelectorOpen;
+  }
+
+  setCurrentHex(card: number | null) {
+    const row = el('hex-row');
+    const name = el('hex-name');
+    if (!row || !name) return;
+    const def = card ? hexCard(card) : null;
+    row.style.display = def ? '' : 'none';
+    name.textContent = def ? def.name : '-';
+  }
+
+  // 血牛把上限改到 140：血条按新上限折算百分比
+  setHpMax(max: number) {
+    if (max === this.hexMaxHp) return;
+    this.hexMaxHp = max;
+    this.lastHp = -1; // 强制下次 setHp 重绘
   }
 
   showKillPoint(points: number) {
@@ -840,7 +893,7 @@ export class Hud {
     const hpEl = el('hp');
     if (hpEl) hpEl.textContent = String(v);
     const fillEl = el('hp-bar-fill');
-    if (fillEl) fillEl.style.width = `${Math.max(0, Math.min(100, v))}%`;
+    if (fillEl) fillEl.style.width = `${Math.max(0, Math.min(this.hexMaxHp, v) / this.hexMaxHp * 100)}%`;
     this.root.classList.toggle('low-hp', v > 0 && v <= 30);
   }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -7,7 +7,7 @@ import { Weapons } from './weapons.js';
 import { Hud } from './hud.js';
 import { AudioEngine, type SfxName } from './audio.js';
 import { ParticleSystem } from './particles.js';
-import { KEY, PHYS, WEAPONS, XM_PELLETS, ULTIMATE_REQUIREMENT, QUICK_CHAT_PHRASES, isGun, isPistol, isShotgun, isSniper, scopeSettleMs, type MapData, type PlayerSnap, type RosterEntry, type WeaponDef } from './constants.js';
+import { KEY, PHYS, WEAPONS, XM_PELLETS, ULTIMATE_REQUIREMENT, QUICK_CHAT_PHRASES, hexCard, isGun, isPistol, isShotgun, isSniper, scopeSettleMs, HEX_BLOOD_OX, HEX_BLOOD_OX_MAX_HP, HEX_FRENZY, HEX_FIRE_RATE_DIV, HEX_QUICKEN, HEX_RELOAD_MULT, HEX_SPRINT, HEX_SPEED_MULT, HEX_SPREAD_MULT, HEX_STEADY, type MapData, type PlayerSnap, type RosterEntry, type WeaponDef } from './constants.js';
 import bundledMap from '../../map.json';
 import neonCityMap from '../../maps/neon-city.json';
 
@@ -232,6 +232,8 @@ let ultimatePoints = 0;
 let ultimateKind = 0;
 let ultimateUntil = 0;
 let blackDreamUntil = 0;
+// 海克斯强化卡：本条命生效的卡 id（0 = 无），死亡清零，速度/散布/射速本地镜像与服务端同值
+let selfHexCard = 0;
 let patternShots = 0;
 let lastPatternShot = 0;
 let latencyMs = 0;
@@ -553,7 +555,7 @@ function isInteractiveTarget(target: EventTarget | null): boolean {
 
 
 function startReload(t = performance.now(), notifyServer = true) {
-  if (!alive || activeSlot > 2 || reloadPendingSlot === activeSlot || weapons.isReloading(t) || !weapons.startReload(t, reserve)) return;
+  if (!alive || activeSlot > 2 || reloadPendingSlot === activeSlot || weapons.isReloading(t) || !weapons.startReload(t, reserve, selfHexCard === HEX_QUICKEN ? HEX_RELOAD_MULT : 1)) return;
   reloadPendingSlot = activeSlot;
   reloadPendingMag = weapons.ammoLocal;
   reloadPendingReserve = reserve;
@@ -648,6 +650,14 @@ window.addEventListener('keydown', (e) => {
     e.preventDefault();
     const phrase = QUICK_CHAT_PHRASES[+e.code.at(-1)! - 1];
     if (phrase) hud.onQuickChat?.(phrase);
+    return;
+  }
+  // 海克斯选卡：放在 alive 守卫之前，死亡倒计时期间也能按键选卡（仿快捷喊话条）
+  if (joined && hud.isHexSelectorOpen() && /^Digit[1-3]$/.test(e.code) && !e.repeat) {
+    e.preventDefault();
+    if (hud.isChatComposing()) return;
+    const card = hud.hexOffer[+e.code.at(-1)! - 1];
+    if (card) hud.onHexPick?.(card);
     return;
   }
   if (!joined || interactive) return;
@@ -1727,6 +1737,10 @@ function handleEvent(e: GameEvent) {
       ultimateUntil = 0;
       blackDreamUntil = 0;
       hud.setUltimate(ultimatePoints, ultimateKind);
+      selfHexCard = 0; // 海克斯卡随死亡失效（与服务端死亡结算块同步）
+      hud.setHpMax(100);
+      hud.setCurrentHex(null);
+      hud.toggleHexSelector(false); // 等服务端新一轮 EvHexOffer 重开
       local.flying = false;
       hud.setFlightState(false, false);
       clearCombatInput();
@@ -1832,6 +1846,26 @@ function handleEvent(e: GameEvent) {
     else {
       const s = states.get(e.player ?? -1);
       if (s) playSpatial('reload_click', s.x, s.z, 0.42, 28);
+    }
+    return;
+  }
+  if (e.type === 22 && e.player === net.yourId && e.cards?.length) {
+    // EvHexOffer：新一轮 3 选 1（进房与每次死亡时由服务端发出，仅本人可见）
+    hud.showHexCards(e.cards);
+    return;
+  }
+  if (e.type === 23 && e.kind) {
+    // EvHexPick：全场播报；本人应用效果并关闭选择面板
+    const def = hexCard(e.kind);
+    if (e.player === net.yourId) {
+      selfHexCard = e.kind;
+      hud.setHpMax(e.kind === HEX_BLOOD_OX ? HEX_BLOOD_OX_MAX_HP : 100);
+      hud.setCurrentHex(e.kind);
+      hud.toggleHexSelector(false);
+      audio.play('weapon_switch', 0.85, 1.25);
+      if (def) hud.showPickupNotice(`海克斯：${def.name}`, 'buff');
+    } else if (def) {
+      hud.addChatMessage('战场播报', `🃏 ${e.name ?? nameOf(e.player)} 获得海克斯「${def.name}」`, false);
     }
     return;
   }
@@ -1980,6 +2014,11 @@ hud.onQuickChat = (text) => {
   if (now - lastQuickChatAt < 1200) return;
   lastQuickChatAt = now;
   net.sendChat(text);
+};
+
+hud.onHexPick = (card) => {
+  if (!joined || practice) return;
+  net.sendHexCard(card); // 面板关闭与数值应用以服务端 EvHexPick 回执为准
 };
 
 function nameOf(id?: number): string {
@@ -2169,7 +2208,7 @@ function frame(t: number) {
   updateWormholes(dt);
 
   if (joined && alive) {
-    local.speedMultiplier = (t < speedBoostUntil ? SPEED_BOOST_MULTIPLIER : 1) * (ultimateKind === 3 && t < ultimateUntil ? 1.45 : 1);
+    local.speedMultiplier = (t < speedBoostUntil ? SPEED_BOOST_MULTIPLIER : 1) * (ultimateKind === 3 && t < ultimateUntil ? 1.45 : 1) * (selfHexCard === HEX_SPRINT ? HEX_SPEED_MULT : 1);
     local.keys = keyMask();
     let remaining = dt;
     let landed = false;
@@ -2368,7 +2407,9 @@ function fire(mode: number, t: number) {
   const pellets = Math.max(1, WEAPONS[weapons.weaponId]?.pellets ?? 1);
   const shotSample = (++shotSeq) & 0xff;
   const dir = shotDirection(localShotDir, shotYaw, shotPitch, spread, pellets > 1 ? shotSample * 17 : shotSample, weapons.weaponId, net.yourId);
-  weapons.onFired(t, weapons.weaponId === 6 && (mode & 1) !== 0 ? 1000 : undefined);
+  // 海克斯「狂热」：本地开火节奏镜像服务端 gap/1.25（刀不受影响，与服务端一致）
+  const hexRateDiv = weapons.weaponId !== 6 && selfHexCard === HEX_FRENZY ? HEX_FIRE_RATE_DIV : 1;
+  weapons.onFired(t, weapons.weaponId === 6 && (mode & 1) !== 0 ? 1000 : undefined, hexRateDiv);
   if (!practice) net.sendFire(shotSeq, net.lastServerTick, mode | (aiming ? 0x80 : 0), shotYaw, shotPitch);
   mag = weapons.ammoLocal;
   if (isSniper(weapons.weaponId)) {
@@ -2462,7 +2503,8 @@ function weaponSpread(def: WeaponDef, vx: number, vz: number, onGround: boolean,
 function localSpread(t: number): number {
   const def = WEAPONS[weapons.weaponId];
   const burstShots = t - lastPatternShot <= 420 ? patternShots : 0;
-  let spread = weaponSpread(def, local.vel.x, local.vel.z, local.onGround, local.crouch, t < landingPenaltyUntil, aiming, burstShots);
+  // 海克斯「稳定」：与服务端一致，先乘散布系数再叠加狙击腰射下限
+  let spread = weaponSpread(def, local.vel.x, local.vel.z, local.onGround, local.crouch, t < landingPenaltyUntil, aiming, burstShots) * (selfHexCard === HEX_STEADY ? HEX_SPREAD_MULT : 1);
   if (isSniper(weapons.weaponId) && (!aiming || t - aimStartedAt < scopeSettleMs(weapons.weaponId))) spread = Math.max(spread, def.moveSpread);
   return spread;
 }

--- a/client/src/net.ts
+++ b/client/src/net.ts
@@ -1,6 +1,6 @@
 import { OP, PROTOCOL_VERSION, type PlayerSnap, type RosterEntry } from './constants.js';
 
-export interface GameEvent { type:number; killer?:number; victim?:number; player?:number; weapon?:number; headshot?:number; origin?:[number,number,number]; dir?:[number,number,number]; name?:string; pickup?:number; kind?:number; ms?:number; streak?:number; message?:string; chicken?:number }
+export interface GameEvent { type:number; killer?:number; victim?:number; player?:number; weapon?:number; headshot?:number; origin?:[number,number,number]; dir?:[number,number,number]; name?:string; pickup?:number; kind?:number; ms?:number; streak?:number; message?:string; chicken?:number; cards?:number[] }
 export interface SelfState { ack:number; slot:number; weapon:number; weaponSkin:number; mag:number; reserve:number; nades:number; ultimatePoints:number; ultimate:number }
 
 export class Net {
@@ -154,6 +154,16 @@ export class Net {
         case 21:
           e.killer = v.getUint16(o, true); e.chicken = v.getUint16(o + 2, true);
           e.origin = vec(v, o + 4); e.weapon = v.getUint8(o + 16); o += 17; break;
+        case 22:
+          e.player = v.getUint16(o, true);
+          e.cards = Array.from({ length: v.getUint8(o + 2) }, (_, k) => v.getUint8(o + 3 + k));
+          o += 3 + e.cards.length; break;
+        case 23: {
+          e.player = v.getUint16(o, true); e.kind = v.getUint8(o + 2);
+          const len = v.getUint8(o + 3);
+          e.name = new TextDecoder().decode(new Uint8Array(v.buffer, v.byteOffset + o + 4, len));
+          o += 4 + len; break;
+        }
       }
       rows.push(e);
     }
@@ -161,7 +171,7 @@ export class Net {
   }
   sendInput(seq:number,keys:number,yaw:number,pitch:number){const b=this.input,v=this.inputView;b[0]=OP.Input;v.setUint16(1,seq,true);b[3]=keys;v.setFloat32(4,yaw,true);v.setFloat32(8,pitch,true);this.raw(b)}
   sendFire(seq:number,tick:number,mode:number,yaw:number,pitch:number){const b=new Uint8Array(16),v=new DataView(b.buffer);b[0]=OP.Fire;v.setUint16(1,seq,true);v.setUint32(3,tick,true);b[7]=mode;v.setFloat32(8,yaw,true);v.setFloat32(12,pitch,true);this.raw(b)}
-  sendReload(){this.raw(new Uint8Array([OP.Reload]))} switchSlot(slot:number){this.raw(new Uint8Array([OP.Switch,slot]))} setLoadout(primary:number,secondary:number,primaryWeaponSkin:number,secondaryWeaponSkin:number){this.raw(new Uint8Array([OP.Loadout,primary,secondary,primaryWeaponSkin,secondaryWeaponSkin]))} requestRoster(){this.raw(new Uint8Array([OP.RosterRequest]))} toggleFlight(){this.raw(new Uint8Array([OP.ToggleFlight]))} castUltimate(kind:number){this.raw(new Uint8Array([OP.Ultimate,kind]))} sendChat(text:string){const b=new TextEncoder().encode(text);const out=new Uint8Array(b.length+1);out[0]=OP.Chat;out.set(b,1);this.raw(out)}
+  sendReload(){this.raw(new Uint8Array([OP.Reload]))} switchSlot(slot:number){this.raw(new Uint8Array([OP.Switch,slot]))} setLoadout(primary:number,secondary:number,primaryWeaponSkin:number,secondaryWeaponSkin:number){this.raw(new Uint8Array([OP.Loadout,primary,secondary,primaryWeaponSkin,secondaryWeaponSkin]))} requestRoster(){this.raw(new Uint8Array([OP.RosterRequest]))} toggleFlight(){this.raw(new Uint8Array([OP.ToggleFlight]))} castUltimate(kind:number){this.raw(new Uint8Array([OP.Ultimate,kind]))} sendHexCard(card:number){this.raw(new Uint8Array([OP.Hex,card]))} sendChat(text:string){const b=new TextEncoder().encode(text);const out=new Uint8Array(b.length+1);out[0]=OP.Chat;out.set(b,1);this.raw(out)}
   sendGrenade(yaw:number,pitch:number){const b=new Uint8Array(9),v=new DataView(b.buffer);b[0]=OP.Grenade;v.setFloat32(1,yaw,true);v.setFloat32(5,pitch,true);this.raw(b)}
   forget(id:number){this.states.delete(id)}
   disconnect(){this.closedByUser=true;if(this.heartbeat){clearInterval(this.heartbeat);this.heartbeat=0}const ws=this.ws;if(ws){ws.onopen=null;ws.onmessage=null;ws.onclose=null;if(ws.readyState<2)ws.close()}this.connected=false;this.states.clear()}

--- a/client/src/weapons.ts
+++ b/client/src/weapons.ts
@@ -135,6 +135,7 @@ export class Weapons {
   nextFireAt = 0;
   ammoLocal = WEAPONS[3].mag;
   reloadStartedAt = 0;
+  reloadDuration = 0;
   reloadingUntil = 0;
   weaponId = 3;
   weaponSkin = 0;
@@ -257,21 +258,23 @@ export class Weapons {
     return t >= this.nextFireAt && t >= this.reloadingUntil && this.ammoLocal > 0;
   }
 
-  startReload(t: number, reserve = 999): boolean {
+  startReload(t: number, reserve = 999, durationMul = 1): boolean {
     const def = WEAPONS[this.weaponId] ?? WEAPONS[0];
     if (this.weaponId === 6 || reserve <= 0 || this.ammoLocal >= def.mag || this.isReloading(t)) return false;
 
+    const dur = def.reloadMs * durationMul;
     this.reloadStartedAt = t;
-    this.reloadingUntil = t + def.reloadMs;
+    this.reloadDuration = dur;
+    this.reloadingUntil = t + dur;
     this.nextFireAt = Math.max(this.nextFireAt, this.reloadingUntil);
 
     // Schedule high-definition synchronized reload sound cues
     const pistolReload = isPistol(this.weaponId);
     const pitch = RELOAD_PITCH[this.weaponId] ?? 1;
     this.scheduledSounds = [
-      { time: t + def.reloadMs * 0.18, name: 'mag_out', vol: 0.75, pitch: pitch * 1.04 },
-      { time: t + def.reloadMs * 0.54, name: 'mag_in', vol: 0.85, pitch },
-      { time: t + def.reloadMs * 0.78, name: pistolReload ? 'reload_click' : 'bolt_cycle', vol: 0.82, pitch: pitch * 0.96 },
+      { time: t + dur * 0.18, name: 'mag_out', vol: 0.75, pitch: pitch * 1.04 },
+      { time: t + dur * 0.54, name: 'mag_in', vol: 0.85, pitch },
+      { time: t + dur * 0.78, name: pistolReload ? 'reload_click' : 'bolt_cycle', vol: 0.82, pitch: pitch * 0.96 },
     ];
 
     return true;
@@ -283,8 +286,7 @@ export class Weapons {
 
   getReloadProgress(t: number): number {
     if (!this.isReloading(t)) return 0;
-    const def = WEAPONS[this.weaponId] ?? WEAPONS[0];
-    const dur = def.reloadMs || 1800;
+    const dur = this.reloadDuration || WEAPONS[this.weaponId]?.reloadMs || 1800;
     return Math.max(0, Math.min(1, (t - this.reloadStartedAt) / dur));
   }
 
@@ -318,9 +320,9 @@ export class Weapons {
     this.curBobY = 0;
   }
 
-  onFired(t: number, intervalOverride?: number) {
+  onFired(t: number, intervalOverride?: number, rateDiv = 1) {
     const def = WEAPONS[this.weaponId] ?? WEAPONS[0];
-    const interval = intervalOverride ?? 60000 / def.rpm;
+    const interval = (intervalOverride ?? 60000 / def.rpm) / rateDiv;
     this.nextFireAt = this.weaponId === 6 ? t + interval : this.nextFireAt > 0 && t - this.nextFireAt < interval ? this.nextFireAt + interval : t + interval;
     if (isSniper(this.weaponId)) {
       this.boltCycleStartedAt = t;

--- a/server/bounty.go
+++ b/server/bounty.go
@@ -41,7 +41,7 @@ func (r *Room) bountyClaim(attacker, victim *PlayerState, now time.Time) {
 		return
 	}
 	delete(r.bountyOf, victim.Id)
-	attacker.HP = uint8(min(MaxHP, int(attacker.HP)+bountyRewardHP))
+	attacker.HP = uint8(min(attacker.maxHP(), int(attacker.HP)+bountyRewardHP))
 	if !attacker.IsBot && attacker.Ultimate == 0 {
 		attacker.UltimatePoints = uint8(min(UltimateRequirement, int(attacker.UltimatePoints)+bountyRewardUltPts))
 	}

--- a/server/hex.go
+++ b/server/hex.go
@@ -1,0 +1,142 @@
+package main
+
+// 海克斯强化卡：每条命 3 选 1 的临时强化，死亡即失效、复活重新选择。
+// 零快照改动：发卡走个人事件 EvHexOffer（仅本人可见），选卡确认走广播事件 EvHexPick；
+// 速度/散布/射速等系数由客户端按自己的 Hex id 本地镜像（与服端同值，保证预测不回弹）。
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+const (
+	HexSprint  uint8 = iota + 1 // 疾行者：移速 +15%
+	HexAssault                  // 强袭：伤害 +15%
+	HexFrenzy                   // 狂热：射速 +25%
+	HexSteady                   // 稳定：散布 -30%
+	HexBulwark                  // 铁壁：受到伤害 -20%
+	HexLeech                    // 利爪：造成伤害 15% 回复生命
+	HexBloodOx                  // 血牛：血量上限 100→140，选卡立即 +40
+	HexAmmoBag                  // 弹药扩容：两把武器备弹翻倍
+	HexQuicken                  // 快手：换弹耗时 -30%
+
+	HexCardCount      = 9
+	HexOfferCount     = 3
+	HexBloodOxBonusHP = 40
+)
+
+type HexDef struct {
+	Id   uint8
+	Name string
+	Desc string
+}
+
+var HexCards = []HexDef{
+	{HexSprint, "疾行者", "移速 +15%"},
+	{HexAssault, "强袭", "伤害 +15%"},
+	{HexFrenzy, "狂热", "射速 +25%"},
+	{HexSteady, "稳定", "散布 -30%"},
+	{HexBulwark, "铁壁", "受到伤害 -20%"},
+	{HexLeech, "利爪", "造成伤害 15% 回复生命"},
+	{HexBloodOx, "血牛", "血量上限 100→140，选卡立即 +40"},
+	{HexAmmoBag, "弹药扩容", "两把武器备弹翻倍"},
+	{HexQuicken, "快手", "换弹耗时 -30%"},
+}
+
+// maxHP 返回当前血量上限；「血牛」持有者为 140。所有回血/满血钳制都应使用它。
+func (p *PlayerState) maxHP() int {
+	if p.Hex == HexBloodOx {
+		return MaxHP + HexBloodOxBonusHP
+	}
+	return MaxHP
+}
+
+func (p *PlayerState) hexSpeedMul() float64 {
+	if p.Hex == HexSprint {
+		return 1.15
+	}
+	return 1
+}
+
+func (p *PlayerState) hexDamageMul() float64 {
+	if p.Hex == HexAssault {
+		return 1.15
+	}
+	return 1
+}
+
+// hexFireRateDiv 射速除数：开火间隔 /= 1.25 即射速 +25%。
+func (p *PlayerState) hexFireRateDiv() float64 {
+	if p.Hex == HexFrenzy {
+		return 1.25
+	}
+	return 1
+}
+
+func (p *PlayerState) hexSpreadMul() float64 {
+	if p.Hex == HexSteady {
+		return 0.70
+	}
+	return 1
+}
+
+func (p *PlayerState) hexDmgTakenMul() float64 {
+	if p.Hex == HexBulwark {
+		return 0.80
+	}
+	return 1
+}
+
+func (p *PlayerState) hexReloadMul() float64 {
+	if p.Hex == HexQuicken {
+		return 0.70
+	}
+	return 1
+}
+
+// offerHex 为真人玩家抽 3 张不重复卡并广播个人事件；bot 不参与海克斯。
+// 在 Join 与每次死亡时调用，覆盖上一轮未选择的 offer。
+func (r *Room) offerHex(p *PlayerState) {
+	if p.IsBot {
+		return
+	}
+	perm := make([]int, len(HexCards))
+	for i := range perm {
+		perm[i] = i
+	}
+	rand.Shuffle(len(perm), func(i, j int) { perm[i], perm[j] = perm[j], perm[i] })
+	var offer [HexOfferCount]uint8
+	for i := range offer {
+		offer[i] = HexCards[perm[i]].Id
+	}
+	p.HexOffer = offer
+	r.Emit(Event{Type: EvHexOffer, Player: p.Id, Cards: offer})
+}
+
+// HexPick 校验并生效玩家的选择；不要求存活（死亡倒计时期间即可选）。
+// 卡片随本条命持续到下一次死亡，因此死亡结算后才选的卡会带入新的一命。
+func (r *Room) HexPick(p *PlayerState, card uint8, now time.Time) bool {
+	if !hexInOffer(p.HexOffer, card) {
+		return false
+	}
+	p.Hex = card
+	p.HexOffer = [HexOfferCount]uint8{}
+	switch card {
+	case HexBloodOx:
+		p.HP = uint8(min(p.maxHP(), int(p.HP)+HexBloodOxBonusHP))
+	case HexAmmoBag:
+		p.Reserves[0] = Weapons[p.Primary].Reserve * 2
+		p.Reserves[1] = Weapons[p.Secondary].Reserve * 2
+	}
+	r.Emit(Event{Type: EvHexPick, Player: p.Id, Kind: card, Name: p.Name})
+	return true
+}
+
+func hexInOffer(offer [HexOfferCount]uint8, card uint8) bool {
+	for _, c := range offer {
+		if c == card {
+			return true
+		}
+	}
+	return false
+}

--- a/server/hex_test.go
+++ b/server/hex_test.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func newHexRoom(t *testing.T) *Room {
+	store, err := NewStore(t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	r := NewRoom(1, &World{Size: [2]float64{96, 96}}, store)
+	// 测试世界补一块地面 AABB（y: -1~0），否则玩家悬空下坠走空中加速度。
+	r.World.aabbs = append(r.World.aabbs, AABB{Min: Vec3{X: -48, Y: -1, Z: -48}, Max: Vec3{X: 48, Y: 0, Z: 48}})
+	a := newTestHuman(10, r)
+	a.Pos = Vec3{0, 0, 0}
+	b := newTestHuman(11, r)
+	b.Pos = Vec3{4, 0, 0}
+	r.Players = append(r.Players, a, b)
+	return r
+}
+
+func lastHexOffer(r *Room, playerId uint16) (Event, bool) {
+	for i := len(r.pending) - 1; i >= 0; i-- {
+		e := r.pending[i]
+		if e.Type == EvHexOffer && e.Player == playerId {
+			return e, true
+		}
+	}
+	return Event{}, false
+}
+
+// 发卡：真人抽 3 张合法且不重复；bot 不参与。
+func TestHexOfferDealtToHumansOnly(t *testing.T) {
+	r := newHexRoom(t)
+	a := &r.Players[0].PlayerState
+	bot := newTestBot(20, r)
+	r.Players = append(r.Players, bot)
+
+	r.offerHex(a)
+	offer, ok := lastHexOffer(r, a.Id)
+	if !ok {
+		t.Fatal("真人应有 EvHexOffer")
+	}
+	seen := map[uint8]bool{}
+	for _, c := range offer.Cards {
+		if c < 1 || c > HexCardCount {
+			t.Fatalf("发卡 %d 超出卡池范围", c)
+		}
+		if seen[c] {
+			t.Fatalf("发卡重复：%v", offer.Cards)
+		}
+		seen[c] = true
+	}
+	for i, c := range a.HexOffer {
+		if c != offer.Cards[i] {
+			t.Fatalf("HexOffer 与事件不一致：%v vs %v", a.HexOffer, offer.Cards)
+		}
+	}
+
+	before := len(r.pending)
+	r.offerHex(&bot.PlayerState)
+	if bot.HexOffer != [HexOfferCount]uint8{} {
+		t.Fatal("bot 不应被发卡")
+	}
+	for _, e := range r.pending[before:] {
+		if e.Type == EvHexOffer {
+			t.Fatal("bot 不应收到 EvHexOffer")
+		}
+	}
+}
+
+// 选卡：合法选中生效并广播；非法与重复选择被拒绝。
+func TestHexPickValidation(t *testing.T) {
+	r := newHexRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	a.HexOffer = [HexOfferCount]uint8{HexSprint, HexBloodOx, HexQuicken}
+
+	if !r.HexPick(a, HexBloodOx, now) {
+		t.Fatal("选择 offer 内的卡应成功")
+	}
+	if a.Hex != HexBloodOx || a.HexOffer != [HexOfferCount]uint8{} {
+		t.Fatal("选中后 Hex 应生效且 offer 清空")
+	}
+	found := false
+	for _, e := range r.pending {
+		if e.Type == EvHexPick && e.Player == a.Id && e.Kind == HexBloodOx {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("选中应广播 EvHexPick")
+	}
+	if r.HexPick(a, HexSprint, now) {
+		t.Fatal("offer 清空后不应再能选卡")
+	}
+	a.HexOffer = [HexOfferCount]uint8{HexSteady, HexLeech, HexFrenzy}
+	if r.HexPick(a, HexAmmoBag, now) {
+		t.Fatal("选择 offer 之外的卡应被拒绝")
+	}
+}
+
+// 死亡失效：旧卡清零并立刻发新一轮；复活不清 Hex（倒计时期间选的卡带入新命）。
+func TestHexDeathClearsAndReoffers(t *testing.T) {
+	r := newHexRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	b := &r.Players[1].PlayerState
+	a.Hex = HexSprint
+
+	r.Damage(b, a, 500, false, 3, now)
+	if a.Alive {
+		t.Fatal(" victim 应死亡")
+	}
+	if a.Hex != 0 {
+		t.Fatalf("死亡后 Hex 应清零, 实际 %d", a.Hex)
+	}
+	if _, ok := lastHexOffer(r, a.Id); !ok {
+		t.Fatal("死亡应触发新一轮发卡")
+	}
+	// 倒计时期间选卡 → 复活后应保留。固定 offer 以便断言血牛。
+	a.HexOffer = [HexOfferCount]uint8{HexBloodOx, HexSprint, HexSteady}
+	if !r.HexPick(a, HexBloodOx, now.Add(time.Second)) {
+		t.Fatal("死亡期间应可选卡")
+	}
+	r.Respawn(a, now.Add(4*time.Second))
+	if a.Hex != HexBloodOx {
+		t.Fatal("复活不应清掉死亡期间选中的卡")
+	}
+	if a.HP != uint8(MaxHP+HexBloodOxBonusHP) {
+		t.Fatalf("血牛持有者复活应满 140 血, 实际 %d", a.HP)
+	}
+}
+
+// 血牛：上限 140、选卡立即 +40 且按新上限钳制；死亡回到 100。
+func TestHexBloodOxMaxHP(t *testing.T) {
+	r := newHexRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	a.HexOffer = [HexOfferCount]uint8{HexBloodOx, HexSprint, HexSteady}
+	a.HP = 70
+
+	if !r.HexPick(a, HexBloodOx, now) {
+		t.Fatal("应可选中血牛")
+	}
+	if a.maxHP() != MaxHP+HexBloodOxBonusHP {
+		t.Fatalf("血牛上限应为 %d, 实际 %d", MaxHP+HexBloodOxBonusHP, a.maxHP())
+	}
+	if a.HP != 110 {
+		t.Fatalf("选卡应立即 +40（70→110）, 实际 %d", a.HP)
+	}
+	// 回血钳制到 140：医疗包 +50。
+	if !applyPickup(a, PickupHealth, now) {
+		t.Fatal("未满血应可拾取医疗包")
+	}
+	if a.HP != uint8(MaxHP+HexBloodOxBonusHP) {
+		t.Fatalf("医疗包后应钳制在 140, 实际 %d", a.HP)
+	}
+	// 满血（按新上限）时医疗包应无效。
+	if applyPickup(a, PickupHealth, now) {
+		t.Fatal("血牛满血时医疗包应无效")
+	}
+	// 无卡时按 100 钳制。
+	a.Hex = 0
+	a.HP = 50
+	if !applyPickup(a, PickupHealth, now) {
+		t.Fatal("低血应可拾取医疗包")
+	}
+	if a.HP != MaxHP {
+		t.Fatalf("无卡上限应回到 %d, 实际 %d", MaxHP, a.HP)
+	}
+}
+
+// 弹药扩容：两把武器备弹翻倍。
+func TestHexAmmoBagDoublesReserve(t *testing.T) {
+	r := newHexRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	base0, base1 := Weapons[a.Primary].Reserve, Weapons[a.Secondary].Reserve
+	a.HexOffer = [HexOfferCount]uint8{HexAmmoBag, HexSprint, HexSteady}
+
+	if !r.HexPick(a, HexAmmoBag, now) {
+		t.Fatal("应可选中弹药扩容")
+	}
+	if a.Reserves[0] != base0*2 || a.Reserves[1] != base1*2 {
+		t.Fatalf("备弹应翻倍: %v, 期望 [%d %d]", a.Reserves, base0*2, base1*2)
+	}
+}
+
+// 疾行者：地面直线移动位移比 ≈1.15。
+func TestHexSprintSpeedMultiplier(t *testing.T) {
+	r := newHexRoom(t)
+	now := time.Now()
+	base := &r.Players[0].PlayerState
+	hex := &r.Players[1].PlayerState
+	hex.Hex = HexSprint
+
+	run := func(p *PlayerState) float64 {
+		p.CmdKeys = KeyForward
+		for i := 0; i < 90; i++ {
+			r.Move(p, now) // Move 的 now 只参与 buff 判断，位移由 tick 常数积分
+		}
+		return p.Pos.Z
+	}
+	dBase, dHex := run(base), run(hex)
+	if dBase == 0 {
+		t.Fatal("基线位移不应为 0")
+	}
+	ratio := -dHex / -dBase
+	if ratio < 1.10 || ratio > 1.20 {
+		t.Fatalf("疾行者位移比应在 1.10~1.20, 实际 %.3f", ratio)
+	}
+}
+
+// 强袭/铁壁：伤害 ×1.15 与受伤 ×0.80。
+func TestHexAssaultAndBulwarkDamage(t *testing.T) {
+	r := newHexRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	b := &r.Players[1].PlayerState
+
+	r.Damage(a, b, 20, false, 3, now)
+	if b.HP != MaxHP-20 {
+		t.Fatalf("基线伤害 20 应扣 20 血, 实际 %d", MaxHP-b.HP)
+	}
+
+	b.HP = MaxHP
+	a.Hex = HexAssault
+	r.Damage(a, b, 20, false, 3, now)
+	if got := MaxHP - b.HP; got != 23 {
+		t.Fatalf("强袭应打出 23 伤害, 实际 %d", got)
+	}
+
+	b.HP = MaxHP
+	a.Hex = 0
+	b.Hex = HexBulwark
+	r.Damage(a, b, 20, false, 3, now)
+	if got := MaxHP - b.HP; got != 16 {
+		t.Fatalf("铁壁应只受 16 伤害, 实际 %d", got)
+	}
+}
+
+// 利爪：造成伤害 15% 回血（向下取整）。
+func TestHexLeechLifesteal(t *testing.T) {
+	r := newHexRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	b := &r.Players[1].PlayerState
+	a.Hex = HexLeech
+	a.HP = 50
+
+	r.Damage(a, b, 20, false, 3, now)
+	if a.HP != 53 {
+		t.Fatalf("利爪应回血 3（20×15%%）, 实际 %d", a.HP-50)
+	}
+
+	a.HP = 99
+	r.Damage(a, b, 20, false, 3, now)
+	if a.HP != MaxHP {
+		t.Fatalf("回血应按 100 上限钳制（99+3）, 实际 %d", a.HP)
+	}
+}
+
+// 狂热：开火间隔缩短到 1/1.25。
+func TestHexFrenzyFireRate(t *testing.T) {
+	r := newHexRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+
+	fireGap := func(p *PlayerState) time.Duration {
+		p.NextFire = time.Time{}
+		r.TryFire(p, 0, 0, 0, r.tick, 1, now)
+		return p.NextFire.Sub(now)
+	}
+	base := fireGap(a)
+	a.Hex = HexFrenzy
+	a.LastShotSeq = 0
+	a.HasShot = false
+	got := fireGap(a)
+	if got >= base || float64(got) > float64(base)/1.2 {
+		t.Fatalf("狂热间隔应明显短于基线: base=%v got=%v", base, got)
+	}
+}
+
+// 快手：换弹耗时 ×0.70，EvReloadStart 的 ms 同步缩放。
+func TestHexQuickenReload(t *testing.T) {
+	r := newHexRoom(t)
+	now := time.Now()
+	a := &r.Players[0].PlayerState
+	a.Mags[0] = 10 // AK 未满弹匣才会启动换弹
+
+	baseReloadMs := Weapons[a.Primary].ReloadMs
+	if !r.StartReload(a, now) {
+		t.Fatal("应能开始换弹")
+	}
+	if got := a.ReloadEnd.Sub(now); got != time.Duration(baseReloadMs)*time.Millisecond {
+		t.Fatalf("基线换弹时长 %v, 实际 %v", baseReloadMs, got)
+	}
+
+	a.Reloading = false
+	a.Mags[0] = 10
+	a.Hex = HexQuicken
+	if !r.StartReload(a, now.Add(time.Second)) {
+		t.Fatal("应能再次换弹")
+	}
+	want := time.Duration(int(float64(baseReloadMs)*0.70)) * time.Millisecond
+	if got := a.ReloadEnd.Sub(now.Add(time.Second)); got != want {
+		t.Fatalf("快手换弹时长应 %v, 实际 %v", want, got)
+	}
+	found := false
+	for _, e := range r.pending {
+		if e.Type == EvReloadStart && e.Player == a.Id && e.Ms == uint16(want/time.Millisecond) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("EvReloadStart 应携带缩放后的 ms")
+	}
+}

--- a/server/hub.go
+++ b/server/hub.go
@@ -204,6 +204,7 @@ func (h *Hub) Join(p *Player, account, name string, primary, secondary, skin, pr
 	if chickens := room.chickenEvents(); len(chickens) > 0 {
 		p.Send(Events(chickens))
 	}
+	room.offerHex(&p.PlayerState)
 	p.ready = true
 	if !room.running {
 		room.running = true

--- a/server/player.go
+++ b/server/player.go
@@ -333,6 +333,15 @@ func (p *Player) readPump(hub *Hub) {
 				room.CastUltimate(&p.PlayerState, payload[0], now)
 				room.mu.Unlock()
 			}
+		case OpHex:
+			if len(payload) < 1 {
+				continue
+			}
+			if room := p.Room; room != nil {
+				room.mu.Lock()
+				room.HexPick(&p.PlayerState, payload[0], now)
+				room.mu.Unlock()
+			}
 		case OpChat:
 			if !p.joined || len(payload) < 1 {
 				continue

--- a/server/proto.go
+++ b/server/proto.go
@@ -6,7 +6,7 @@ import (
 	"unicode/utf8"
 )
 
-const ProtocolVersion = 10
+const ProtocolVersion = 11
 const SkinCount uint8 = 8
 
 const (
@@ -21,6 +21,7 @@ const (
 	OpToggleFlight  = 0x0B
 	OpUltimate      = 0x0C
 	OpChat          = 0x0D
+	OpHex           = 0x0E
 
 	OpWelcome     = 0x81
 	OpSnapshot    = 0x82
@@ -56,16 +57,20 @@ const (
 	EvChickenDeath
 	EvZombieSpawn
 	EvZombieDeath
+	EvHexOffer
+	EvHexPick
 )
 
 type Event struct {
-	Type                        uint8
-	Killer, Victim, Player      uint16
-	Headshot, Weapon, Dmg, Kind uint8
-	Origin, Dir                 Vec3
-	Ms                          uint16
-	Name                        string
-	Message                     string
+	Type                   uint8
+	Killer, Victim, Player uint16
+	Headshot, Weapon, Dmg  uint8
+	Kind                   uint8
+	Cards                  [HexOfferCount]uint8
+	Origin, Dir            Vec3
+	Ms                     uint16
+	Name                   string
+	Message                string
 }
 
 type Buf struct{ b []byte }
@@ -251,6 +256,18 @@ func Events(evts []Event) []byte {
 			w.U16(e.Victim)
 			w.V3(e.Origin)
 			w.U8(e.Weapon)
+		case EvHexOffer:
+			w.U16(e.Player)
+			w.U8(HexOfferCount)
+			for _, c := range e.Cards {
+				w.U8(c)
+			}
+		case EvHexPick:
+			w.U16(e.Player)
+			w.U8(e.Kind)
+			nb := safeNameBytes(e.Name)
+			w.U8(uint8(len(nb)))
+			w.b = append(w.b, nb...)
 		}
 	}
 	return w.Bytes()

--- a/server/proto_test.go
+++ b/server/proto_test.go
@@ -967,3 +967,25 @@ func TestFlightSnapshotStateBit(t *testing.T) {
 		t.Fatalf("flight state bit missing: %08b", state.state)
 	}
 }
+
+func TestHexEventEncoding(t *testing.T) {
+	b := Events([]Event{
+		{Type: EvHexOffer, Player: 7, Cards: [HexOfferCount]uint8{2, 5, 9}},
+		{Type: EvHexPick, Player: 7, Kind: 5, Name: "测试"},
+	})
+	// 帧头：op + count，事件 22（offer）：player u16 + n u8 + 3×card；
+	// 事件 23（pick）：player u16 + kind u8 + len u8 + name。
+	want := []byte{
+		OpEvents, 2,
+		EvHexOffer, 7, 0, 3, 2, 5, 9,
+		EvHexPick, 7, 0, 5, 6, 230, 181, 139, 232, 175, 149,
+	}
+	if len(b) != len(want) {
+		t.Fatalf("长度 %d, 期望 %d: % x", len(b), len(want), b)
+	}
+	for i := range want {
+		if b[i] != want[i] {
+			t.Fatalf("字节 %d = %d, 期望 %d: % x", i, b[i], want[i], b)
+		}
+	}
+}

--- a/server/room.go
+++ b/server/room.go
@@ -323,6 +323,10 @@ func (r *Room) eventsFor(target *Player, evts []Event) []Event {
 			send = true
 		case EvStreakBuff:
 			send = e.Player == target.Id
+		case EvHexOffer:
+			send = e.Player == target.Id
+		case EvHexPick:
+			send = true
 		case EvHit:
 			send = e.Player == target.Id || e.Victim == target.Id
 		case EvRespawn:

--- a/server/sim.go
+++ b/server/sim.go
@@ -152,6 +152,8 @@ type PlayerState struct {
 	ThornsUntil                                                    time.Time
 	LifestealUntil                                                 time.Time
 	RampageUntil                                                   time.Time
+	HexOffer                                                       [HexOfferCount]uint8
+	Hex                                                            uint8
 	inputWindowStart                                               time.Time
 	inputCount                                                     int
 }
@@ -364,6 +366,7 @@ func (r *Room) Move(p *PlayerState, now time.Time) {
 	if now.Before(p.SpeedUntil) {
 		speed *= p.streakSpeedMul()
 	}
+	speed *= p.hexSpeedMul() // 海克斯「疾行者」
 	if p.Crouch {
 		speed *= CrouchSpeed
 	}
@@ -460,6 +463,9 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 	if p.RampageUntil.After(now) {
 		gap /= 2 // 狂暴：射速 ×2
 	}
+	if div := p.hexFireRateDiv(); div > 1 {
+		gap = time.Duration(float64(gap) / div) // 海克斯「狂热」
+	}
 	if weapon == 6 {
 		gap = KnifeSlashInterval
 		if mode&1 != 0 {
@@ -498,6 +504,7 @@ func (r *Room) TryFire(p *PlayerState, yaw, pitch float64, mode uint8, seenTick 
 	spread := 0.0
 	if isGun(uint8(weapon)) {
 		spread = weaponSpread(def, p.Vel.X, p.Vel.Z, p.OnGround, p.Crouch, now.Before(p.LandingUntil), ads, max(0, int(p.ShotCounter)-1))
+		spread *= p.hexSpreadMul() // 海克斯「稳定」
 		settle := AWPScopeTime
 		if weapon == 11 {
 			settle = 240 * time.Millisecond
@@ -695,6 +702,8 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	if now.Before(attacker.DmgUntil) {
 		dmg *= attacker.streakDamageMul()
 	}
+	dmg *= attacker.hexDamageMul() // 海克斯「强袭」
+	dmg *= victim.hexDmgTakenMul() // 海克斯「铁壁」
 	actual := dmg
 	if victim.Armor > 0 && isGun(weapon) {
 		actual = dmg * Weapons[weapon].ArmorPen
@@ -711,7 +720,11 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	}
 	// 吸血：造成伤害回复一半（向下取整）。
 	if attacker.LifestealUntil.After(now) && attacker.Id != victim.Id {
-		attacker.HP = uint8(min(MaxHP, int(attacker.HP)+int(d)/2))
+		attacker.HP = uint8(min(attacker.maxHP(), int(attacker.HP)+int(d)/2))
+	}
+	// 海克斯「利爪」：造成伤害 15% 回复生命。
+	if attacker.Hex == HexLeech && attacker.Id != victim.Id {
+		attacker.HP = uint8(min(attacker.maxHP(), int(attacker.HP)+int(float64(d)*0.15)))
 	}
 	hs := uint8(0)
 	if headshot {
@@ -753,6 +766,7 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	victim.BlackDreamUntil, victim.InvincibleUntilUlt, victim.GhostUntil = time.Time{}, time.Time{}, time.Time{}
 	victim.DmgUntil, victim.RecoilUntil, victim.SpeedUntil = time.Time{}, time.Time{}, time.Time{}
 	victim.ThornsUntil, victim.LifestealUntil, victim.RampageUntil = time.Time{}, time.Time{}, time.Time{}
+	victim.Hex = 0 // 海克斯卡随本条命死亡失效（死亡倒计时期间选的新卡由 HexPick 写入，不受此处影响）
 	if !attacker.IsBot {
 		r.Store.Accumulate(attacker.Account, 1, 0)
 		if !victim.IsBot && isGun(weapon) {
@@ -793,6 +807,7 @@ func (r *Room) Damage(attacker, victim *PlayerState, dmg float64, headshot bool,
 	victim.RevengeActive, victim.RevengeShots = false, 0
 	victim.InvincibleUntil = time.Time{}
 	victim.RespawnAt = now.Add(RespawnDelayS)
+	r.offerHex(victim) // 复活倒计时期间发新一轮 3 选 1
 }
 
 // 连杀梗播报：服务端以「战场播报」身份走 EvChat 通道整活。
@@ -921,7 +936,7 @@ func (p *PlayerState) healPressure() int {
 	if p.HP <= 70 {
 		return 58
 	}
-	if p.HP < MaxHP {
+	if int(p.HP) < p.maxHP() {
 		return 22
 	}
 	if p.Armor <= 15 {
@@ -1005,7 +1020,7 @@ func (r *Room) applyStreakReward(p *PlayerState, now time.Time) {
 			p.grantStreakAmmo()
 			kind |= StreakAmmo
 		case StreakHeal:
-			p.HP = uint8(min(MaxHP, int(p.HP)+healAmt))
+			p.HP = uint8(min(p.maxHP(), int(p.HP)+healAmt))
 			p.Armor = uint8(min(100, int(p.Armor)+min(40, 15+n*4)))
 			kind |= StreakHeal
 		case StreakSpeed:
@@ -1071,10 +1086,11 @@ func (r *Room) StartReload(p *PlayerState, now time.Time) bool {
 	if mag >= def.Mag || reserve <= 0 {
 		return false
 	}
+	reloadMs := int(float64(def.ReloadMs) * p.hexReloadMul()) // 海克斯「快手」
 	p.Reloading = true
-	p.ReloadEnd = now.Add(time.Duration(def.ReloadMs) * time.Millisecond)
+	p.ReloadEnd = now.Add(time.Duration(reloadMs) * time.Millisecond)
 	p.NextFire = p.ReloadEnd
-	r.Emit(Event{Type: EvReloadStart, Player: p.Id, Ms: uint16(def.ReloadMs)})
+	r.Emit(Event{Type: EvReloadStart, Player: p.Id, Ms: uint16(reloadMs)})
 	return true
 }
 
@@ -1095,7 +1111,9 @@ func (r *Room) FinishReloads(now time.Time) {
 func (r *Room) Respawn(p *PlayerState, now time.Time) {
 	p.Pos = r.BestSpawn(p)
 	p.Vel = Vec3{}
-	p.HP = MaxHP
+	// 注意：这里不清 p.Hex——死亡倒计时期间选中的海克斯卡要带入新的一命
+	//（旧卡的失效只发生在 Damage 的死亡结算块）。
+	p.HP = uint8(p.maxHP())
 	p.Armor = 100
 	p.Alive = true
 	p.OnGround, p.Crouch, p.Flying = true, false, false
@@ -1306,15 +1324,15 @@ func applyPickup(p *PlayerState, kind uint8, now time.Time) bool {
 		p.Reserves = [2]int{primary.Reserve, secondary.Reserve}
 		p.Reloading, p.ReloadEnd, p.NextFire = false, time.Time{}, now
 	case PickupHealth:
-		if p.HP >= MaxHP {
+		if int(p.HP) >= p.maxHP() {
 			return false
 		}
-		p.HP = uint8(min(MaxHP, int(p.HP)+50))
+		p.HP = uint8(min(p.maxHP(), int(p.HP)+50))
 	case PickupSpeed:
 		p.SpeedUntil = now.Add(speedBoostDuration)
 	case PickupAirdrop:
 		// 传奇补给：满血满甲弹药全满（大招点奖励由 StepPickups 结算时发放）。
-		p.HP = MaxHP
+		p.HP = uint8(p.maxHP())
 		p.Armor = 100
 		primary, secondary := Weapons[p.Primary], Weapons[p.Secondary]
 		p.Mags = [2]int{primary.Mag, secondary.Mag}
@@ -1643,7 +1661,7 @@ func (r *Room) chickenShot(p *PlayerState, origin, dir Vec3, wallDist, playerDis
 			return true
 		}
 		best.King = false
-		p.HP = MaxHP
+		p.HP = uint8(p.maxHP())
 		p.Armor = 100
 		p.grantStreakAmmo()
 		r.nextKingAt = now.Add(kingRespawnMin + time.Duration(rand.IntN(int((kingRespawnMax-kingRespawnMin)/time.Second)))*time.Second)
@@ -1654,8 +1672,8 @@ func (r *Room) chickenShot(p *PlayerState, origin, dir Vec3, wallDist, playerDis
 				break
 			}
 		}
-	} else if p.HP < MaxHP {
-		p.HP = uint8(min(MaxHP, int(p.HP)+25))
+	} else if int(p.HP) < p.maxHP() {
+		p.HP = uint8(min(p.maxHP(), int(p.HP)+25))
 	}
 	best.Alive = false
 	best.RespawnAt = now.Add(time.Duration(15+rand.IntN(10)) * time.Second)

--- a/server/zombie.go
+++ b/server/zombie.go
@@ -206,8 +206,8 @@ func (r *Room) zombieShot(p *PlayerState, origin, dir Vec3, wallDist, playerDist
 	}
 	best.Alive = false
 	r.Emit(Event{Type: EvZombieDeath, Killer: p.Id, Victim: best.Id, Origin: best.Pos, Weapon: weapon})
-	if p.HP < MaxHP {
-		p.HP = uint8(min(MaxHP, int(p.HP)+zombieKillReward))
+	if int(p.HP) < p.maxHP() {
+		p.HP = uint8(min(p.maxHP(), int(p.HP)+zombieKillReward))
 	}
 	return true
 }

--- a/server/zone.go
+++ b/server/zone.go
@@ -69,7 +69,7 @@ func (r *Room) stepZones() {
 			if occupant.Ultimate == 0 {
 				occupant.UltimatePoints = uint8(min(UltimateRequirement, int(occupant.UltimatePoints)+zoneRewardUlt))
 			}
-			occupant.HP = uint8(min(MaxHP, int(occupant.HP)+zoneRewardHP))
+			occupant.HP = uint8(min(occupant.maxHP(), int(occupant.HP)+zoneRewardHP))
 			if r.hasZoneAudience() {
 				r.Emit(Event{Type: EvChat, Player: 0, Name: "战场播报",
 					Message: fmt.Sprintf("🏛 %s 巩固了 %s 点（+%d 大招点 +%d HP）", occupant.Name, zoneNames[zi], zoneRewardUlt, zoneRewardHP)})


### PR DESCRIPTION
## 《海克斯觉醒》DLC · 每条命 3 选 1 强化卡

进入对局与每次阵亡后，服务端从 9 张卡池随机发 3 张（不重复），玩家用数字键 1-3 或点选 1 张，效果**仅本条命生效**：死亡即失效，复活倒计时期间弹出新一批 3 选 1（面板保留，落地后仍可边打边选）。bot 不参与。

### 卡池（v1 九张）

| 卡 | 效果 | 实现挂点 |
|---|---|---|
| 疾行者 | 移速 +15% | `Move` 查询乘系数 + 客户端 `speedMultiplier` 镜像 |
| 强袭 | 伤害 +15% | `Damage` 攻击方乘系数 |
| 狂热 | 射速 +25% | `TryFire` gap/1.25 + 客户端开火节奏镜像 |
| 稳定 | 散布 -30% | `weaponSpread` 后乘系数（先于狙击腰射下限，双端同序） |
| 铁壁 | 受伤 -20% | `Damage` 受害方乘系数 |
| 利爪 | 造成伤害 15% 回血 | `Damage` 内结算，按 `maxHP()` 钳制 |
| 血牛 | 血量上限 100→140，选卡立即 +40 | 按玩家查询的 `maxHP()`，全服回血/满血钳制点改造 |
| 弹药扩容 | 两把武器备弹翻倍 | 选卡一次性生效 |
| 快手 | 换弹耗时 -30% | `StartReload` + `EvReloadStart` 的 ms 同步缩放 + 客户端本地镜像 |

### 协议 v10 → v11

- 上行新增 `OpHex 0x0E`（1 字节卡 id），服务端校验「该卡确实在本次 offer 内」，不要求存活（死亡倒计时期间可选）
- 下行复用 `OpEvents`，新增事件：`EvHexOffer`（**个人事件**，`eventsFor` 仅发本人：player u16 + n u8 + 3×卡 id）/ `EvHexPick`（**广播**：player u16 + 卡 id + 名字）
- 双端 `ProtocolVersion` 同步升 11，新旧客户端混连会被拒绝并提示刷新

### 设计要点

- **零快照改动**：卡片状态不进快照位（bit 位已满），速度/散布/射速系数由客户端按自己的卡 id 本地镜像，与服务端同值保证预测不回弹（乘法顺序与服务端逐位对齐，含狙击腰射下限的先后关系）
- **血牛**：`MaxHP` 常量消费点全部改为 `p.maxHP()`（吸血/连杀回血/医疗包/传奇补给/据点/赏金/炸鸡/金鸡王/复活），无卡时行为不变
- **死亡语义**：旧卡在 `Damage` 死亡结算块清零；`Respawn` **不清** Hex——死亡倒计时期间选中的新卡要带入新的一命（有测试守护该行为）
- bot 完全不参与（不收 offer、不占事件）

### 测试

- 新增 `server/hex_test.go`：发卡合法性（3 张不重复、bot 跳过）、选卡校验（非法/重复拒绝）、死亡清卡 + 复活保留、血牛上限与即时回血、弹药翻倍、移速位移比 ≈1.15、强袭/铁壁伤害、利爪回血与上限钳制、狂热射速间隔、快手换弹时长与 `EvReloadStart` 缩放
- `proto_test.go` 新增 `TestHexEventEncoding` 逐字节断言
- `go test ./...` 全绿；`npm run build` 通过
- 本地端到端实测（真实 WebSocket 客户端 + 浏览器）：进房收卡 → 选卡 → 全局播报 → 死亡后自动重发新一轮，全部正常

### 备注

- UI 沿用大招选择器的面板模式，紫色海克斯主题；移动端卡片为原生按钮可直接点选
- HUD 左下角 vitals 新增当前卡徽章，死亡清空


### 如何体验

```bash
docker compose up -d --build   # 或 cd server && go run . + cd client && npm run dev
```

进房即弹 3 选 1 面板（数字键 1-3 或点选）；被击杀后 3 秒复活倒计时期间会自动弹出新一批卡。选「血牛」可看到 HP 上限变为 140、vitals 区出现当前卡徽章；另一窗口开第二个客户端互相击杀可看到「获得海克斯」的全局播报。
